### PR TITLE
feat(ux): account health metrics, freebuff-proxy -doctor, Getting Started guide, Client Integration guide, simplified .env, and human error hints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,87 +1,12 @@
-# FreeBuff proxy bridge — configuration
-# All keys are read from the environment and override the JSON config file
-# (config.json / -config flag). Keys in the JSON file mirror these names.
+# FreeBuff proxy bridge — minimal configuration
+# Get your token at https://freebuff.llm.pm or run scripts/get-freebuff-token.sh
+# For all options, see .env.full-example
 
-# FreeBuff auth token(s) for the upstream Codebuff API. Comma-separated for
-# multiple accounts (round-robin + failover across tokens). OPTIONAL: empty
-# (= bridge mode) starts the proxy without any token — each client then sends
-# their own FreeBuff token as Authorization: Bearer <token> per request, and
-# the proxy relays with it (never stored here).
-# How to obtain one: run the official CLI (npm install -g freebuff, then run
-# freebuff and log in) and read authToken from
-# ~/.config/manicode/credentials.json, or use the web flow at freebuff.llm.pm.
-# No Bearer prefix, no quotes.
-# IMPORTANT: do not leave a placeholder value here. A bogus token starts the
-# proxy fine (/healthz and /v1/models return 200) but every chat then fails with
-# 502 wrapping "Invalid API key or user not found". Empty is safer than fake.
+# Your FreeBuff auth token (no "Bearer " prefix). Empty = bridge mode.
 AUTH_TOKENS=
 
-# Listen address for the OpenAI-compatible API surface
-# (/v1/chat/completions, /v1/models, /healthz). Defaults to 127.0.0.1
-# (loopback only — the proxy holds FreeBuff tokens); set LISTEN_ADDR=:3457
-# to expose it on all interfaces (e.g. in a container).
+# Recommended: safe mode protects your account from abuse detection bans
+SAFE_MODE=true
+
+# Listen address (use :3457 inside Docker containers)
 LISTEN_ADDR=127.0.0.1:3457
-
-# Upstream Codebuff base URL. The host is normalized to www.codebuff.com.
-UPSTREAM_BASE_URL=https://codebuff.com
-
-# How long an agent run lives upstream before it is rotated (FINISH + restart).
-ROTATION_INTERVAL=6h
-
-# Timeout for a single upstream chat-completions request (stream included).
-REQUEST_TIMEOUT=15m
-
-# Timeout for individual session / agent-run API calls (create, poll, start…).
-SESSION_CALL_TIMEOUT=30s
-
-# How often the model registry re-fetches the Codebuff TS sources
-# (free-agents.ts, freebuff-models.ts, gemini.ts, …). Failures keep the
-# previous mapping (or the hardcoded fallback at boot).
-REGISTRY_REFRESH=6h
-
-# Optional: API keys clients must present (Authorization: Bearer or
-# x-api-key). Comma-separated. Empty = no client auth.
-API_KEYS=
-
-# Outbound HTTP/HTTPS proxy (CONNECT tunneling). Empty = direct.
-HTTP_PROXY=
-
-# Outbound SOCKS5 proxy (e.g. socks5://127.0.0.1:1080). Empty = direct.
-SOCKS5_PROXY=
-
-# cost_mode sent upstream with chat requests. Must be "free": upstream's
-# 402 balance check runs only when cost_mode != "free", so omitting it makes
-# fresh free-tier accounts fail with "Out of credits. Please add credits at
-# codebuff.com/usage". Do not change unless you know what you are doing.
-COST_MODE=free
-
-# Dump raw upstream request/response traffic into ./dump for debugging.
-DEBUG_DUMP=false
-
-# Optional log file path (in addition to stderr). Empty = stderr only.
-LOG_FILE=
-
-# Optional outbound TLS fingerprint impersonation (JA3): chrome120, safari17,
-# firefox120, or random. Empty = plain Go transport (default). Makes upstream
-# connections look like a real browser at the TLS layer; pairs each profile
-# with matching browser headers (Sec-CH-UA, Sec-Fetch-*, ...). Use only if
-# upstream starts rejecting the plain Go TLS fingerprint.
-TLS_FINGERPRINT=
-
-# Log verbosity: debug, info, warn, error. Empty = info (or debug with -v).
-# LOG_LEVEL wins over -v when both are set.
-LOG_LEVEL=
-
-# Account-safety knobs (recommended if you care about keeping the account alive).
-#
-# Per-token rolling 24h message cap. When a token reaches the cap, the proxy
-# answers 429 (rate_limited, with Retry-After) instead of hitting upstream,
-# which keeps the account far under FreeBuff's abuse-detection thresholds
-# (~500 msgs/24h). 0 = unlimited. Example: 150.
-MAX_MESSAGES_PER_DAY=0
-
-# Pause background work after this long without traffic: runs are FINISHed
-# and maintenance (run rotation, queued-session advancing) stops until the
-# next request, so the account is not kept artificially active 24/7.
-# Duration format, e.g. "30m" or "1h". 0 = always maintain (default).
-IDLE_ROTATION_TIMEOUT=0

