### PR TITLE
feat(session): persist session state to disk for restart-resume

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,13 @@ IDLE_ROTATION_TIMEOUT=30m
 # timeout). Never retries 429/403/401. 1 = safe default; 0 disables.
 TRANSIENT_RETRIES=1
 
+# Persist upstream session state to disk so a restart resumes an unexpired
+# session instead of burning a fresh daily session slot. Opt-in: the session
+# instance id + expiry are written to SESSION_STATE_FILE (0600) keyed by a
+# SHA-256 hash of your token — the raw token is never written.
+#SESSION_PERSIST=false
+#SESSION_STATE_FILE=.freebuff-session-state.json
+
 # ── Cost safety ──────────────────────────────────────────────────────────
 # MUST stay "free": any other value routes requests as PAID and fresh free
 # accounts get 402 "Out of credits". Do not change this.

--- a/.env.full-example
+++ b/.env.full-example
@@ -40,6 +40,11 @@ HTTP_PROXY=
 # Browser TLS stealth fingerprint (auto, chrome126, firefox128, safari18, edge126)
 TLS_FINGERPRINT=auto
 
+# Persist session state across restarts (resume unexpired sessions instead of
+# burning a new daily slot). Opt-in.
+#SESSION_PERSIST=false
+#SESSION_STATE_FILE=.freebuff-session-state.json
+
 # Logging
 LOG_LEVEL=info
 # Optional log file (empty = stderr only). File paths in this file are

--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ All keys can be set via environment variables or the JSON config file passed to 
 | `CLI_VERSION` | `0.10.7` | Upstream CLI version string used in the request envelope |
 | `MODEL_ALIASES` | `""` | Map aliases to real model IDs, e.g. `gpt-4o:deepseek/deepseek-v4-flash` |
 | `TRANSIENT_RETRIES` | `1` | Max additional attempts after a transient transport failure; `0` disables |
+| `SESSION_PERSIST` | `false` | Persist session state to disk so a restart resumes an unexpired session instead of burning a new daily slot |
+| `SESSION_STATE_FILE` | `.freebuff-session-state.json` | Path of the session state file (used when `SESSION_PERSIST=true`; token-keyed, `0600`) |
 
 ### Safe Mode & Zero-Spam Quota Handling
 

