### PR TITLE
feat(stealth): anti-ban hardening, safe mode, request jitter, 2025+ TLS profiles, and config validation hints

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,15 +31,17 @@ type Config struct {
 	HTTPProxy           string
 	SOCKS5Proxy         string
 	CostMode            string // "" (omit) or "free"; A/B pending, PRD §8
-	TLSFingerprint      string // "" (plain Go transport) | chrome120 | safari17 | firefox120 | random
+	TLSFingerprint      string // "" (plain Go transport) | chrome120 | chrome126 | safari17 | safari18 | firefox120 | firefox128 | edge126 | random | auto
 	RegistryRefresh     time.Duration
 	DebugDump           bool
 	LogFile             string
 	LogLevel            string        // "" (use -v/default) or debug|info|warn|error
 	MaxMessagesPerDay   int           // 0 = unlimited: per-token cap on successful chats per 24h
 	IdleRotationTimeout time.Duration // 0 = disabled: pause rotation/refresh after this idle period
+	SafeMode            bool          // true = apply recommended anti-ban safe defaults
+	RequestJitter       time.Duration // random delay range [0, RequestJitter) before upstream chat calls
+	CLIVersion          string        // upstream CLI version string (default: 0.10.7)
 }
-
 // BridgeMode reports whether the proxy runs without any AUTH_TOKENS: every
 // client supplies their own FreeBuff token per request (Authorization: Bearer
 // or x-api-key), and the proxy relays with that token upstream.
@@ -65,6 +67,9 @@ type rawConfig struct {
 	LogLevel            string   `json:"LOG_LEVEL"`
 	MaxMessagesPerDay   int      `json:"MAX_MESSAGES_PER_DAY"`
 	IdleRotationTimeout string   `json:"IDLE_ROTATION_TIMEOUT"`
+	SafeMode            bool     `json:"SAFE_MODE"`
+	RequestJitter       string   `json:"REQUEST_JITTER"`
+	CLIVersion          string   `json:"CLI_VERSION"`
 }
 
 func defaultRawConfig() rawConfig {
@@ -78,6 +83,9 @@ func defaultRawConfig() rawConfig {
 		CostMode:            "free", // free-tier mode; omission routes requests as PAID and fresh free accounts get 402 "Out of credits" (upstream check: cost_mode !== 'free' → billing)
 		MaxMessagesPerDay:   0,      // 0 = unlimited
 		IdleRotationTimeout: "0",    // 0 = disabled
+		SafeMode:            false,
+		RequestJitter:       "0s",
+		CLIVersion:          "0.10.7",
 	}
 }
 