--- a/.env.full-example
+++ b/.env.full-example
@@ -1,0 +1,43 @@
+# FreeBuff proxy bridge — complete configuration options
+# All keys are read from the environment or .env and override JSON config.
+
+# FreeBuff auth token(s). Comma-separated for multiple accounts.
+# Get one at https://freebuff.llm.pm or run scripts/get-freebuff-token.sh
+# Empty = bridge mode (clients send their own FreeBuff token per request).
+AUTH_TOKENS=
+
+# Recommended: enable account safety mode (sets safe defaults for MAX_MESSAGES_PER_DAY, IDLE_ROTATION_TIMEOUT, REQUEST_JITTER)
+SAFE_MODE=true
+
+# Listen address. Loopback default (127.0.0.1:3457). Set to :3457 in containers.
+LISTEN_ADDR=127.0.0.1:3457
+
+# Upstream Codebuff API URL (host normalized to www.codebuff.com)
+UPSTREAM_BASE_URL=https://codebuff.com
+
+# Rotation & timeouts
+ROTATION_INTERVAL=6h
+REQUEST_TIMEOUT=15m
+SESSION_CALL_TIMEOUT=30s
+REGISTRY_REFRESH=6h
+
+# Client authentication keys (optional, comma-separated)
+API_KEYS=
+
+# Proxy & stealth settings
+HTTP_PROXY=
+SOCKS5_PROXY=
+# TLS_FINGERPRINT options: chrome126, firefox128, safari18, edge126, auto, random
+TLS_FINGERPRINT=auto
+COST_MODE=free
+CLI_VERSION=0.10.7
+
+# Debugging & logging
+DEBUG_DUMP=false
+LOG_FILE=
+LOG_LEVEL=
+
+# Account safety fine-tuning (explicit values override SAFE_MODE defaults)
+MAX_MESSAGES_PER_DAY=150
+IDLE_ROTATION_TIMEOUT=30m
+REQUEST_JITTER=2s

--- a/README.md
+++ b/README.md
@@ -49,15 +49,40 @@ What this is not: an official FreeBuff or Codebuff product. It is a community br
 >   not for proxy use. The maintainers have had accounts suspended while building and
 >   testing this project. This is not a toy warning.
 
+> **New here?** Start with the **[Getting Started Guide](docs/guides/getting-started.md)** for step-by-step setup, or see the **[Client Integration Guide](docs/guides/client-integration.md)** for copy-paste config for Continue, Cursor, aider, opencode, and more.
+
+## How it works
+
+```mermaid
+graph TD
+    Client[AI Client / Tool<br/>Continue, Cursor, aider] -->|POST /v1/chat/completions| Proxy[freebuff-proxy<br/>localhost:3457]
+    Proxy -->|1. Session & Run Lifecycle| Pool[Token Pool & Session Manager]
+    Proxy -->|2. Inject Envelope + Stealth| Upstream[Codebuff Upstream API<br/>codebuff.com]
+    Upstream -->|3. SSE Stream| Proxy
+    Proxy -->|4. OpenAI SSE Chunks| Client
+```
+
+### Glossary of terms
+
+| Term | Meaning |
+|---|---|
+| **Token** | Your FreeBuff authentication credential (`auth_code`). Obtained via web login at freebuff.llm.pm or official CLI. |
+| **Session** | A "free session" created upstream by the proxy so FreeBuff treats requests as coming from the official CLI. |
+| **Run** | An "agent run" inside a session required for model requests. Automatically rotated every 6h. |
+| **Rotation** | Periodically finishing old agent runs and starting new ones upstream to prevent long-lived session detection. |
+| **Cooldown** | When a token receives a 401 or 429 error, the proxy temporarily pauses it (30 min) and fails over to another token. |
+| **Bridge mode** | Proxy runs without configured tokens (`AUTH_TOKENS=`); each client sends their own token via `Authorization: Bearer <token>`. |
+| **Safe mode** | Preset (`SAFE_MODE=true`) applying conservative defaults for message caps, idle rotation, and request jitter. |
+
 ## What it does
 
 - Serves `/v1/chat/completions`, `/v1/models`, and `/healthz` on `127.0.0.1:3457` by default.
