### PR TITLE
fix(stealth): correct Sec-Fetch-Site to cross-site, drop Upgrade-Insecure-Requests, add Sec-CH-UA-Mobile

### DIFF
--- a/internal/stealth/headers.go
+++ b/internal/stealth/headers.go
@@ -40,14 +40,25 @@ func SanitizeHeaders(h http.Header) {
 }
 
 // ApplyProfileHeaders sets browser-typical headers on h from the profile.
-// Only non-empty profile fields are written. Sec-Fetch-* and
-// Upgrade-Insecure-Requests are always set (real browsers always send them).
+// Only non-empty profile fields are written. Sec-Fetch-* headers are set to
+// values appropriate for a cross-origin API request (not a navigation):
+//   - Sec-Fetch-Site: cross-site (the request targets a different origin)
+//   - Sec-Fetch-Mode: cors       (API POST, not navigate)
+//   - Sec-Fetch-Dest: empty      (not a document/script/image load)
+//
+// Upgrade-Insecure-Requests is deliberately NOT set: real browsers only send
+// it on top-level navigation requests (GET to a page), never on API POSTs.
+// Its presence on a POST is a fingerprinting signal.
+//
+// Sec-CH-UA-Mobile is set to "?0" for Chromium profiles because real desktop
+// Chrome always sends it; its absence is detectable.
 func ApplyProfileHeaders(h http.Header, p *Profile) {
 	if p.UserAgent != "" {
 		h.Set("User-Agent", p.UserAgent)
 	}
 	if p.SecChUA != "" {
 		h.Set("Sec-CH-UA", p.SecChUA)
+		h.Set("Sec-CH-UA-Mobile", "?0")
 	}
 	if p.SecChUAPlatform != "" {
 		h.Set("Sec-CH-UA-Platform", p.SecChUAPlatform)
@@ -58,10 +69,9 @@ func ApplyProfileHeaders(h http.Header, p *Profile) {
 	if p.AcceptEncoding != "" {
 		h.Set("Accept-Encoding", p.AcceptEncoding)
 	}
-	h.Set("Sec-Fetch-Site", "none")
+	h.Set("Sec-Fetch-Site", "cross-site")
 	h.Set("Sec-Fetch-Mode", "cors")
 	h.Set("Sec-Fetch-Dest", "empty")
-	h.Set("Upgrade-Insecure-Requests", "1")
 }
 
 // SanitizeAndApply removes proxy headers and applies browser profile headers.

--- a/internal/stealth/stealth_test.go
+++ b/internal/stealth/stealth_test.go
@@ -79,14 +79,20 @@ func TestApplyProfileHeaders(t *testing.T) {
 		if got := h.Get("Sec-CH-UA"); got != ProfileChrome120.SecChUA {
 			t.Errorf("Sec-CH-UA = %q", got)
 		}
-		if got := h.Get("Sec-Fetch-Site"); got != "none" {
-			t.Errorf("Sec-Fetch-Site = %q, want none", got)
+		if got := h.Get("Sec-CH-UA-Mobile"); got != "?0" {
+			t.Errorf("Sec-CH-UA-Mobile = %q, want ?0", got)
+		}
+		if got := h.Get("Sec-Fetch-Site"); got != "cross-site" {
+			t.Errorf("Sec-Fetch-Site = %q, want cross-site", got)
 		}
 		if got := h.Get("Sec-Fetch-Mode"); got != "cors" {
 			t.Errorf("Sec-Fetch-Mode = %q, want cors", got)
 		}
 		if got := h.Get("Sec-Fetch-Dest"); got != "empty" {
 			t.Errorf("Sec-Fetch-Dest = %q, want empty", got)
+		}
+		if got := h.Get("Upgrade-Insecure-Requests"); got != "" {
+			t.Errorf("Upgrade-Insecure-Requests = %q, want absent (only for navigation GETs)", got)
 		}
 	})
 
@@ -97,8 +103,14 @@ func TestApplyProfileHeaders(t *testing.T) {
 		if got := h.Get("Sec-CH-UA"); got != "" {
 			t.Errorf("Firefox Sec-CH-UA = %q, want empty", got)
 		}
+		if got := h.Get("Sec-CH-UA-Mobile"); got != "" {
+			t.Errorf("Firefox Sec-CH-UA-Mobile = %q, want empty (Firefox has no Client Hints)", got)
+		}
 		if got := h.Get("User-Agent"); got == "" || got != ProfileFirefox120.UserAgent {
 			t.Errorf("User-Agent = %q", got)
+		}
+		if got := h.Get("Sec-Fetch-Site"); got != "cross-site" {
+			t.Errorf("Sec-Fetch-Site = %q, want cross-site", got)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Three stealth header fixes that reduce ban risk when `TLS_FINGERPRINT` is active:

### 1. Sec-Fetch-Site: `none` -> `cross-site`

`Sec-Fetch-Site: none` means "user typed this URL in the address bar." A POST to `codebuff.com/api/v1/chat/completions` with `Sec-Fetch-Site: none` is semantically impossible from a real browser. Changed to `cross-site` which is what a browser-based API client would send.

### 2. Removed `Upgrade-Insecure-Requests: 1`

Real browsers only send this header on top-level navigation GETs (loading a page). It is never sent on API POSTs. Its presence on a POST is a fingerprinting signal that marks the connection as non-browser automation.

### 3. Added `Sec-CH-UA-Mobile: ?0`

Real desktop Chrome always sends `Sec-CH-UA-Mobile: ?0`. Its absence when other Client Hints (`Sec-CH-UA`, `Sec-CH-UA-Platform`) are present is detectable by CDN/WAF infrastructure. Only set for Chromium profiles (Firefox does not support Client Hints).

## Testing

- All existing tests pass
- `TestApplyProfileHeaders` updated to verify:
  - `Sec-Fetch-Site: cross-site` (was `none`)
  - `Sec-CH-UA-Mobile: ?0` present on Chrome, absent on Firefox
  - `Upgrade-Insecure-Requests` absent

Fixes #5