@@ -113,7 +121,9 @@ func Load(configPath string) (Config, error) {
 	overrideString(&raw.LogLevel, "LOG_LEVEL")
 	overrideInt(&raw.MaxMessagesPerDay, "MAX_MESSAGES_PER_DAY")
 	overrideString(&raw.IdleRotationTimeout, "IDLE_ROTATION_TIMEOUT")
-
+	overrideBool(&raw.SafeMode, "SAFE_MODE")
+	overrideString(&raw.RequestJitter, "REQUEST_JITTER")
+	overrideString(&raw.CLIVersion, "CLI_VERSION")
 	parseDuration := func(raw, name string) (time.Duration, error) {
 		d, err := time.ParseDuration(strings.TrimSpace(raw))
 		if err != nil {
@@ -140,13 +150,19 @@ func Load(configPath string) (Config, error) {
 	}
 	// IDLE_ROTATION_TIMEOUT is zero-tolerant: "" or "0" both mean disabled.
 	idleRotationTimeout := time.Duration(0)
-	if strings.TrimSpace(raw.IdleRotationTimeout) != "" {
+	if strings.TrimSpace(raw.IdleRotationTimeout) != "" && strings.TrimSpace(raw.IdleRotationTimeout) != "0" {
 		idleRotationTimeout, err = parseDuration(raw.IdleRotationTimeout, "IDLE_ROTATION_TIMEOUT")
 		if err != nil {
 			return Config{}, err
 		}
 	}
-
+	requestJitter := time.Duration(0)
+	if strings.TrimSpace(raw.RequestJitter) != "" {
+		requestJitter, err = parseDuration(raw.RequestJitter, "REQUEST_JITTER")
+		if err != nil {
+			return Config{}, err
+		}
+	}
 	upstreamBaseURL, err := normalizeUpstreamBaseURL(raw.UpstreamBaseURL)
 	if err != nil {
 		return Config{}, err
@@ -170,6 +186,23 @@ func Load(configPath string) (Config, error) {
 		LogLevel:            strings.TrimSpace(raw.LogLevel),
 		MaxMessagesPerDay:   raw.MaxMessagesPerDay,
 		IdleRotationTimeout: idleRotationTimeout,
+		SafeMode:            raw.SafeMode,
+		RequestJitter:       requestJitter,
+		CLIVersion:          strings.TrimSpace(raw.CLIVersion),
+	}
+
+	// SafeMode presets: when SAFE_MODE=true, apply recommended defaults
+	// for any zero-valued account-safety knob.
+	if cfg.SafeMode {
+		if cfg.MaxMessagesPerDay == 0 {
+			cfg.MaxMessagesPerDay = 150
+		}
+		if cfg.IdleRotationTimeout == 0 {
+			cfg.IdleRotationTimeout = 30 * time.Minute
+		}
+		if cfg.RequestJitter == 0 {
+			cfg.RequestJitter = 2 * time.Second
+		}
 	}
 
 	if err := cfg.Validate(); err != nil {
@@ -179,10 +212,13 @@ func Load(configPath string) (Config, error) {
 }
 
 // Validate checks the resolved configuration. It must be called before use.
+// Includes actionable fix suggestions for common misconfigurations (#16).
 func (c Config) Validate() error {
 	switch {
 	case c.ListenAddr == "":
 		return errors.New("LISTEN_ADDR cannot be empty")
+	case !strings.Contains(c.ListenAddr, ":"):
+		return fmt.Errorf("LISTEN_ADDR %q missing port separator ':' (did you mean '127.0.0.1:3457' or ':3457'?)", c.ListenAddr)
 	case c.UpstreamBaseURL == "":
 		return errors.New("UPSTREAM_BASE_URL cannot be empty")
 	case c.RotationInterval <= 0:
@@ -193,14 +229,25 @@ func (c Config) Validate() error {
 		return errors.New("SESSION_CALL_TIMEOUT must be greater than zero")
 	case c.RegistryRefresh <= 0:
 		return errors.New("REGISTRY_REFRESH must be greater than zero")
+	case c.RequestJitter < 0:
+		return errors.New("REQUEST_JITTER cannot be negative")
+	}
+
+	for i, tok := range c.AuthTokens {
+		if strings.HasPrefix(strings.ToLower(tok), "bearer ") {
+			return fmt.Errorf("AUTH_TOKENS token #%d starts with 'Bearer ' prefix -- remove 'Bearer ' (the proxy adds it upstream automatically)", i+1)
+		}
+		if tok == "cb_xxx" || tok == "cb_yyy" || tok == "YOUR_TOKEN_HERE" {
+			return fmt.Errorf("AUTH_TOKENS token #%d is a placeholder %q -- replace with a real FreeBuff token from https://freebuff.llm.pm", i+1, tok)
+		}
 	}
 
 	if c.TLSFingerprint != "" {
-		switch c.TLSFingerprint {
-		case "chrome120", "safari17", "firefox120", "random":
+		switch strings.ToLower(c.TLSFingerprint) {
+		case "chrome120", "chrome126", "safari17", "safari18", "firefox120", "firefox128", "edge126", "random", "auto":
 			// valid
 		default:
-			return fmt.Errorf("TLS_FINGERPRINT %q must be one of: chrome120, safari17, firefox120, random", c.TLSFingerprint)
+			return fmt.Errorf("TLS_FINGERPRINT %q must be one of: chrome120, chrome126, safari17, safari18, firefox120, firefox128, edge126, random, auto", c.TLSFingerprint)
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,9 +15,8 @@ var envKeys = []string{
 	"LISTEN_ADDR", "UPSTREAM_BASE_URL", "AUTH_TOKENS", "ROTATION_INTERVAL",
 	"REQUEST_TIMEOUT", "SESSION_CALL_TIMEOUT", "API_KEYS", "HTTP_PROXY",
 	"SOCKS5_PROXY", "COST_MODE", "TLS_FINGERPRINT", "REGISTRY_REFRESH", "DEBUG_DUMP", "LOG_FILE", "LOG_LEVEL",
-	"MAX_MESSAGES_PER_DAY", "IDLE_ROTATION_TIMEOUT",
+	"MAX_MESSAGES_PER_DAY", "IDLE_ROTATION_TIMEOUT", "SAFE_MODE", "REQUEST_JITTER", "CLI_VERSION",
 }
-
 func clearEnv(t *testing.T) {
 	t.Helper()
 	// Isolate from any real ./.env in the working directory (the repo ships
@@ -73,6 +72,56 @@ func TestDefaults(t *testing.T) {
 	if cfg.CostMode != "free" {
 		t.Errorf("CostMode = %q, want free (default: omission routes requests as paid -> 402)", cfg.CostMode)
 	}
+}
+
+func TestSafeMode(t *testing.T) {
+	t.Setenv("AUTH_TOKENS", "tok-1")
+	t.Setenv("SAFE_MODE", "true")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.MaxMessagesPerDay != 150 {
+		t.Errorf("MaxMessagesPerDay = %d, want 150 under SafeMode", cfg.MaxMessagesPerDay)
+	}
+	if cfg.IdleRotationTimeout != 30*time.Minute {
+		t.Errorf("IdleRotationTimeout = %v, want 30m under SafeMode", cfg.IdleRotationTimeout)
+	}
+	if cfg.RequestJitter != 2*time.Second {
+		t.Errorf("RequestJitter = %v, want 2s under SafeMode", cfg.RequestJitter)
+	}
+}
+
+func TestValidationFixSuggestions(t *testing.T) {
+	t.Run("Bearer prefix", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("AUTH_TOKENS", "Bearer token123")
+		_, err := Load("")
+		if err == nil || !strings.Contains(err.Error(), "starts with 'Bearer ' prefix") {
+			t.Errorf("expected Bearer prefix error, got: %v", err)
+		}
+	})
+
+	t.Run("Placeholder token", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("AUTH_TOKENS", "cb_xxx")
+		_, err := Load("")
+		if err == nil || !strings.Contains(err.Error(), "placeholder") {
+			t.Errorf("expected placeholder error, got: %v", err)
+		}
+	})
+
+	t.Run("ListenAddr missing colon", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("AUTH_TOKENS", "tok1")
+		t.Setenv("LISTEN_ADDR", "3457")
+		_, err := Load("")
+		if err == nil || !strings.Contains(err.Error(), "missing port separator ':'") {
+			t.Errorf("expected missing port separator error, got: %v", err)
+		}
+	})
 }
 
 func TestLoadNoTokensBridgeMode(t *testing.T) {

--- a/internal/stealth/profiles.go
+++ b/internal/stealth/profiles.go
@@ -4,9 +4,9 @@
 package stealth
 
 import (
-	"math/rand"
+	cryptoRand "crypto/rand"
+	"encoding/binary"
 	"strings"
-	"time"
 
 	utls "github.com/refraction-networking/utls"
 )
@@ -16,10 +16,15 @@ type ProfileID string
 
 const (
 	ProfileIDChrome120  ProfileID = "chrome120"
+	ProfileIDChrome126  ProfileID = "chrome126"
 	ProfileIDSafari17   ProfileID = "safari17"
+	ProfileIDSafari18   ProfileID = "safari18"
 	ProfileIDFirefox120 ProfileID = "firefox120"
+	ProfileIDFirefox128 ProfileID = "firefox128"
+	ProfileIDEdge126    ProfileID = "edge126"
+	ProfileIDRandom     ProfileID = "random"
+	ProfileIDAuto       ProfileID = "auto"
 )
-
 // Profile defines a complete browser TLS fingerprint including the utls
 // ClientHelloID and matching HTTP headers.
 type Profile struct {
@@ -46,13 +51,33 @@ var (
 		AcceptEncoding:  "gzip, deflate, br",
 	}
 
-	// ProfileSafari17 mimics Safari 17 on macOS. Uses HelloCustom with a
-	// precise ClientHelloSpec since utls has no dedicated Safari preset.
+	// ProfileChrome126 mimics Chrome 126 on Windows (2024+).
+	ProfileChrome126 = &Profile{
+		ID:              ProfileIDChrome126,
+		ClientHelloID:   utls.HelloChrome_120,
+		UserAgent:       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+		SecChUA:         `"Not/A)Brand";v="8", "Chromium";v="126", "Google Chrome";v="126"`,
+		SecChUAPlatform: `"Windows"`,
+		AcceptLanguage:  "en-US,en;q=0.9",
+		AcceptEncoding:  "gzip, deflate, br, zstd",
+	}
+
+	// ProfileSafari17 mimics Safari 17 on macOS.
 	ProfileSafari17 = &Profile{
 		ID:             ProfileIDSafari17,
 		ClientHelloID:  utls.HelloCustom,
 		CustomSpec:     safari17Spec(),
 		UserAgent:      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+		AcceptLanguage: "en-US,en;q=0.9",
+		AcceptEncoding: "gzip, deflate, br",
+	}
+
+	// ProfileSafari18 mimics Safari 18 on macOS (2024+).
+	ProfileSafari18 = &Profile{
+		ID:             ProfileIDSafari18,
+		ClientHelloID:  utls.HelloCustom,
+		CustomSpec:     safari17Spec(),
+		UserAgent:      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
 		AcceptLanguage: "en-US,en;q=0.9",
 		AcceptEncoding: "gzip, deflate, br",
 	}
@@ -66,18 +91,42 @@ var (
 		AcceptEncoding: "gzip, deflate, br",
 	}
 
-	// ProfileRandom picks a random fingerprint on each connection.
+	// ProfileFirefox128 mimics Firefox 128 ESR on Linux (2024+).
+	ProfileFirefox128 = &Profile{
+		ID:             ProfileIDFirefox128,
+		ClientHelloID:  utls.HelloFirefox_120,
+		UserAgent:      "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0",
+		AcceptLanguage: "en-US,en;q=0.5",
+		AcceptEncoding: "gzip, deflate, br, zstd",
+	}
+
+	// ProfileEdge126 mimics Microsoft Edge 126 on Windows (2024+).
+	ProfileEdge126 = &Profile{
+		ID:              ProfileIDEdge126,
+		ClientHelloID:   utls.HelloChrome_120,
+		UserAgent:       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0",
+		SecChUA:         `"Not/A)Brand";v="8", "Chromium";v="126", "Microsoft Edge";v="126"`,
+		SecChUAPlatform: `"Windows"`,
+		AcceptLanguage:  "en-US,en;q=0.9",
+		AcceptEncoding:  "gzip, deflate, br, zstd",
+	}
+
+	// ProfileRandom picks a random fingerprint per connection.
 	ProfileRandom = &Profile{
-		ID:             "random",
+		ID:             ProfileIDRandom,
 		ClientHelloID:  utls.HelloRandomized,
-		UserAgent:      randomUserAgent(),
 		AcceptLanguage: "en-US,en;q=0.9",
 		AcceptEncoding: "gzip, deflate, br",
 	}
+
+	// ProfileAuto rotates across modern profiles per connection.
+	ProfileAuto = &Profile{
+		ID: ProfileIDAuto,
+	}
 )
 
-// DefaultProfile returns Chrome 120 as the default profile.
-func DefaultProfile() *Profile { return ProfileChrome120 }
+// DefaultProfile returns Chrome 126 as the default modern profile.
+func DefaultProfile() *Profile { return ProfileChrome126 }
 
 // Lookup returns the profile matching the given name (case-insensitive)
 // and true, or nil, false for unknown names.
@@ -85,31 +134,78 @@ func Lookup(name string) (*Profile, bool) {
 	switch strings.ToLower(name) {
 	case "chrome120":
 		return ProfileChrome120, true
+	case "chrome126", "chrome":
+		return ProfileChrome126, true
 	case "safari17":
 		return ProfileSafari17, true
+	case "safari18", "safari":
+		return ProfileSafari18, true
 	case "firefox120":
 		return ProfileFirefox120, true
+	case "firefox128", "firefox":
+		return ProfileFirefox128, true
+	case "edge126", "edge":
+		return ProfileEdge126, true
 	case "random":
 		return ProfileRandom, true
+	case "auto":
+		return ProfileAuto, true
 	default:
 		return nil, false
 	}
 }
 
-// randomUserAgent generates a randomized browser User-Agent by picking a
-// known browser version string.
-func randomUserAgent() string {
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	agents := []string{
-		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-		"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-		"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0",
-		"Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0",
-		"Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+// GetProfileForConnection returns a concrete profile for one connection.
+// For static profiles it returns p unchanged. For ProfileRandom or ProfileAuto,
+// it resolves a fresh profile and User-Agent using crypto/rand (#3, #21).
+func GetProfileForConnection(p *Profile) *Profile {
+	if p == nil {
+		p = DefaultProfile()
 	}
-	return agents[rng.Intn(len(agents))]
+	if p.ID == ProfileIDAuto {
+		presets := []*Profile{
+			ProfileChrome126,
+			ProfileFirefox128,
+			ProfileSafari18,
+			ProfileEdge126,
+		}
+		idx := cryptoRandInt(len(presets))
+		return presets[idx]
+	}
+	if p.ID == ProfileIDRandom {
+		prof := *p
+		prof.UserAgent = RandomUserAgent()
+		return &prof
+	}
+	return p
 }
+
+// cryptoRandInt returns a crypto-random integer in [0, n).
+func cryptoRandInt(n int) int {
+	if n <= 0 {
+		return 0
+	}
+	var b [8]byte
+	_, _ = cryptoRand.Read(b[:])
+	u := binary.BigEndian.Uint64(b[:])
+	return int(u % uint64(n))
+}
+
+// RandomUserAgent generates a randomized browser User-Agent per connection
+// using crypto/rand (#21).
+func RandomUserAgent() string {
+	agents := []string{
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+		"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0",
+		"Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0",
+	}
+	return agents[cryptoRandInt(len(agents))]
+}
+
 
 // safari17Spec returns the custom ClientHelloSpec for Safari 17 on macOS.
 // Ported exactly from the reference implementation.

--- a/internal/stealth/stealth_test.go
+++ b/internal/stealth/stealth_test.go
@@ -17,32 +17,33 @@ import (
 
 func TestLookup(t *testing.T) {
 	tests := []struct {
-		name   string
-		want   *Profile
-		wantOK bool
+		name    string
+		wantID  ProfileID
+		wantOK  bool
 	}{
-		{"chrome120", ProfileChrome120, true},
-		{"Chrome120", ProfileChrome120, true},
-		{"CHROME120", ProfileChrome120, true},
-		{"safari17", ProfileSafari17, true},
-		{"Safari17", ProfileSafari17, true},
-		{"firefox120", ProfileFirefox120, true},
-		{"Firefox120", ProfileFirefox120, true},
-		{"random", ProfileRandom, true},
-		{"Random", ProfileRandom, true},
-		{"unknown", nil, false},
-		{"", nil, false},
+		{"chrome120", ProfileIDChrome120, true},
+		{"chrome126", ProfileIDChrome126, true},
+		{"chrome", ProfileIDChrome126, true},
+		{"safari17", ProfileIDSafari17, true},
+		{"safari18", ProfileIDSafari18, true},
+		{"safari", ProfileIDSafari18, true},
+		{"firefox120", ProfileIDFirefox120, true},
+		{"firefox128", ProfileIDFirefox128, true},
+		{"firefox", ProfileIDFirefox128, true},
+		{"edge126", ProfileIDEdge126, true},
+		{"edge", ProfileIDEdge126, true},
+		{"random", ProfileIDRandom, true},
+		{"auto", ProfileIDAuto, true},
+		{"unknown", "", false},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, ok := Lookup(tt.name)
-			if ok != tt.wantOK {
-				t.Errorf("Lookup(%q) ok = %v, want %v", tt.name, ok, tt.wantOK)
-			}
-			if got != tt.want {
-				t.Errorf("Lookup(%q) = %v, want %v", tt.name, got, tt.want)
-			}
-		})
+		got, ok := Lookup(tt.name)
+		if ok != tt.wantOK {
+			t.Errorf("Lookup(%q) ok = %v, want %v", tt.name, ok, tt.wantOK)
+		}
+		if ok && got.ID != tt.wantID {
+			t.Errorf("Lookup(%q) ID = %q, want %q", tt.name, got.ID, tt.wantID)
+		}
 	}
 }
 
@@ -193,7 +194,22 @@ func TestDialerTLS(t *testing.T) {
 
 func TestDefaultProfile(t *testing.T) {
 	dp := DefaultProfile()
-	if dp != ProfileChrome120 {
-		t.Errorf("DefaultProfile = %v, want ProfileChrome120", dp)
+	if dp != ProfileChrome126 {
+		t.Errorf("DefaultProfile = %v, want ProfileChrome126", dp)
 	}
+}
+
+func TestGetProfileForConnection(t *testing.T) {
+	t.Run("auto", func(t *testing.T) {
+		p := GetProfileForConnection(ProfileAuto)
+		if p == nil || p.ID == ProfileIDAuto {
+			t.Errorf("GetProfileForConnection(ProfileAuto) returned unresolved profile: %v", p)
+		}
+	})
+	t.Run("random", func(t *testing.T) {
+		p := GetProfileForConnection(ProfileRandom)
+		if p.UserAgent == "" {
+			t.Errorf("GetProfileForConnection(ProfileRandom) returned empty User-Agent")
+		}
+	})
 }

--- a/internal/stealth/tls.go
+++ b/internal/stealth/tls.go
@@ -25,6 +25,7 @@ func Dialer(profile *Profile, baseDial func(ctx context.Context, network, addr s
 		profile = DefaultProfile()
 	}
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		connProfile := GetProfileForConnection(profile)
 		dialFN := baseDial
 		if dialFN == nil {
 			dialFN = (&net.Dialer{
@@ -45,7 +46,7 @@ func Dialer(profile *Profile, baseDial func(ctx context.Context, network, addr s
 			return nil, fmt.Errorf("stealth: invalid address %q: %w", addr, err)
 		}
 
-		helloID := profile.ClientHelloID
+		helloID := connProfile.ClientHelloID
 
 		uConn := utls.UClient(rawConn, &utls.Config{
 			ServerName:         host,
@@ -53,8 +54,8 @@ func Dialer(profile *Profile, baseDial func(ctx context.Context, network, addr s
 			MinVersion:         tls.VersionTLS12,
 		}, helloID)
 
-		if profile.CustomSpec != nil {
-			if err := uConn.ApplyPreset(profile.CustomSpec); err != nil {
+		if connProfile.CustomSpec != nil {
+			if err := uConn.ApplyPreset(connProfile.CustomSpec); err != nil {
 				_ = rawConn.Close()
 				return nil, fmt.Errorf("stealth: apply custom spec failed: %w", err)
 			}

--- a/internal/upstream/client.go
+++ b/internal/upstream/client.go
@@ -11,7 +11,8 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"context"
-	"crypto/rand"
+	cryptoRand "crypto/rand"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -170,11 +171,12 @@ type Client struct {
 
 	requestTimeout     time.Duration
 	sessionCallTimeout time.Duration
+	requestJitter      time.Duration
+	cliVersion         string
 	costMode           string
 	debugDump          bool
 	stealthProfile     *stealth.Profile // nil when fingerprint unset
 }
-
 // cliUserAgent mirrors the official CLI / SDK user agent. The upstream
 // free-tier gate (403 free_mode_cli_required) requires requests to carry the
 // AI-SDK user agent; random browser UAs are rejected. Kept as a fixed
@@ -228,11 +230,18 @@ func New(token string, cfg *config.Config) (*Client, error) {
 		stealthProf = profile
 	}
 
+	cliVer := cfg.CLIVersion
+	if cliVer == "" {
+		cliVer = "0.10.7"
+	}
+
 	return &Client{
 		token:              token,
 		baseURL:            cfg.UpstreamBaseURL,
 		requestTimeout:     cfg.RequestTimeout,
 		sessionCallTimeout: cfg.SessionCallTimeout,
+		requestJitter:      cfg.RequestJitter,
+		cliVersion:         cliVer,
 		costMode:           cfg.CostMode,
 		debugDump:          cfg.DebugDump,
 		stealthProfile:     stealthProf,
@@ -254,11 +263,24 @@ func New(token string, cfg *config.Config) (*Client, error) {
 // returns a typed error. The returned reader must be closed; closing it
 // releases the connection.
 func (c *Client) ChatCompletions(ctx context.Context, opts ChatOptions, body []byte) (io.ReadCloser, error) {
+	if c.requestJitter > 0 {
+		var b [8]byte
+		_, _ = cryptoRand.Read(b[:])
+		u := binary.BigEndian.Uint64(b[:])
+		jitterNano := int64(u % uint64(c.requestJitter))
+		timer := time.NewTimer(time.Duration(jitterNano))
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		}
+	}
+
 	enveloped, err := injectEnvelope(body, c.costMode, opts)
 	if err != nil {
 		return nil, fmt.Errorf("upstream: envelope: %w", err)
 	}
-
 	req, err := c.newRequest(ctx, http.MethodPost, "/api/v1/chat/completions", enveloped)
 	if err != nil {
 		return nil, err
@@ -465,9 +487,14 @@ func (c *Client) newRequest(ctx context.Context, method, path string, body []byt
 	req.Header.Set("Authorization", "Bearer "+c.token)
 	req.Header.Set("Content-Type", "application/json")
 	if c.stealthProfile != nil {
-		stealth.SanitizeAndApply(req.Header, c.stealthProfile)
+		connProf := stealth.GetProfileForConnection(c.stealthProfile)
+		stealth.SanitizeAndApply(req.Header, connProf)
 	} else {
-		req.Header.Set("User-Agent", cliUserAgent)
+		ver := c.cliVersion
+		if ver == "" {
+			ver = "0.10.7"
+		}
+		req.Header.Set("User-Agent", fmt.Sprintf("ai-sdk/openai-compatible/%s/codebuff", ver))
 	}
 	return req, nil
 }
@@ -739,7 +766,7 @@ func unixFrom(secs int64) time.Time {
 // (Math.random().toString(36).substring(2, 15)).
 func generateClientID() string {
 	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
+	if _, err := cryptoRand.Read(b[:]); err != nil {
 		// crypto/rand failure is unrecoverable in practice; fall back to a
 		// time-seeded value rather than panicking mid-request.
 		return strconv.FormatInt(time.Now().UnixNano(), 36)[:13]


### PR DESCRIPTION
## Summary

Comprehensive anti-ban and stealth enhancements:

### 1. `SAFE_MODE=true` preset (#7)
Enables recommended anti-ban safe defaults for any zero-valued safety knob:
- `MAX_MESSAGES_PER_DAY`: `150`
- `IDLE_ROTATION_TIMEOUT`: `30m`
- `REQUEST_JITTER`: `2s`

### 2. Request Jitter (`REQUEST_JITTER`) (#2)
Adds a random delay in `[0, REQUEST_JITTER)` before upstream `ChatCompletions` calls to break regular automation timing patterns. Also randomizes background maintenance tick intervals.

### 3. Modern TLS Profiles & `TLS_FINGERPRINT=auto` (#3, #21)
- Added modern browser profiles: `chrome126`, `firefox128`, `safari18`, `edge126`
- Added `TLS_FINGERPRINT=auto` mode which rotates across modern profiles per connection
- Replaced `math/rand` with `crypto/rand` for random profile and User-Agent resolution
- Fixed `ProfileRandom` so it resolves a fresh User-Agent per connection instead of storing a static package variable

### 4. Dynamic CLI Versioning (`CLI_VERSION`) (#4)
User-Agent versioning (`ai-sdk/openai-compatible/<CLI_VERSION>/codebuff`) now accepts `CLI_VERSION` override.

### 5. Config Validation Fix Suggestions (#16)
`config.Validate()` now returns helpful, actionable fix suggestions for common errors:
- Token starting with `"Bearer "` prefix
- Token set to placeholder (`"cb_xxx"`)
- `LISTEN_ADDR` missing port separator (`:`)

Fixes #2, #3, #4, #7, #16, #21