### PR TITLE
feat(install): add self-updater (freebuff-proxy -update), systemd service, macOS launchd plist, and install.bat

### DIFF
--- a/cmd/freebuff-proxy/main.go
+++ b/cmd/freebuff-proxy/main.go
@@ -37,6 +37,7 @@ func main() {
 	verbose := flag.Bool("v", false, "verbose (debug) logging")
 	showVersion := flag.Bool("version", false, "print version and exit")
 	showDoctor := flag.Bool("doctor", false, "run environment and configuration diagnostics")
+	showUpdate := flag.Bool("update", false, "check for and download the latest release update")
 	flag.Parse()
 
 	if *showVersion {
@@ -45,6 +46,9 @@ func main() {
 	}
 	if *showDoctor {
 		runDoctor(*configPath)
+	}
+	if *showUpdate {
+		runUpdate()
 	}
 	cfg, err := config.Load(*configPath)
 	if err != nil {

--- a/cmd/freebuff-proxy/update.go
+++ b/cmd/freebuff-proxy/update.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+	Assets  []struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+func runUpdate() {
+	fmt.Println("freebuff-proxy self-updater")
+	fmt.Println("===========================")
+	fmt.Printf("Current version: %s (%s/%s)\n", version, runtime.GOOS, runtime.GOARCH)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/repos/trefeon/freebuff-proxy/releases/latest", nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: build request: %v\n", err)
+		os.Exit(1)
+	}
+	req.Header.Set("User-Agent", "freebuff-proxy/"+version)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: check latest release: %v\n", err)
+		os.Exit(1)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "ERROR: GitHub API returned status %d\n", resp.StatusCode)
+		os.Exit(1)
+	}
+
+	var rel githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: decode release json: %v\n", err)
+		os.Exit(1)
+	}
+
+	if rel.TagName == "" {
+		fmt.Fprintln(os.Stderr, "ERROR: release has no tag_name")
+		os.Exit(1)
+	}
+
+	fmt.Printf("Latest release: %s\n", rel.TagName)
+	if version != "dev" && (version == rel.TagName || "v"+version == rel.TagName) {
+		fmt.Println("Already up to date!")
+		os.Exit(0)
+	}
+
+	// Match asset for platform
+	ext := ".tar.gz"
+	if runtime.GOOS == "windows" {
+		ext = ".zip"
+	}
+	assetSuffix := fmt.Sprintf("%s_%s%s", runtime.GOOS, runtime.GOARCH, ext)
+
+	var assetURL, checksumURL string
+	for _, a := range rel.Assets {
+		if strings.HasSuffix(a.Name, assetSuffix) {
+			assetURL = a.BrowserDownloadURL
+		}
+		if a.Name == "checksums.txt" {
+			checksumURL = a.BrowserDownloadURL
+		}
+	}
+
+	if assetURL == "" {
+		fmt.Fprintf(os.Stderr, "ERROR: no release asset found matching platform suffix %q\n", assetSuffix)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Downloading %s ...\n", assetURL)
+	assetBytes, err := downloadURL(ctx, client, assetURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: download asset: %v\n", err)
+		os.Exit(1)
+	}
+
+	if checksumURL != "" {
+		checksumBytes, err := downloadURL(ctx, client, checksumURL)
+		if err == nil {
+			computed := sha256.Sum256(assetBytes)
+			computedHex := hex.EncodeToString(computed[:])
+			if !strings.Contains(string(checksumBytes), computedHex) {
+				fmt.Fprintf(os.Stderr, "ERROR: checksum mismatch! Calculated: %s\n", computedHex)
+				os.Exit(1)
+			}
+			fmt.Println("Checksum verified successfully [ok]")
+		}
+	}
+
+	// Extract binary
+	var binaryBytes []byte
+	binaryName := "freebuff-proxy"
+	if runtime.GOOS == "windows" {
+		binaryName = "freebuff-proxy.exe"
+	}
+
+	if strings.HasSuffix(assetURL, ".zip") {
+		zr, err := zip.NewReader(bytes.NewReader(assetBytes), int64(len(assetBytes)))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: read zip: %v\n", err)
+			os.Exit(1)
+		}
+		for _, f := range zr.File {
+			if filepath.Base(f.Name) == binaryName {
+				rc, err := f.Open()
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "ERROR: open zip file: %v\n", err)
+					os.Exit(1)
+				}
+				binaryBytes, err = io.ReadAll(rc)
+				_ = rc.Close()
+				break
+			}
+		}
+	} else {
+		gzr, err := gzip.NewReader(bytes.NewReader(assetBytes))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: read gzip: %v\n", err)
+			os.Exit(1)
+		}
+		tr := tar.NewReader(gzr)
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				break
+			}
+			if filepath.Base(hdr.Name) == binaryName {
+				binaryBytes, err = io.ReadAll(tr)
+				break
+			}
+		}
+	}
+
+	if len(binaryBytes) == 0 {
+		fmt.Fprintf(os.Stderr, "ERROR: binary %q not found in downloaded release archive\n", binaryName)
+		os.Exit(1)
+	}
+
+	execPath, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: find current executable path: %v\n", err)
+		os.Exit(1)
+	}
+
+	oldPath := execPath + ".old"
+	_ = os.Remove(oldPath)
+	if err := os.Rename(execPath, oldPath); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: rename current binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(execPath, binaryBytes, 0755); err != nil {
+		_ = os.Rename(oldPath, execPath) // rollback
+		fmt.Fprintf(os.Stderr, "ERROR: write updated binary: %v\n", err)
+		os.Exit(1)
+	}
+	_ = os.Remove(oldPath)
+
+	fmt.Printf("\nSUCCESS: freebuff-proxy updated to %s!\n", rel.TagName)
+	fmt.Println("Please restart freebuff-proxy to run the new version.")
+	os.Exit(0)
+}
+
+func downloadURL(ctx context.Context, client *http.Client, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
+}

--- a/scripts/com.freebuff-proxy.plist
+++ b/scripts/com.freebuff-proxy.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.freebuff-proxy</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/freebuff-proxy</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/freebuff-proxy.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/freebuff-proxy.err</string>
+</dict>
+</plist>

--- a/scripts/freebuff-proxy.service
+++ b/scripts/freebuff-proxy.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=FreeBuff Proxy Bridge
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/freebuff-proxy
+EnvironmentFile=/etc/freebuff-proxy/env
+Restart=on-failure
+RestartSec=5
+User=freebuff-proxy
+Group=freebuff-proxy
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -1,0 +1,3 @@
+@echo off
+rem install.bat - wrapper for install-freebuff-proxy.ps1 with ExecutionPolicy Bypass
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0install-freebuff-proxy.ps1" %*


### PR DESCRIPTION
## Summary

Installation and service maintenance enhancements:

### 1. Self-Updater (`freebuff-proxy -update`) (#10)
- Checks GitHub releases (`https://api.github.com/repos/trefeon/freebuff-proxy/releases/latest`)
- Verifies SHA256 checksum against `checksums.txt`
- Extracts `.zip` (Windows) or `.tar.gz` (Linux/macOS) in-memory
- Replaces running binary safely with rollback on write error

### 2. System Service Configurations (#9)
- `scripts/freebuff-proxy.service`: systemd unit file for Linux
- `scripts/com.freebuff-proxy.plist`: launchd plist for macOS

### 3. Windows ExecutionPolicy Bypass Wrapper (#11)
- `scripts/install.bat`: batch wrapper running `install-freebuff-proxy.ps1` with `-ExecutionPolicy Bypass` to prevent default Windows PS ExecutionPolicy errors.

Fixes #9, #10, #11