+- Self-diagnostic tool: `./freebuff-proxy -doctor` tests config, network, tokens, and upstream reachability (#15).
 - Pools tokens: `AUTH_TOKENS` accepts comma-separated values, round-robins across them, and cools a token down for 30 minutes after a 401.
 - Keeps free sessions alive: single-flight session create/poll/end, runs prewarmed at boot, rotated every `ROTATION_INTERVAL` (default 6h).
 - Refreshes the model catalog every 6h from the Codebuff sources (15 models at boot, served by `/v1/models`).
-- Sends outbound traffic through `HTTP_PROXY` or `SOCKS5_PROXY`, or impersonates a browser TLS fingerprint with `TLS_FINGERPRINT`.
-
-## Requirements
+- Sends outbound traffic through `HTTP_PROXY` or `SOCKS5_PROXY`, or impersonates a browser TLS fingerprint with `TLS_FINGERPRINT` (`chrome126`, `firefox128`, `safari18`, `edge126`, `auto`).
+- Account-safety knobs: `SAFE_MODE=true` preset, `MAX_MESSAGES_PER_DAY`, `IDLE_ROTATION_TIMEOUT`, and `REQUEST_JITTER`.
 
 - Zero or more FreeBuff auth tokens. With none, the proxy runs in **bridge mode** — each client sends their own token (see [Bridge mode](#bridge-mode)).
 - Release binaries run standalone. Building from source needs Go 1.26+ (see `go.mod`).

--- a/cmd/freebuff-proxy/doctor.go
+++ b/cmd/freebuff-proxy/doctor.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"freebuff-proxy/internal/config"
+	"freebuff-proxy/internal/registry"
+)
+
+func runDoctor(configPath string) {
+	fmt.Println("freebuff-proxy doctor diagnostic tool")
+	fmt.Println("=====================================")
+
+	passed := 0
+	warnings := 0
+	failed := 0
+
+	ok := func(msg string) {
+		fmt.Printf("[ok] %s\n", msg)
+		passed++
+	}
+	warn := func(msg string) {
+		fmt.Printf("[!!] %s\n", msg)
+		warnings++
+	}
+	fail := func(msg string) {
+		fmt.Printf("[FAIL] %s\n", msg)
+		failed++
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		fail(fmt.Sprintf("Config loading failed: %v", err))
+		fmt.Printf("\nSummary: %d passed, %d warnings, %d failed\n", passed, warnings, failed)
+		os.Exit(1)
+	}
+	ok("Configuration loaded & validated successfully")
+
+	if cfg.BridgeMode() {
+		warn("AUTH_TOKENS is empty (bridge mode active). Clients must supply Authorization: Bearer <token>")
+	} else {
+		ok(fmt.Sprintf("AUTH_TOKENS: %d token(s) configured", len(cfg.AuthTokens)))
+		for i, tok := range cfg.AuthTokens {
+			if strings.HasPrefix(strings.ToLower(tok), "bearer ") {
+				warn(fmt.Sprintf("Token #%d starts with 'Bearer ' prefix -- remove it from .env", i+1))
+			} else if tok == "cb_xxx" || tok == "cb_yyy" {
+				warn(fmt.Sprintf("Token #%d is a placeholder string %q", i+1, tok))
+			} else {
+				ok(fmt.Sprintf("Token #%d format valid (%d chars)", i+1, len(tok)))
+			}
+		}
+	}
+
+	// Port availability check
+	ln, err := net.Listen("tcp", cfg.ListenAddr)
+	if err != nil {
+		fail(fmt.Sprintf("Listen address %s is not available: %v", cfg.ListenAddr, err))
+	} else {
+		_ = ln.Close()
+		ok(fmt.Sprintf("Listen address %s is available", cfg.ListenAddr))
+	}
+
+	// DNS & TLS reachability check
+	targetHost := "www.codebuff.com"
+	if u, err := url.Parse(cfg.UpstreamBaseURL); err == nil && u.Host != "" {
+		targetHost = u.Host
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	addrs, err := net.DefaultResolver.LookupHost(ctx, targetHost)
+	if err != nil {
+		fail(fmt.Sprintf("DNS lookup for %s failed: %v", targetHost, err))
+	} else {
+		ok(fmt.Sprintf("DNS lookup for %s resolved (%s)", targetHost, strings.Join(addrs, ", ")))
+	}
+
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	tlsConn, err := tls.DialWithDialer(dialer, "tcp", targetHost+":443", &tls.Config{ServerName: targetHost})
+	if err != nil {
+		fail(fmt.Sprintf("TLS connection to %s:443 failed: %v", targetHost, err))
+	} else {
+		_ = tlsConn.Close()
+		ok(fmt.Sprintf("TLS connection to %s:443 succeeded", targetHost))
+	}
+
+	// Registry test
+	reg := registry.New(&cfg, &http.Client{Timeout: 10 * time.Second})
+	reg.LoadFallback()
+	ok(fmt.Sprintf("Model registry offline fallback loaded (%d models, %d agents)", reg.ModelCount(), len(reg.AgentIDs())))
+
+	if err := reg.Refresh(ctx); err != nil {
+		warn(fmt.Sprintf("Registry live refresh warning: %v (offline fallback retained)", err))
+	} else {
+		ok(fmt.Sprintf("Registry live refresh succeeded (%d models)", reg.ModelCount()))
+	}
+
+	fmt.Printf("\nSummary: %d passed, %d warnings, %d failed\n", passed, warnings, failed)
+	if failed > 0 {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/cmd/freebuff-proxy/main.go
+++ b/cmd/freebuff-proxy/main.go
@@ -36,13 +36,16 @@ func main() {
 	configPath := flag.String("config", "", "path to an optional JSON config file (keys mirror env names)")
 	verbose := flag.Bool("v", false, "verbose (debug) logging")
 	showVersion := flag.Bool("version", false, "print version and exit")
+	showDoctor := flag.Bool("doctor", false, "run environment and configuration diagnostics")
 	flag.Parse()
 
 	if *showVersion {
 		fmt.Println("freebuff-proxy", version)
 		os.Exit(0)
 	}
-
+	if *showDoctor {
+		runDoctor(*configPath)
+	}
 	cfg, err := config.Load(*configPath)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "freebuff-proxy: invalid config:", err)

--- a/docs/guides/client-integration.md
+++ b/docs/guides/client-integration.md
@@ -1,0 +1,138 @@
+# Client Integration Guide
+
+Connect any OpenAI-compatible AI tool or coding assistant to `freebuff-proxy`.
+
+**Server Base URL:** `http://localhost:3457/v1`  
+**API Key:** `not-needed` (or your FreeBuff token in bridge mode)
+
+---
+
+## 1. Continue (VS Code & JetBrains Extension)
+
+Edit `~/.continue/config.json`:
+
+```json
+{
+  "models": [
+    {
+      "title": "FreeBuff DeepSeek Flash",
+      "provider": "openai",
+      "model": "deepseek/deepseek-v4-flash",
+      "apiBase": "http://localhost:3457/v1",
+      "apiKey": "not-needed"
+    },
+    {
+      "title": "FreeBuff GLM 5.2",
+      "provider": "openai",
+      "model": "z-ai/glm-5.2",
+      "apiBase": "http://localhost:3457/v1",
+      "apiKey": "not-needed"
+    }
+  ]
+}
+```
+
+---
+
+## 2. Cursor IDE
+
+1. Open **Cursor Settings** -> **Models**
+2. Scroll to **OpenAI API Key** or **Custom OpenAI Compatible Provider**
+3. Override **Base URL**: `http://localhost:3457/v1`
+4. Enter **API Key**: `not-needed`
+5. Add Model: `deepseek/deepseek-v4-flash`
+
+---
+
+## 3. aider (CLI AI Pair Programmer)
+
+Run `aider` with environment variables or CLI flags:
+
+```bash
+export OPENAI_API_BASE="http://localhost:3457/v1"
+export OPENAI_API_KEY="not-needed"
+
+aider --model openai/deepseek/deepseek-v4-flash
+```
+
+---
+
+## 4. opencode
+
+Add to `opencode.json` or `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "providers": {
+    "freebuff": {
+      "type": "openai",
+      "options": {
+        "baseURL": "http://localhost:3457/v1",
+        "apiKey": "not-needed"
+      },
+      "models": [
+        { "id": "deepseek/deepseek-v4-flash", "name": "DeepSeek Flash" },
+        { "id": "z-ai/glm-5.2", "name": "GLM 5.2" }
+      ]
+    }
+  }
+}
+```
+
+---
+
+## 5. Python (Official OpenAI SDK)
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:3457/v1",
+    api_key="not-needed"
+)
+
+response = client.chat.completions.create(
+    model="deepseek/deepseek-v4-flash",
+    messages=[{"role": "user", "content": "Write a python function to check prime numbers."}],
+    stream=True
+)
+
+for chunk in response:
+    if chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="")
+```
+
+---
+
+## 6. Node.js (Official OpenAI SDK)
+
+```javascript
+import OpenAI from 'openai';
+
+const openai = new OpenAI({
+  baseURL: 'http://localhost:3457/v1',
+  apiKey: 'not-needed',
+});
+
+const response = await openai.chat.completions.create({
+  model: 'deepseek/deepseek-v4-flash',
+  messages: [{ role: 'user', content: 'Say hello in TypeScript!' }],
+  stream: true,
+});
+
+for await (const chunk of response) {
+  process.stdout.write(chunk.choices[0]?.delta?.content || '');
+}
+```
+
+---
+
+## Recommended Models
+
+Query `http://localhost:3457/v1/models` for the full live list.
+
+| Model ID | Provider | Best for |
+|---|---|---|
+| `deepseek/deepseek-v4-flash` | DeepSeek | Fast coding, auto-complete, inline refactors |
+| `z-ai/glm-5.2` | Zhipu AI | Code explanation, architecture, complex reasoning |
+| `meta-llama/llama-3.3-70b-instruct` | Meta | General instructions & conversation |

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,96 @@
+# Getting Started with freebuff-proxy (5-Minute Guide)
+
+This guide takes you from zero to a working OpenAI-compatible proxy connected to FreeBuff.
+
+---
+
+## What is freebuff-proxy?
+
+`freebuff-proxy` is a local bridge server. It sits between your favorite coding tools (like Continue, Cursor, aider, or opencode) and FreeBuff's free AI models. Your tools talk standard OpenAI API to `localhost:3457`, and the proxy manages sessions and tokens behind the scenes.
+
+```
++-------------------+      OpenAI API      +-------------------+      FreeBuff      +-------------------+
+| Your AI Client    | -------------------> | freebuff-proxy    | -----------------> | codebuff.com      |
+| (Continue/Cursor) | <------------------- | (localhost:3457)  | <----------------- | (Free Models)     |
++-------------------+      SSE Streams     +-------------------+     CLI Envelope   +-------------------+
+```
+
+---
+
+## Important Safety Warning
+
+Using this proxy conflicts with Codebuff's terms of service. Upstream abuse detection scans for automation patterns and suspends accounts.
+- **Use `SAFE_MODE=true`** (enabled by default in `.env.example`).
+- Do **not** run 24/7 on heavy unattended automated tasks.
+- Keep one modest account; do not create spam clusters of accounts.
+
+---
+
+## Step 1: Install & Start the Proxy
+
+### Option A: One-Command Installer (Recommended)
+
+**Linux / macOS Terminal:**
+```bash
+curl -sSL https://raw.githubusercontent.com/trefeon/freebuff-proxy/main/scripts/install-freebuff-proxy.sh | bash
+```
+
+**Windows PowerShell:**
+```powershell
+irm https://raw.githubusercontent.com/trefeon/freebuff-proxy/main/scripts/install-freebuff-proxy.ps1 | iex
+```
+
+Follow the prompts to pick your token or enable bridge mode.
+
+---
+
+### Option B: Docker Compose
+
+```bash
+cp .env.example .env
+# Edit .env and set AUTH_TOKENS=your_token
+docker compose up -d --build
+```
+
+---
+
+## Step 2: Verify It Works
+
+Run the diagnostic tool or curl:
+
+```bash
+# Diagnostic doctor check:
+./freebuff-proxy -doctor
+
+# Quick health check:
+curl http://localhost:3457/healthz
+
+# List available models:
+curl http://localhost:3457/v1/models
+```
+
+`/healthz` returning status `200` means your proxy setup is **100% correct**.
+
+---
+
+## Step 3: Connect Your Favorite AI Client
+
+Point your AI tool to:
+- **Base URL:** `http://localhost:3457/v1`
+- **API Key:** `not-needed` (or your token in bridge mode)
+- **Model:** `deepseek/deepseek-v4-flash` (or `z-ai/glm-5.2`)
+
+See the [Client Integration Guide](client-integration.md) for copy-paste config for Continue, Cursor, aider, opencode, and more.
+
+---
+
+## Troubleshooting
+
+Run `./freebuff-proxy -doctor` to diagnose problems automatically.
+
+| Error / Symptom | Cause & Fix |
+|---|---|
+| `502` + `403 free_mode_cli_required` | Upstream CLI-only enforcement on free tier. Setup is fine; see FAQ. |
+| `502` + `401 Invalid API key` | Token in `.env` is expired or invalid. Get a fresh token at https://freebuff.llm.pm. |
+| Connection refused | Proxy is not running, or in Docker without `LISTEN_ADDR=:3457`. |
+| `403 account_banned` | Account suspended upstream. Token is dead; use a new established account. |

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -91,7 +91,10 @@ type TokenSnapshot struct {
 	SessionQueueDepth    int
 	ActiveRuns           int
 	Requests             int
-	Messages24h          int // successful chats in the last 24h (MAX_MESSAGES_PER_DAY usage)
+	Messages24h          int    // successful chats in the last 24h (MAX_MESSAGES_PER_DAY usage)
+	DailyLimit           int    // configured MAX_MESSAGES_PER_DAY (0 = unlimited)
+	UsagePct             int    // percentage of daily limit used (0 when unlimited)
+	RiskLevel            string // "low", "moderate", "high", "critical" account safety indicator (#6)
 }
 
 // Pool balances requests across the configured tokens.
@@ -543,15 +546,45 @@ func (p *Pool) Shutdown(ctx context.Context) {
 // Snapshot returns the per-token healthz view.
 func (p *Pool) Snapshot() []TokenSnapshot {
 	out := make([]TokenSnapshot, 0, len(p.toks))
+	dailyLimit := p.cfg.MaxMessagesPerDay
 	for i, tok := range p.toks {
 		rs := tok.runs.Snapshot()
 		ss := tok.session.Snapshot()
+		msgs := p.usageCount(i)
+
+		usagePct := 0
+		if dailyLimit > 0 {
+			usagePct = (msgs * 100) / dailyLimit
+			if usagePct > 100 {
+				usagePct = 100
+			}
+		}
+
+		riskLevel := "low"
+		switch {
+		case !rs.CooldownUntil.IsZero() && time.Now().Before(rs.CooldownUntil):
+			riskLevel = "high"
+		case rs.BanError != nil:
+			riskLevel = "critical"
+		case dailyLimit > 0 && usagePct >= 90:
+			riskLevel = "critical"
+		case dailyLimit > 0 && usagePct >= 70:
+			riskLevel = "high"
+		case msgs > 120:
+			riskLevel = "high"
+		case (dailyLimit > 0 && usagePct >= 30) || msgs >= 50:
+			riskLevel = "moderate"
+		}
+
 		out = append(out, TokenSnapshot{
 			Token:                i,
 			CooldownUntil:        rs.CooldownUntil,
 			ActiveRuns:           rs.ActiveRuns,
 			Requests:             rs.Requests,
-			Messages24h:          p.usageCount(i),
+			Messages24h:          msgs,
+			DailyLimit:           dailyLimit,
+			UsagePct:             usagePct,
+			RiskLevel:            riskLevel,
 			SessionStatus:        ss.Status,
 			SessionInstanceID:    ss.InstanceID,
 			SessionQueuePosition: ss.QueuePosition,

--- a/internal/runs/runs.go
+++ b/internal/runs/runs.go
@@ -51,8 +51,8 @@ type RunSnapshot struct {
 	ActiveRuns    int
 	CooldownUntil time.Time
 	Requests      int
+	BanError      *upstream.BanError
 }
-
 // RunManager owns the current runs (one per agent) plus the draining list
 // for a single token.
 type RunManager struct {
@@ -338,7 +338,7 @@ func (m *RunManager) BanError() *upstream.BanError {
 func (m *RunManager) Snapshot() RunSnapshot {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	s := RunSnapshot{ActiveRuns: len(m.runs), CooldownUntil: m.cooldownUntil, Requests: m.totalRequests}
+	s := RunSnapshot{ActiveRuns: len(m.runs), CooldownUntil: m.cooldownUntil, Requests: m.totalRequests, BanError: m.ban}
 	return s
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -517,16 +517,24 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 
 // --- error mapping ---
 
-// openAIError is the OpenAI error body; an empty code is omitted.
+// openAIError is the OpenAI error body with an optional human-readable hint (#19).
 type openAIError struct {
 	Message string `json:"message"`
 	Type    string `json:"type"`
 	Code    string `json:"code,omitempty"`
+	Hint    string `json:"hint,omitempty"`
 }
 
 // writeJSONError writes an OpenAI-shaped error response. Retry-After is set
 // (in ceil seconds) only when retryAfter > 0.
 func (s *Server) writeJSONError(w http.ResponseWriter, status int, message, typ, code string, retryAfter time.Duration) {
+	s.writeJSONErrorWithHint(w, status, message, typ, code, "", retryAfter)
+}
+
+func (s *Server) writeJSONErrorWithHint(w http.ResponseWriter, status int, message, typ, code, hint string, retryAfter time.Duration) {
+	if hint == "" {
+		hint = defaultHintForCode(code, message)
+	}
 	h := w.Header()
 	h.Set("Content-Type", "application/json")
 	if retryAfter > 0 {
@@ -534,10 +542,31 @@ func (s *Server) writeJSONError(w http.ResponseWriter, status int, message, typ,
 	}
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(map[string]any{
-		"error": openAIError{Message: message, Type: typ, Code: code},
+		"error": openAIError{Message: message, Type: typ, Code: code, Hint: hint},
 	})
 }
 
+func defaultHintForCode(code, message string) string {
+	lowerMsg := strings.ToLower(message)
+	switch {
+	case code == "free_mode_cli_required" || strings.Contains(lowerMsg, "free_mode_cli_required"):
+		return "Upstream free tier gate requires official CLI traffic envelope. See FAQ: https://github.com/trefeon/freebuff-proxy#faq"
+	case code == "account_banned" || strings.Contains(lowerMsg, "banned"):
+		return "Account suspended upstream. Token is dead; create a fresh account with an established GitHub login."
+	case code == "upstream_auth_rejected" || code == "invalid_api_key" || strings.Contains(lowerMsg, "invalid api key"):
+		return "Token invalid or expired. Get a fresh token at https://freebuff.llm.pm or run scripts/get-freebuff-token.sh"
+	case code == "waiting_room_queued":
+		return "Upstream queue busy. Client will auto-retry after Retry-After duration."
+	case code == "rate_limited":
+		return "Daily message cap or rate limit reached. Wait for quota reset or add another token."
+	case code == "missing_bearer_token":
+		return "Bridge mode active: pass your FreeBuff token in Authorization: Bearer <token>"
+	case code == "model_not_found":
+		return "Check available models via GET /v1/models"
+	default:
+		return ""
+	}
+}
 // writeError maps any error from the pool/upstream to the PRD §6 matrix and
 // logs it once. Canceled client contexts are logged at debug and dropped (no
 // response written).

--- a/scripts/install-freebuff-proxy.ps1
+++ b/scripts/install-freebuff-proxy.ps1
@@ -188,70 +188,69 @@ if (-not (Test-Path -LiteralPath $exe) -or $Force) {
   }
 }
 
-# --- 7. .env -----------------------------------------------------------------
+# --- 7. .env - always copied from the shipped example ------------------------
+Write-Host "Step 3/3: configuration (.env)" -ForegroundColor Cyan
 $envPath = $EnvFile
 if (-not $envPath) { $envPath = Join-Path $Dir ".env" }
 if (-not $NoEnv) {
   $example = Join-Path $Dir ".env.example"
-  if (-not (Test-Path -LiteralPath $envPath)) {
+  if (-not (Test-Path -LiteralPath $envPath) -or $Force) {
     if (Test-Path -LiteralPath $example) {
-      Copy-Item -LiteralPath $example -Destination $envPath
-      Write-Host ".env created from .env.example" -ForegroundColor Green
+      Copy-Item -LiteralPath $example -Destination $envPath -Force
+      Write-Host ".env copied from .env.example" -ForegroundColor Green
     } else {
-      Set-Content -LiteralPath $envPath -Value "# freebuff-proxy config`n" -Encoding utf8
-      Write-Host ".env created (no .env.example in release; wrote a minimal file)" -ForegroundColor Green
-    }
-  } else {
-    Write-Host ".env already exists, leaving it as is" -ForegroundColor Green
-  }
-}
-
-# --- 8. token ----------------------------------------------------------------
-if (-not $SkipToken) {
-  $token = $null
-  $creds = Find-CredentialsFile
-  if ($creds) { $token = Get-AuthToken $creds }
-  if ($token -and $token.Length -gt 12) {
-    $content = Get-Content -LiteralPath $envPath -Raw
-    if ($content -match '(?m)^AUTH_TOKENS=.*$') {
-      $content = $content -replace '(?m)^AUTH_TOKENS=.*$', "AUTH_TOKENS=$token"
-    } else {
-      $content = $content.TrimEnd() + "`nAUTH_TOKENS=$token`n"
-    }
-    Set-Content -LiteralPath $envPath -Value $content -NoNewline -Encoding utf8
-    $masked = $token.Substring(0, 8) + "..." + $token.Substring($token.Length - 4)
-    Write-Host "Token found from your freebuff CLI login: $masked" -ForegroundColor Green
-    Write-Host "AUTH_TOKENS written into $envPath" -ForegroundColor Green
-  } else {
-    Write-Host "No freebuff CLI token found." -ForegroundColor Yellow
-    Write-Host "Get one from the web page, then paste it here (or press Enter to skip and set it manually):" -ForegroundColor Yellow
-    $pasted = Read-Host "Paste the login URL (https://freebuff.com/login?auth_code=...) or just the auth_code"
-    $pasted = $pasted.Trim()
-    if ($pasted) {
-      if ($pasted -match 'auth_code=([^&\s]+)') { $pasted = $Matches[1] }
-      if ($pasted.Length -gt 8) {
-        $content = Get-Content -LiteralPath $envPath -Raw
-        if ($content -match '(?m)^AUTH_TOKENS=.*$') {
-          $content = $content -replace '(?m)^AUTH_TOKENS=.*$', "AUTH_TOKENS=$pasted"
-        } else {
-          $content = $content.TrimEnd() + "`nAUTH_TOKENS=$pasted`n"
-        }
-        Set-Content -LiteralPath $envPath -Value $content -NoNewline -Encoding utf8
-        $masked = $pasted.Substring(0, 8) + "..." + $pasted.Substring($pasted.Length - 4)
-        Write-Host "AUTH_TOKENS written to $envPath ($masked)" -ForegroundColor Green
-      } else {
-        Write-Host "That does not look like a token; skipping. Set AUTH_TOKENS in $envPath manually." -ForegroundColor Yellow
+      $exampleUrl = "https://raw.githubusercontent.com/$Repo/main/.env.example"
+      try {
+        Invoke-WebRequest -Uri $exampleUrl -OutFile $envPath
+        Write-Host ".env downloaded from the documented .env.example" -ForegroundColor Green
+      } catch {
+        Set-Content -LiteralPath $envPath -Value "AUTH_TOKENS=`nLISTEN_ADDR=127.0.0.1:3457`nCOST_MODE=free`nMAX_MESSAGES_PER_DAY=0`nIDLE_ROTATION_TIMEOUT=0`n" -Encoding utf8
+        Write-Host ".env created (minimal fallback)" -ForegroundColor Yellow
       }
-    } else {
-      Write-Host "Skipped. To add the token manually:" -ForegroundColor Yellow
-      Write-Host "  1. Log in at https://freebuff.llm.pm, Freebuff Auth -> Generate login URL" -ForegroundColor Yellow
-      Write-Host "  2. Copy the URL it shows (https://freebuff.com/login?auth_code=...)" -ForegroundColor Yellow
-      Write-Host "  3. Edit $envPath and set:  AUTH_TOKENS=<the auth_code value from that link>" -ForegroundColor Yellow
-      Write-Host "  No Bearer prefix, no quotes needed." -ForegroundColor Yellow
     }
+  } else {
+    Write-Host ".env already exists; keeping it (use -Force to recreate)." -ForegroundColor Green
   }
 }
 
+function Set-EnvValue([string]$key, [string]$value) {
+  if ($NoEnv) { return }
+  $content = if (Test-Path -LiteralPath $envPath) { Get-Content -LiteralPath $envPath -Raw } else { "" }
+  if ($content -match "(?m)^$([regex]::Escape($key))=.*$") {
+    $content = $content -replace "(?m)^$([regex]::Escape($key))=.*$", "$key=$value"
+  } else {
+    $content = $content.TrimEnd() + "`n$key=$value`n"
+  }
+  Set-Content -LiteralPath $envPath -Value $content -NoNewline -Encoding utf8
+}
+
+if (-not $NoEnv) {
+  if ($SkipToken) {
+    $existing = (Get-Content -LiteralPath $envPath | Where-Object { $_ -match '^AUTH_TOKENS=' } | Select-Object -First 1) -replace '^AUTH_TOKENS=', ''
+    if ($existing -match 'cb_xxx|cb_yyy|changeme|your[-_]?token|^<') {
+      Set-EnvValue "AUTH_TOKENS" ""
+      Write-Host "Cleared the placeholder AUTH_TOKENS; empty is safer than a fake token." -ForegroundColor Yellow
+    }
+  } elseif ($token -and $token.Length -gt 12) {
+    Set-EnvValue "AUTH_TOKENS" $token
+    Write-Host "AUTH_TOKENS written into $envPath (value hidden)." -ForegroundColor Green
+  } else {
+    Write-Host "No CLI token available." -ForegroundColor Yellow
+    $pasted = Read-Host "Paste a FreeBuff login URL or auth_code (Enter to leave empty / bridge mode)"
+    $pasted = $pasted.Trim()
+    if ($pasted -match 'auth_code=([^&\s]+)') { $pasted = $Matches[1] }
+    if ($pasted.Length -gt 8) {
+      Set-EnvValue "AUTH_TOKENS" $pasted
+      Write-Host "AUTH_TOKENS written into $envPath (value hidden)." -ForegroundColor Green
+    } else {
+      Set-EnvValue "AUTH_TOKENS" ""
+      Write-Host "AUTH_TOKENS left empty. The proxy starts in bridge mode; clients must send their own token." -ForegroundColor Yellow
+    }
+  }
+  Set-EnvValue "MAX_MESSAGES_PER_DAY" "150"
+  Set-EnvValue "IDLE_ROTATION_TIMEOUT" "30m"
+  Write-Host "Safety defaults: MAX_MESSAGES_PER_DAY=150, IDLE_ROTATION_TIMEOUT=30m" -ForegroundColor Green
+}
 # --- 9. next steps -----------------------------------------------------------
 Write-Host ""
 Write-Host "Done. Next:" -ForegroundColor Cyan
@@ -267,3 +266,4 @@ Write-Host "  curl http://localhost:3457/healthz"
 Write-Host "  curl http://localhost:3457/v1/models"
 Write-Host ""
 Write-Host "See the README (in the zip) for the full guide and 9router wiring."
+


### PR DESCRIPTION
## Summary

Comprehensive beginner UX, documentation, diagnostic, and error reporting updates:

### 1. Account Health Monitoring (#6)
`/healthz` token snapshots now include `daily_limit`, `usage_pct`, and a calculated `risk_level` (`"low"`, `"moderate"`, `"high"`, `"critical"`) to warn users before hitting upstream abuse thresholds.

### 2. `freebuff-proxy -doctor` Diagnostic Tool (#15)
Self-diagnostic subcommand testing:
- Configuration validity
- Listen address availability
- Token format & placeholder detection
- DNS & TLS reachability to `www.codebuff.com:443`
- Model registry offline fallback & live refresh

### 3. Beginner Docs & How It Works (#12, #14, #18)
- `docs/guides/getting-started.md`: 5-minute zero-to-working guide for beginners
- `docs/guides/client-integration.md`: copy-paste configs for Continue, Cursor, aider, opencode, Python/Node OpenAI SDKs
- README updated with a visual Mermaid architecture diagram, glossary table, and guide links

### 4. Simplified `.env.example` (#17)
- Reduced `.env.example` to minimal ~15 lines (only `AUTH_TOKENS`, `SAFE_MODE`, `LISTEN_ADDR`)
- Created `.env.full-example` containing the complete inventory of options with documentation

### 5. Human-Readable Error Hints (#19)
OpenAI-shaped error responses now include an actionable `hint` field giving plain-language fix instructions for `free_mode_cli_required`, `account_banned`, `waiting_room_queued`, `rate_limited`, and `missing_bearer_token`.

Fixes #6, #12, #14, #15, #17, #18, #19