--- a/cmd/freebuff-proxy/main.go
+++ b/cmd/freebuff-proxy/main.go
@@ -135,7 +135,14 @@ func main() {
 	go refreshLoop(ctx, logger, reg, cfg.RegistryRefresh)
 
 	// One upstream client and session manager per token, bound into the pool
-	// together with a per-token run manager.
+	// together with a per-token run manager. When SESSION_PERSIST is enabled
+	// one shared store backs every session manager (fixed, runtime-added, and
+	// bridge entries), so a restart resumes unexpired sessions.
+	var store *session.Store
+	if cfg.SessionPersist {
+		store = session.NewStore(cfg.SessionStateFile)
+		logger.Info("session state persistence enabled", "file", cfg.SessionStateFile)
+	}
 	clients := make([]*upstream.Client, 0, len(cfg.AuthTokens))
 	sessions := make([]*session.Manager, 0, len(cfg.AuthTokens))
 	for i, token := range cfg.AuthTokens {
@@ -146,7 +153,7 @@ func main() {
 			os.Exit(1)
 		}
 		clients = append(clients, client)
-		sessions = append(sessions, session.NewManager(client))
+		sessions = append(sessions, session.NewManagerWithStore(client, store))
 	}
 	if cfg.DiscoveredSource != "" {
 		logger.Info("auto-discovered FreeBuff token from CLI login", "email", cfg.DiscoveredEmail, "file", cfg.DiscoveredSource)
@@ -157,6 +164,7 @@ func main() {
 		holdForExitIfConsole()
 		os.Exit(1)
 	}
+	p.SetSessionStore(store)
 
 	// Prewarm + the 60s maintain loop run until ctx is canceled (shutdown).
 	p.Start(ctx)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,8 @@ type Config struct {
 	CLIVersion            string            // upstream CLI version string (default: 0.10.7)
 	ModelAliases          map[string]string // map model alias -> real model ID (#25)
 	TransientRetries      int               // max additional attempts after a transient transport failure (0 = disabled; default 1)
+	SessionPersist        bool              // true = persist session state to disk so restart resumes unexpired sessions (SESSION_PERSIST)
+	SessionStateFile      string            // path to the session state file (SESSION_STATE_FILE; default .freebuff-session-state.json)
 	DiscoveredSource      string            // auto-discovered credentials file path (if any)
 	DiscoveredEmail       string            // auto-discovered account email (if any)
 }
@@ -109,6 +111,8 @@ type rawConfig struct {
 	CLIVersion            string   `json:"CLI_VERSION"`
 	ModelAliases          string   `json:"MODEL_ALIASES"`
 	TransientRetries      *int     `json:"TRANSIENT_RETRIES"`
+	SessionPersist        bool     `json:"SESSION_PERSIST"`
+	SessionStateFile      string   `json:"SESSION_STATE_FILE"`
 }
 
 func defaultRawConfig() rawConfig {
@@ -127,6 +131,8 @@ func defaultRawConfig() rawConfig {
 		RequestJitter:       "",    // "" = disabled (unset → SAFE_MODE preset may fill)
 		CLIVersion:          "0.10.7",
 		TransientRetries:    nil, // nil = 1 (one retry after a transient transport failure; 0 disables)
+		SessionPersist:      false, // opt-in: persist session state across restarts
+		SessionStateFile:    ".freebuff-session-state.json",
 	}
 }
 
@@ -182,6 +188,8 @@ func Load(configPath string) (Config, error) {
 	overrideString(&raw.CLIVersion, "CLI_VERSION")
 	overrideString(&raw.ModelAliases, "MODEL_ALIASES")
 	overrideInt(&raw.TransientRetries, "TRANSIENT_RETRIES")
+	overrideBool(&raw.SessionPersist, "SESSION_PERSIST")
+	overrideString(&raw.SessionStateFile, "SESSION_STATE_FILE")
 
 	parseDuration := func(raw, name string) (time.Duration, error) {
 		d, err := time.ParseDuration(strings.TrimSpace(raw))
@@ -275,6 +283,8 @@ func Load(configPath string) (Config, error) {
 		CLIVersion:            strings.TrimSpace(raw.CLIVersion),
 		ModelAliases:          parseMap(raw.ModelAliases),
 		TransientRetries:      transientRetries,
+		SessionPersist:        raw.SessionPersist,
+		SessionStateFile:      strings.TrimSpace(raw.SessionStateFile),
 	}
 
 	// Auto-discover CLI token if no AUTH_TOKENS were explicitly configured
@@ -387,6 +397,8 @@ func (c Config) Validate() error {
 		return errors.New("REQUEST_JITTER cannot be negative")
 	case c.TransientRetries < 0:
 		return errors.New("TRANSIENT_RETRIES cannot be negative")
+	case c.SessionPersist && strings.TrimSpace(c.SessionStateFile) == "":
+		return errors.New("SESSION_STATE_FILE cannot be empty when SESSION_PERSIST is enabled")
 	case c.CostMode != "" && c.CostMode != "free":
 		return errors.New(`COST_MODE must be "free" or unset -- any other value (e.g. a typo) routes requests as PAID and fresh free accounts get 402 "Out of credits"`)
 	case c.ProxyRotation != "" && c.ProxyRotation != "per-token" && c.ProxyRotation != "round-robin" && c.ProxyRotation != "random":
@@ -536,6 +548,8 @@ func applyDotenv(raw *rawConfig) error {
 	overrideStringFrom(&raw.ModelAliases, get, "MODEL_ALIASES")
 	overrideIntFrom(&raw.TransientRetries, get, "TRANSIENT_RETRIES")
 	overrideStringFrom(&raw.ProxyRotation, get, "PROXY_ROTATION")
+	overrideBoolFrom(&raw.SessionPersist, get, "SESSION_PERSIST")
+	overrideStringFrom(&raw.SessionStateFile, get, "SESSION_STATE_FILE")
 	return nil
 }
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -157,6 +157,11 @@ type Pool struct {
 	bridgeMu    sync.Mutex
 	bridge      map[string]*bridgeEntry
 	bridgeOrder []string
+
+	// store persists session state across restarts (SESSION_PERSIST); nil
+	// disables. Injected by the caller (main) via SetSessionStore so there
+	// is exactly one store shared by pooled and bridge entries.
+	store *session.Store
 }
 
 type tokenEntry struct {
@@ -207,7 +212,7 @@ func (p *Pool) AddToken(token string) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("pool: add token: %w", err)
 	}
-	sess := session.NewManager(client)
+	sess := session.NewManagerWithStore(client, p.store)
 	entry := &tokenEntry{
 		session: sess,
 		runs:    runs.NewRunManager(client, sess, p.cfg.RotationInterval),
@@ -268,6 +273,14 @@ func (p *Pool) RemoveAllTokens(ctx context.Context) {
 // TokenCount returns the current fixed-token count.
 func (p *Pool) TokenCount() int {
 	return len(*p.toks.Load())
+}
+
+// SetSessionStore injects the shared session-state store used by runtime
+// token additions (AddToken) and bridge entries. Call before the pool
+// starts serving requests; the fixed-token session managers are built by the
+// caller and must use the same store instance.
+func (p *Pool) SetSessionStore(store *session.Store) {
+	p.store = store
 }
 
 // Acquire resolves the model's agent, picks a start token round-robin, and
@@ -857,8 +870,8 @@ func (p *Pool) Shutdown(ctx context.Context) {
 		if snap := entry.runs.Snapshot(); snap.ActiveRuns > 0 {
 			errs = append(errs, fmt.Sprintf("bridge %s: %d runs left after shutdown", entry.token, snap.ActiveRuns))
 		}
-		if err := entry.session.EndSession(entryCtx); err != nil {
-			errs = append(errs, fmt.Sprintf("bridge %s: end session: %v", entry.token, err))
+		if err := entry.session.Shutdown(entryCtx); err != nil {
+			errs = append(errs, fmt.Sprintf("bridge %s: shutdown session: %v", entry.token, err))
 		}
 		cancel()
 	}
@@ -1087,7 +1100,7 @@ func (p *Pool) bridgeEntryFor(clientToken string) (*bridgeEntry, error) {
 		return nil, fmt.Errorf("bridge: %w", err)
 	}
 	entry := &bridgeEntry{token: clientToken, client: client}
-	entry.session = session.NewManager(client)
+	entry.session = session.NewManagerWithStore(client, p.store)
 	entry.runs = runs.NewRunManager(client, entry.session, p.cfg.RotationInterval)
 	entry.lastUsed = time.Now()
 

--- a/internal/runs/runs.go
+++ b/internal/runs/runs.go
@@ -286,8 +286,8 @@ func (m *RunManager) Shutdown(ctx context.Context) {
 			errs = append(errs, fmt.Sprintf("finish run %s: %v", run.RunID, err))
 		}
 	}
-	if err := m.session.EndSession(ctx); err != nil {
-		errs = append(errs, fmt.Sprintf("end session: %v", err))
+	if err := m.session.Shutdown(ctx); err != nil {
+		errs = append(errs, fmt.Sprintf("shutdown session: %v", err))
 	}
 	if len(errs) > 0 {
 		slog.Warn("runs: shutdown with errors", "errors", strings.Join(errs, "; "))

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -57,6 +57,12 @@ func (e *WaitingRoomError) Error() string {
 type Manager struct {
 	client *upstream.Client
 
+	// store, when non-nil, persists the cached session state across process
+	// restarts (SESSION_PERSIST). key is the stable store key derived from
+	// the client token (upstream.Client.TokenKey).
+	store *Store
+	key   string
+
 	mu         sync.Mutex
 	state      *cachedState
 	refreshCh  chan struct{} // closed by the in-flight refresher when done
@@ -88,7 +94,26 @@ type cachedState struct {
 
 // NewManager builds a session manager for the given upstream client.
 func NewManager(client *upstream.Client) *Manager {
-	return &Manager{client: client}
+	return NewManagerWithStore(client, nil)
+}
+
+// NewManagerWithStore builds a session manager that also persists its cached
+// state through store (nil disables persistence).
+func NewManagerWithStore(client *upstream.Client, store *Store) *Manager {
+	m := &Manager{client: client, store: store}
+	if client != nil {
+		m.key = client.TokenKey()
+	}
+	return m
+}
+
+// commit replaces the cached state and mirrors it into the store (when
+// configured). Caller must hold m.mu.
+func (m *Manager) commit(cs *cachedState) {
+	m.state = cs
+	if m.store != nil && m.key != "" {
+		m.store.Save(m.key, cs)
+	}
 }
 
 // EnsureSession returns the session instance id for the default model, or ""
@@ -266,7 +291,13 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string) error {
 		if cached != nil && cached.status == "queued" && cached.instanceID != "" {
 			st, err = m.client.GetSession(ctx, cached.instanceID)
 		} else {
-			st, err = m.client.CreateSessionForModel(ctx, targetModel)
+			// Resume a persisted session (restart reuse) before creating a
+			// new one: a persisted active slot that is still alive upstream
+			// is adopted instead of burning a fresh session quota.
+			st = m.pollPersisted(ctx)
+			if st == nil {
+				st, err = m.client.CreateSessionForModel(ctx, targetModel)
+			}
 		}
 		if err != nil {
 			return err
@@ -280,7 +311,7 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string) error {
 				model = targetModel
 			}
 			m.mu.Lock()
-			m.state = &cachedState{
+			m.commit(&cachedState{
 				status:             "active",
 				instanceID:         st.InstanceID,
 				model:              model,
@@ -290,14 +321,14 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string) error {
 				countryCode:        st.CountryCode,
 				countryBlockReason: st.CountryBlockReason,
 				quotaByModel:       st.RateLimitsByModel,
-			}
+			})
 			m.mu.Unlock()
 			slog.Debug("session created", "status", "active", "instance_id", st.InstanceID,
 				"model", model, "expires_at", st.ExpiresAt.Format(time.RFC3339))
 			return nil
 		case "disabled":
 			m.mu.Lock()
-			m.state = &cachedState{status: "disabled"}
+			m.commit(&cachedState{status: "disabled"})
 			m.mu.Unlock()
 			slog.Debug("session created", "status", "disabled", "instance_id", "")
 			return nil
@@ -318,21 +349,21 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string) error {
 				model = targetModel
 			}
 			m.mu.Lock()
-			m.state = &cachedState{
+			m.commit(&cachedState{
 				status:     "queued",
 				instanceID: st.InstanceID,
 				model:      model,
 				position:   st.Position,
 				queueDepth: st.QueueDepth,
 				pollAt:     pollAt,
-			}
+			})
 			m.mu.Unlock()
 			slog.Debug("session queued", "instance_id", st.InstanceID, "model", model,
 				"position", st.Position, "queue_depth", st.QueueDepth, "poll_at", pollAt.Format(time.RFC3339))
 			return nil
 		case "ended", "superseded", "none":
 			m.mu.Lock()
-			m.state = nil
+			m.commit(nil)
 			m.mu.Unlock()
 			slog.Debug("session recreated", "reason", status, "instance_id", st.InstanceID)
 		case "banned", "country_blocked", "rate_limited", "ip_capped", "spend_limited":
@@ -345,7 +376,7 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string) error {
 			if m.state != nil {
 				oldInstance = m.state.instanceID
 			}
-			m.state = nil
+			m.commit(nil)
 			m.mu.Unlock()
 			_ = m.client.EndSession(ctx, oldInstance)
 			slog.Debug("session released on model lock, retrying", "current", st.CurrentModel, "target", targetModel)
@@ -354,7 +385,7 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string) error {
 			slog.Warn("session: model unavailable upstream, falling back to default", "requested", targetModel, "fallback", DefaultFallbackModel)
 			targetModel = DefaultFallbackModel
 			m.mu.Lock()
-			m.state = nil
+			m.commit(nil)
 			m.mu.Unlock()
 		default:
 			return fmt.Errorf("session: unknown upstream status %q", status)
@@ -442,7 +473,7 @@ func (m *Manager) Invalidate() {
 	if m.state != nil {
 		instanceID = m.state.instanceID
 	}
-	m.state = nil
+	m.commit(nil)
 	m.mu.Unlock()
 	slog.Debug("session invalidated", "instance_id", instanceID)
 }
@@ -454,7 +485,7 @@ func (m *Manager) EndSession(ctx context.Context) error {
 	if s := m.state; s != nil {
 		instanceID = s.instanceID
 	}
-	m.state = nil
+	m.commit(nil)
 	m.mu.Unlock()
 
 	if instanceID == "" {
@@ -465,6 +496,71 @@ func (m *Manager) EndSession(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+// Shutdown handles session teardown at process shutdown. When persistence is
+// disabled it behaves exactly like EndSession (DELETE upstream). When
+// persistence is enabled it leaves the upstream session alive — so a later
+// restart can resume it — and ensures the current state is flushed to the
+// store. Runs are FINISHed separately by the run manager.
+func (m *Manager) Shutdown(ctx context.Context) error {
+	if m.store == nil {
+		return m.EndSession(ctx)
+	}
+	m.mu.Lock()
+	if m.state != nil && m.state.status == "active" && m.state.instanceID != "" {
+		m.store.Save(m.key, m.state)
+	}
+	m.mu.Unlock()
+	slog.Debug("session kept for restart", "instance_id", func() string {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if m.state != nil {
+			return m.state.instanceID
+		}
+		return ""
+	}())
+	return nil
+}
+
+// pollPersisted attempts to resume a persisted session before a fresh create
+// (restart reuse). It returns a non-nil SessionState when the persisted slot
+// is still active upstream (adopted), and nil otherwise — either there is no
+// persisted slot, it is expired, or it is dead upstream (in which case it is
+// removed from the store). Transport errors are returned so the caller
+// surfaces them like a failed create.
+func (m *Manager) pollPersisted(ctx context.Context) *upstream.SessionState {
+	if m.store == nil || m.key == "" {
+		return nil
+	}
+	cs := m.store.Load(m.key)
+	if cs == nil || cs.status != "active" || cs.instanceID == "" {
+		return nil
+	}
+	// Only resume a slot that is still genuinely active (with the 5s safety
+	// margin). An expired-but-in-grace slot is draining; resume it is not
+	// worth the risk of admitting new work onto a dying session.
+	if cs.expiresAt.IsZero() || !time.Now().Before(cs.expiresAt.Add(-expiryMargin)) {
+		m.store.Remove(m.key)
+		return nil
+	}
+
+	st, err := m.client.GetSession(ctx, cs.instanceID)
+	if err != nil {
+		slog.Debug("session resume poll failed", "instance_id", cs.instanceID, "err", err)
+		return nil
+	}
+	switch st.Status {
+	case "active":
+		slog.Debug("session resumed from store", "instance_id", st.InstanceID, "expires_at", st.ExpiresAt.Format(time.RFC3339))
+		return st
+	case "ended", "superseded", "none", "banned":
+		m.store.Remove(m.key)
+		return nil
+	default:
+		// queued / country_blocked / etc. — not resumable as an active slot.
+		return nil
+	}
 }
 
 // Heartbeat sends a periodic compact GET with x-freebuff-heartbeat: 1 for active sessions,
@@ -489,7 +585,7 @@ func (m *Manager) Heartbeat(ctx context.Context) error {
 		if st.Status == "banned" {
 			m.mu.Lock()
 			if m.state != nil && m.state.instanceID == instanceID {
-				m.state = nil
+				m.commit(nil)
 				slog.Debug("session dropped during heartbeat", "reason", st.Status, "instance_id", instanceID)
 			}
 			m.mu.Unlock()
@@ -499,7 +595,7 @@ func (m *Manager) Heartbeat(ctx context.Context) error {
 	if st.Status == "ended" || st.Status == "superseded" || st.Status == "none" {
 		m.mu.Lock()
 		if m.state != nil && m.state.instanceID == instanceID {
-			m.state = nil
+			m.commit(nil)
 			slog.Debug("session ended during heartbeat", "reason", st.Status, "instance_id", instanceID)
 		}
 		m.mu.Unlock()

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -1,0 +1,180 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// storeVersion guards the on-disk format; bump it when the schema changes so
+// a stale file is ignored instead of mis-parsed.
+const storeVersion = 1
+
+// persistedState is the on-disk shape of one token's cached session. The
+// instance id + expiry are the fields that matter for restart-resume; the
+// rest are carried so a resumed session keeps its tier/country/queue view.
+type persistedState struct {
+	InstanceID         string    `json:"instance_id"`
+	Model              string    `json:"model"`
+	Status             string    `json:"status"`
+	ExpiresAt          time.Time `json:"expires_at"`
+	GracePeriodEndsAt  time.Time `json:"grace_period_ends_at"`
+	Position           int       `json:"position"`
+	QueueDepth         int       `json:"queue_depth"`
+	PollAt             time.Time `json:"poll_at"`
+	AccessTier         string    `json:"access_tier"`
+	CountryCode        string    `json:"country_code"`
+	CountryBlockReason string    `json:"country_block_reason"`
+}
+
+type storeFile struct {
+	Version  int                       `json:"version"`
+	Sessions map[string]persistedState `json:"sessions"`
+}
+
+// Store persists cached session state to a single JSON file so a proxy
+// restart can resume an unexpired upstream session instead of burning a new
+// session slot. Keys are token hashes (upstream.Client.TokenKey), never raw
+// tokens. All methods are safe for concurrent use; writes are atomic
+// (temp file + rename) and the file is created with mode 0600.
+type Store struct {
+	path string
+
+	mu     sync.Mutex
+	data   map[string]persistedState
+	loaded bool
+}
+
+// NewStore builds a store backed by path. The file is read lazily on the
+// first Load; NewStore never fails (a missing/unreadable file is treated as
+// empty and a later Save overwrites it).
+func NewStore(path string) *Store {
+	return &Store{path: path}
+}
+
+func (s *Store) loadLocked() {
+	if s.loaded {
+		return
+	}
+	s.loaded = true
+	s.data = make(map[string]persistedState)
+
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			slog.Warn("session store: read failed", "path", s.path, "err", err)
+		}
+		return
+	}
+	var file storeFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		slog.Warn("session store: parse failed, ignoring", "path", s.path, "err", err)
+		return
+	}
+	if file.Version != storeVersion {
+		slog.Warn("session store: version mismatch, ignoring", "path", s.path, "version", file.Version)
+		return
+	}
+	if file.Sessions != nil {
+		s.data = file.Sessions
+	}
+}
+
+// Load returns the persisted cached state for key, or nil when absent or
+// already expired beyond the grace window. Load never performs upstream
+// calls; it only filters obviously-dead entries.
+func (s *Store) Load(key string) *cachedState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.loadLocked()
+	ps, ok := s.data[key]
+	if !ok {
+		return nil
+	}
+	// Drop entries whose grace window is already closed: resuming them is
+	// impossible and keeping them only delays the inevitable re-create.
+	if !ps.GracePeriodEndsAt.IsZero() && time.Now().After(ps.GracePeriodEndsAt) {
+		delete(s.data, key)
+		return nil
+	}
+	return &cachedState{
+		status:             ps.Status,
+		instanceID:         ps.InstanceID,
+		model:              ps.Model,
+		expiresAt:          ps.ExpiresAt,
+		gracePeriodEndsAt:  ps.GracePeriodEndsAt,
+		position:           ps.Position,
+		queueDepth:         ps.QueueDepth,
+		pollAt:             ps.PollAt,
+		accessTier:         ps.AccessTier,
+		countryCode:        ps.CountryCode,
+		countryBlockReason: ps.CountryBlockReason,
+	}
+}
+
+// Save persists cs under key. A nil cs removes the key. Disabled sessions
+// (no instance id, no expiry) are not persisted: there is nothing to resume.
+func (s *Store) Save(key string, cs *cachedState) {
+	if key == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.loadLocked()
+
+	if cs == nil || (cs.instanceID == "" && cs.status != "queued") {
+		delete(s.data, key)
+		s.flushLocked()
+		return
+	}
+	s.data[key] = persistedState{
+		InstanceID:         cs.instanceID,
+		Model:              cs.model,
+		Status:             cs.status,
+		ExpiresAt:          cs.expiresAt,
+		GracePeriodEndsAt:  cs.gracePeriodEndsAt,
+		Position:           cs.position,
+		QueueDepth:         cs.queueDepth,
+		PollAt:             cs.pollAt,
+		AccessTier:         cs.accessTier,
+		CountryCode:        cs.countryCode,
+		CountryBlockReason: cs.countryBlockReason,
+	}
+	s.flushLocked()
+}
+
+// Remove drops key from the store (session invalidated/ended at runtime).
+func (s *Store) Remove(key string) {
+	s.Save(key, nil)
+}
+
+// flushLocked writes the current map atomically. Caller holds s.mu.
+func (s *Store) flushLocked() {
+	file := storeFile{Version: storeVersion, Sessions: s.data}
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		slog.Warn("session store: marshal failed", "path", s.path, "err", err)
+		return
+	}
+
+	dir := filepath.Dir(s.path)
+	if dir != "" {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			slog.Warn("session store: mkdir failed", "dir", dir, "err", err)
+			return
+		}
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		slog.Warn("session store: write failed", "path", s.path, "err", err)
+		return
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		slog.Warn("session store: rename failed", "path", s.path, "err", err)
+		_ = os.Remove(tmp)
+	}
+}

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -1,0 +1,214 @@
+package session
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"freebuff-proxy/internal/config"
+	"freebuff-proxy/internal/testutil"
+	"freebuff-proxy/internal/upstream"
+)
+
+func newTestManagerWithStore(t *testing.T, mock *testutil.MockUpstream, store *Store) *Manager {
+	t.Helper()
+	client, err := upstream.New("tok", &config.Config{
+		UpstreamBaseURL:    mock.URL(),
+		RequestTimeout:     15 * time.Minute,
+		SessionCallTimeout: 5 * time.Second,
+		RotationInterval:   6 * time.Hour,
+		RegistryRefresh:    6 * time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return NewManagerWithStore(client, store)
+}
+
+func TestStoreRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	store := NewStore(path)
+
+	if got := store.Load("key"); got != nil {
+		t.Fatalf("Load on empty store = %+v, want nil", got)
+	}
+
+	expiry := time.Now().Add(time.Hour).UTC().Truncate(time.Millisecond)
+	store.Save("key", &cachedState{
+		status:            "active",
+		instanceID:        "inst-1",
+		model:             "m",
+		expiresAt:         expiry,
+		gracePeriodEndsAt: expiry.Add(graceWindow),
+		accessTier:        "limited",
+		countryCode:       "US",
+	})
+
+	// A second Store instance over the same file must see the write.
+	store2 := NewStore(path)
+	got := store2.Load("key")
+	if got == nil {
+		t.Fatal("Load after Save = nil")
+	}
+	if got.instanceID != "inst-1" || got.status != "active" {
+		t.Errorf("Load = %+v, want inst-1/active", got)
+	}
+	if !got.expiresAt.Equal(expiry) {
+		t.Errorf("expiresAt = %v, want %v", got.expiresAt, expiry)
+	}
+
+	store.Remove("key")
+	if got := NewStore(path).Load("key"); got != nil {
+		t.Errorf("Load after Remove = %+v, want nil", got)
+	}
+}
+
+func TestStoreDropsExpiredGrace(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "state.json"))
+	store.Save("key", &cachedState{
+		status:            "active",
+		instanceID:        "inst-1",
+		expiresAt:         time.Now().Add(-40 * time.Minute),
+		gracePeriodEndsAt: time.Now().Add(-10 * time.Minute), // grace already closed
+	})
+	if got := store.Load("key"); got != nil {
+		t.Fatalf("Load of expired entry = %+v, want nil", got)
+	}
+}
+
+func TestShutdownKeepsSessionWhenPersist(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	store := NewStore(filepath.Join(t.TempDir(), "state.json"))
+	mgr := newTestManagerWithStore(t, mock, store)
+
+	if _, err := mgr.EnsureSession(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if mock.SessionCreates != 1 {
+		t.Fatalf("SessionCreates = %d, want 1", mock.SessionCreates)
+	}
+
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if mock.SessionEnds != 0 {
+		t.Errorf("SessionEnds = %d, want 0 (session kept alive for restart)", mock.SessionEnds)
+	}
+	if got := store.Load(mgr.key); got == nil || got.instanceID != "inst-abc-123" {
+		t.Errorf("store after Shutdown = %+v, want active inst-abc-123", got)
+	}
+}
+
+func TestShutdownEndsSessionWithoutPersist(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mgr := newTestManager(t, mock)
+
+	if _, err := mgr.EnsureSession(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if mock.SessionEnds != 1 {
+		t.Errorf("SessionEnds = %d, want 1 (no persistence → DELETE upstream)", mock.SessionEnds)
+	}
+}
+
+func TestResumePersistedOnRestart(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	path := filepath.Join(t.TempDir(), "state.json")
+
+	// First process: create a session and shut down (keeps it alive).
+	mgr1 := newTestManagerWithStore(t, mock, NewStore(path))
+	if _, err := mgr1.EnsureSession(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr1.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if mock.SessionCreates != 1 {
+		t.Fatalf("SessionCreates after first process = %d, want 1", mock.SessionCreates)
+	}
+
+	// Second process (same token → same store key): must resume, not create.
+	mgr2 := newTestManagerWithStore(t, mock, NewStore(path))
+	instance, err := mgr2.EnsureSession(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if instance != "inst-abc-123" {
+		t.Errorf("resumed instance = %q, want inst-abc-123", instance)
+	}
+	if mock.SessionCreates != 1 {
+		t.Errorf("SessionCreates after resume = %d, want still 1 (no new quota burned)", mock.SessionCreates)
+	}
+	if mock.SessionPolls != 1 {
+		t.Errorf("SessionPolls = %d, want 1 (resume poll)", mock.SessionPolls)
+	}
+}
+
+func TestResumeSkipsDeadPersistedSession(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	path := filepath.Join(t.TempDir(), "state.json")
+	store := NewStore(path)
+
+	// The upstream reports the persisted slot as ended, then serves a fresh
+	// active session for the re-create.
+	mock.SessionSequence = []string{"ended", "active"}
+
+	client, err := upstream.New("tok", &config.Config{
+		UpstreamBaseURL:    mock.URL(),
+		RequestTimeout:     15 * time.Minute,
+		SessionCallTimeout: 5 * time.Second,
+		RotationInterval:   6 * time.Hour,
+		RegistryRefresh:    6 * time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgr := NewManagerWithStore(client, store)
+	store.Save(mgr.key, &cachedState{
+		status:            "active",
+		instanceID:        "inst-dead",
+		expiresAt:         time.Now().Add(time.Hour),
+		gracePeriodEndsAt: time.Now().Add(time.Hour + graceWindow),
+	})
+
+	if _, err := mgr.EnsureSession(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// The dead slot must have been discarded and a fresh session created.
+	if mock.SessionCreates != 1 {
+		t.Errorf("SessionCreates = %d, want 1 (dead slot re-created)", mock.SessionCreates)
+	}
+	got := store.Load(mgr.key)
+	if got == nil || got.instanceID != "inst-abc-123" {
+		t.Errorf("store after re-create = %+v, want fresh active inst-abc-123", got)
+	}
+}
+
+func TestStoreFileMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	store := NewStore(path)
+	store.Save("key", &cachedState{status: "active", instanceID: "i", expiresAt: time.Now().Add(time.Hour)})
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Unix enforces 0600; Windows ignores the perm bits (only the read-only
+	// attribute is honored), so the mode assertion is Unix-only.
+	if runtime.GOOS != "windows" {
+		if perm := fi.Mode().Perm(); perm != 0o600 {
+			t.Errorf("state file mode = %o, want 600", perm)
+		}
+	}
+}

--- a/internal/upstream/client.go
+++ b/internal/upstream/client.go
@@ -13,6 +13,8 @@ import (
 	"compress/gzip"
 	"context"
 	cryptoRand "crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
@@ -330,6 +332,14 @@ type Client struct {
 	// retryBackoff overrides the randomized 200-600ms pre-retry sleep (test
 	// seam; nil uses the crypto/rand jitter).
 	retryBackoff func() time.Duration
+}
+
+// TokenKey returns a stable, non-secret key derived from the client token
+// for session-state persistence. The key is a SHA-256 hex digest of the raw
+// token, so the token itself never appears in the persisted file.
+func (c *Client) TokenKey() string {
+	sum := sha256.Sum256([]byte(c.token))
+	return hex.EncodeToString(sum[:])
 }
 
 // cliUserAgent mirrors the official CLI / SDK user agent. The upstream


### PR DESCRIPTION
## What

Adds opt-in session-state persistence so a proxy restart resumes an
unexpired upstream session instead of burning a new daily session slot.

FreeBuff's free tier enforces a daily session cap, so every restart that
creates a fresh session can silently exhaust that quota. With this change,
when `SESSION_PERSIST=true` the proxy writes its cached session state
(instance id, expiry, grace window, queue position, tier/country metadata)
to a JSON file and, on the next start, first polls the persisted slot to
see whether it is still alive upstream — only creating a new session if it
is not.

## How it works

- `internal/session/store.go` — atomic (temp-file + rename), concurrency-safe
  JSON store. Entries are keyed by a **SHA-256 hash of the token**
  (`upstream.Client.TokenKey`), so the raw token is never written to disk.
  The file is created with mode `0600`.
- `session.Manager` gains an optional store. Every cached-state transition is
  mirrored into the store. On shutdown with persistence enabled, the upstream
  session is deliberately **kept alive** (no `DELETE`) so the next process can
  resume it; runs are still FINISHed separately by the run manager.
- On session refresh, a persisted active slot is polled first; a dead slot is
  dropped and a fresh session is created (no change to quota behavior).
- The store is shared across fixed, runtime-added, and bridge token entries
  (`pool.SetSessionStore`), so all session managers read/write the same file.

## Configuration (.env)

```dotenv
# Opt-in: persist session state across restarts (resume unexpired sessions
# instead of burning a new daily slot).
SESSION_PERSIST=true

# Path of the session state file. Token-keyed, created with mode 0600.
SESSION_STATE_FILE=.freebuff-session-state.json
```

- `SESSION_PERSIST` — `true`/`false`, default `false` (opt-in; behavior is
  unchanged when unset).
- `SESSION_STATE_FILE` — file path, default `.freebuff-session-state.json`.
  Rejected (validation error) if empty while `SESSION_PERSIST=true`.

Both keys work as environment variables or in the JSON config file.

## Tests

`internal/session/store_test.go` covers: store roundtrip across instances,
expired-grace filtering, shutdown-keeps-session with persistence,
shutdown-ends-session without persistence, restart resume (no extra
`CreateSession`), dead-slot fallback, and `0600` file mode (Unix).

Full `go test ./...` passes.