### PR TITLE
feat(session): persist session state to disk for restart-resume (review-fixed, supersedes #35)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,13 @@ IDLE_ROTATION_TIMEOUT=30m
 # timeout). Never retries 429/403/401. 1 = safe default; 0 disables.
 TRANSIENT_RETRIES=1
 
+# Persist upstream session state to disk so a restart resumes an unexpired
+# session instead of burning a fresh daily session slot. Opt-in: the session
+# instance id + expiry are written to SESSION_STATE_FILE (0600) keyed by a
+# SHA-256 hash of your token — the raw token is never written.
+#SESSION_PERSIST=false
+#SESSION_STATE_FILE=.freebuff-session-state.json
+
 # ── Cost safety ──────────────────────────────────────────────────────────
 # MUST stay "free": any other value routes requests as PAID and fresh free
 # accounts get 402 "Out of credits". Do not change this.

--- a/.env.full-example
+++ b/.env.full-example
@@ -40,6 +40,11 @@ HTTP_PROXY=
 # Browser TLS stealth fingerprint (auto, chrome126, firefox128, safari18, edge126)
 TLS_FINGERPRINT=auto
 
+# Persist session state across restarts (resume unexpired sessions instead of
+# burning a new daily slot). Opt-in.
+#SESSION_PERSIST=false
+#SESSION_STATE_FILE=.freebuff-session-state.json
+
 # Logging
 LOG_LEVEL=info
 # Optional log file (empty = stderr only). File paths in this file are

--- a/README.md
+++ b/README.md
@@ -256,6 +256,12 @@ All keys can be set via environment variables or the JSON config file passed to 
 | `SESSION_PERSIST` | `false` | Persist session state to disk so a restart resumes an unexpired session instead of burning a new daily slot |
 | `SESSION_STATE_FILE` | `.freebuff-session-state.json` | Path of the session state file (used when `SESSION_PERSIST=true`; token-keyed, `0600`) |
 
+When `SESSION_PERSIST=true`, the state file stores a SHA-256 hash of each
+active token plus its session metadata (instance id, expiry, tier/country) —
+including bridge-mode client tokens, since every session manager shares the
+one store. The raw token is never written, and the file is created with mode
+`0600`. Leave `SESSION_PERSIST` unset (or `false`) to opt out entirely.
+
 ### Safe Mode & Zero-Spam Quota Handling
 
 `SAFE_MODE=true` is the **default** for all setups (set `SAFE_MODE=false` to

--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ All keys can be set via environment variables or the JSON config file passed to 
 | `CLI_VERSION` | `0.10.7` | Upstream CLI version string used in the request envelope |
 | `MODEL_ALIASES` | `""` | Map aliases to real model IDs, e.g. `gpt-4o:deepseek/deepseek-v4-flash` |
 | `TRANSIENT_RETRIES` | `1` | Max additional attempts after a transient transport failure; `0` disables |
+| `SESSION_PERSIST` | `false` | Persist session state to disk so a restart resumes an unexpired session instead of burning a new daily slot |
+| `SESSION_STATE_FILE` | `.freebuff-session-state.json` | Path of the session state file (used when `SESSION_PERSIST=true`; token-keyed, `0600`) |
 
 ### Safe Mode & Zero-Spam Quota Handling
 

--- a/cmd/freebuff-proxy/main.go
+++ b/cmd/freebuff-proxy/main.go
@@ -135,7 +135,14 @@ func main() {
 	go refreshLoop(ctx, logger, reg, cfg.RegistryRefresh)
 
 	// One upstream client and session manager per token, bound into the pool
-	// together with a per-token run manager.
+	// together with a per-token run manager. When SESSION_PERSIST is enabled
+	// one shared store backs every session manager (fixed, runtime-added, and
+	// bridge entries), so a restart resumes unexpired sessions.
+	var store *session.Store
+	if cfg.SessionPersist {
+		store = session.NewStore(cfg.SessionStateFile)
+		logger.Info("session state persistence enabled", "file", cfg.SessionStateFile)
+	}
 	clients := make([]*upstream.Client, 0, len(cfg.AuthTokens))
 	sessions := make([]*session.Manager, 0, len(cfg.AuthTokens))
 	for i, token := range cfg.AuthTokens {
@@ -146,7 +153,7 @@ func main() {
 			os.Exit(1)
 		}
 		clients = append(clients, client)
-		sessions = append(sessions, session.NewManager(client))
+		sessions = append(sessions, session.NewManagerWithStore(client, store))
 	}
 	if cfg.DiscoveredSource != "" {
 		logger.Info("auto-discovered FreeBuff token from CLI login", "email", cfg.DiscoveredEmail, "file", cfg.DiscoveredSource)
@@ -157,6 +164,7 @@ func main() {
 		holdForExitIfConsole()
 		os.Exit(1)
 	}
+	p.SetSessionStore(store)
 
 	// Prewarm + the 60s maintain loop run until ctx is canceled (shutdown).
 	p.Start(ctx)

--- a/cmd/freebuff-proxy/main.go
+++ b/cmd/freebuff-proxy/main.go
@@ -140,8 +140,34 @@ func main() {
 	// bridge entries), so a restart resumes unexpired sessions.
 	var store *session.Store
 	if cfg.SessionPersist {
-		store = session.NewStore(cfg.SessionStateFile)
-		logger.Info("session state persistence enabled", "file", cfg.SessionStateFile)
+		// Log the absolute state-file path: a relative SESSION_STATE_FILE is
+		// resolved against the working directory, which is where the file
+		// actually appears on disk.
+		stateFile := cfg.SessionStateFile
+		if abs, err := filepath.Abs(stateFile); err == nil {
+			stateFile = abs
+		}
+		store = session.NewStore(stateFile)
+		logger.Info("session state persistence enabled", "file", stateFile)
+
+		// Same cwd-vs-exe trap as .env: on Windows launchers (Task
+		// Scheduler, shortcuts, services) the working directory is often not
+		// the executable's directory, so warn when a state file next to the
+		// executable is silently ignored for the same reason.
+		if !filepath.IsAbs(cfg.SessionStateFile) {
+			if cwd, err := os.Getwd(); err == nil {
+				exe, exeErr := os.Executable()
+				if exeErr == nil {
+					exeDir := filepath.Dir(exe)
+					if filepath.Clean(cwd) != exeDir {
+						if _, statErr := os.Stat(filepath.Join(exeDir, cfg.SessionStateFile)); statErr == nil {
+							logger.Warn("found session state file next to the executable, but SESSION_STATE_FILE is read from the working directory — that file is NOT used",
+								"cwd", cwd, "exe_dir", exeDir, "state_file", stateFile)
+						}
+					}
+				}
+			}
+		}
 	}
 	clients := make([]*upstream.Client, 0, len(cfg.AuthTokens))
 	sessions := make([]*session.Manager, 0, len(cfg.AuthTokens))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,8 @@ type Config struct {
 	CLIVersion            string            // upstream CLI version string (default: 0.10.7)
 	ModelAliases          map[string]string // map model alias -> real model ID (#25)
 	TransientRetries      int               // max additional attempts after a transient transport failure (0 = disabled; default 1)
+	SessionPersist        bool              // true = persist session state to disk so restart resumes unexpired sessions (SESSION_PERSIST)
+	SessionStateFile      string            // path to the session state file (SESSION_STATE_FILE; default .freebuff-session-state.json)
 	DiscoveredSource      string            // auto-discovered credentials file path (if any)
 	DiscoveredEmail       string            // auto-discovered account email (if any)
 }
@@ -109,6 +111,8 @@ type rawConfig struct {
 	CLIVersion            string   `json:"CLI_VERSION"`
 	ModelAliases          string   `json:"MODEL_ALIASES"`
 	TransientRetries      *int     `json:"TRANSIENT_RETRIES"`
+	SessionPersist        bool     `json:"SESSION_PERSIST"`
+	SessionStateFile      string   `json:"SESSION_STATE_FILE"`
 }
 
 func defaultRawConfig() rawConfig {
@@ -127,6 +131,8 @@ func defaultRawConfig() rawConfig {
 		RequestJitter:       "",    // "" = disabled (unset → SAFE_MODE preset may fill)
 		CLIVersion:          "0.10.7",
 		TransientRetries:    nil, // nil = 1 (one retry after a transient transport failure; 0 disables)
+		SessionPersist:      false, // opt-in: persist session state across restarts
+		SessionStateFile:    ".freebuff-session-state.json",
 	}
 }
 
@@ -182,6 +188,8 @@ func Load(configPath string) (Config, error) {
 	overrideString(&raw.CLIVersion, "CLI_VERSION")
 	overrideString(&raw.ModelAliases, "MODEL_ALIASES")
 	overrideInt(&raw.TransientRetries, "TRANSIENT_RETRIES")
+	overrideBool(&raw.SessionPersist, "SESSION_PERSIST")
+	overrideString(&raw.SessionStateFile, "SESSION_STATE_FILE")
 
 	parseDuration := func(raw, name string) (time.Duration, error) {
 		d, err := time.ParseDuration(strings.TrimSpace(raw))
@@ -275,6 +283,8 @@ func Load(configPath string) (Config, error) {
 		CLIVersion:            strings.TrimSpace(raw.CLIVersion),
 		ModelAliases:          parseMap(raw.ModelAliases),
 		TransientRetries:      transientRetries,
+		SessionPersist:        raw.SessionPersist,
+		SessionStateFile:      strings.TrimSpace(raw.SessionStateFile),
 	}
 
 	// Auto-discover CLI token if no AUTH_TOKENS were explicitly configured
@@ -387,6 +397,8 @@ func (c Config) Validate() error {
 		return errors.New("REQUEST_JITTER cannot be negative")
 	case c.TransientRetries < 0:
 		return errors.New("TRANSIENT_RETRIES cannot be negative")
+	case c.SessionPersist && strings.TrimSpace(c.SessionStateFile) == "":
+		return errors.New("SESSION_STATE_FILE cannot be empty when SESSION_PERSIST is enabled")
 	case c.CostMode != "" && c.CostMode != "free":
 		return errors.New(`COST_MODE must be "free" or unset -- any other value (e.g. a typo) routes requests as PAID and fresh free accounts get 402 "Out of credits"`)
 	case c.ProxyRotation != "" && c.ProxyRotation != "per-token" && c.ProxyRotation != "round-robin" && c.ProxyRotation != "random":
@@ -536,6 +548,8 @@ func applyDotenv(raw *rawConfig) error {
 	overrideStringFrom(&raw.ModelAliases, get, "MODEL_ALIASES")
 	overrideIntFrom(&raw.TransientRetries, get, "TRANSIENT_RETRIES")
 	overrideStringFrom(&raw.ProxyRotation, get, "PROXY_ROTATION")
+	overrideBoolFrom(&raw.SessionPersist, get, "SESSION_PERSIST")
+	overrideStringFrom(&raw.SessionStateFile, get, "SESSION_STATE_FILE")
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -95,6 +95,43 @@ func TestDefaults(t *testing.T) {
 	if cfg.CostMode != "free" {
 		t.Errorf("CostMode = %q, want free (default: omission routes requests as paid -> 402)", cfg.CostMode)
 	}
+	if cfg.SessionPersist {
+		t.Error("SessionPersist = true, want false (default: persistence opt-in)")
+	}
+	if cfg.SessionStateFile != ".freebuff-session-state.json" {
+		t.Errorf("SessionStateFile = %q, want %q", cfg.SessionStateFile, ".freebuff-session-state.json")
+	}
+}
+
+// TestSessionPersist pins the SESSION_PERSIST env parsing: an unrecognized
+// boolean value is silently ignored (the default stays false — no error),
+// and "true" enables persistence with the configured state file path. The
+// SESSION_PERSIST=true + empty SESSION_STATE_FILE validation error is only
+// reachable through the JSON/struct path (an env value of "" is treated as
+// unset and leaves the default), so it is pinned in TestValidate.
+func TestSessionPersist(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("AUTH_TOKENS", "tok-1")
+
+	// garbage value is silently ignored, default (false) stands
+	t.Setenv("SESSION_PERSIST", "garbage")
+	if cfg, err := Load(""); err != nil {
+		t.Fatalf("Load (garbage): %v", err)
+	} else if cfg.SessionPersist {
+		t.Error("SessionPersist = true for SESSION_PERSIST=garbage, want false (unrecognized value ignored)")
+	}
+	t.Setenv("SESSION_PERSIST", "")
+
+	// recognized true value enables persistence and honors the state file
+	t.Setenv("SESSION_PERSIST", "true")
+	t.Setenv("SESSION_STATE_FILE", "custom-state.json")
+	if cfg, err := Load(""); err != nil {
+		t.Fatalf("Load (true): %v", err)
+	} else if !cfg.SessionPersist {
+		t.Error("SessionPersist = false for SESSION_PERSIST=true, want true")
+	} else if cfg.SessionStateFile != "custom-state.json" {
+		t.Errorf("SessionStateFile = %q, want %q", cfg.SessionStateFile, "custom-state.json")
+	}
 }
 
 func TestTransientRetries(t *testing.T) {
@@ -529,6 +566,7 @@ func TestValidate(t *testing.T) {
 		{"bad cost mode", func(c *Config) { c.CostMode = "Free" }},
 		{"bad proxy rotation", func(c *Config) { c.ProxyRotation = "round robin" }},
 		{"negative max messages", func(c *Config) { c.MaxMessagesPerDay = -1 }},
+		{"session persist with empty state file", func(c *Config) { c.SessionPersist = true; c.SessionStateFile = "" }},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -165,6 +165,14 @@ type Pool struct {
 	// disables. Injected by the caller (main) via SetSessionStore so there
 	// is exactly one store shared by pooled and bridge entries.
 	store *session.Store
+
+	// storeSessionPersist and storeStateFile record the persistence config
+	// the store was created with (captured by SetSessionStore), so SetConfig
+	// can detect a reload that changes the persistence semantics — the live
+	// store cannot be swapped at runtime, so such a change only takes
+	// effect on the next restart.
+	storeSessionPersist bool
+	storeStateFile      string
 }
 
 type tokenEntry struct {
@@ -210,6 +218,21 @@ func New(cfg *config.Config, clients []*upstream.Client, sessions []*session.Man
 // Acquire/maintain pass without rebuilding the pool.
 func (p *Pool) SetConfig(cfg *config.Config) {
 	p.cfg.Store(cfg)
+
+	// Session persistence is decided at startup: the store is built from the
+	// boot config and injected once via SetSessionStore, so a reload cannot
+	// move the live store. Warn when the reloaded config changes the
+	// persistence semantics — otherwise operators get a silent no-op (the
+	// dashboard save / admin reload funnels through here).
+	persistChanged := cfg.SessionPersist != p.storeSessionPersist ||
+		(cfg.SessionPersist && cfg.SessionStateFile != p.storeStateFile)
+	if persistChanged {
+		p.logger.Warn("SESSION_PERSIST/SESSION_STATE_FILE changed via reload; takes effect on the next restart",
+			"old_session_persist", p.storeSessionPersist,
+			"new_session_persist", cfg.SessionPersist,
+			"old_state_file", p.storeStateFile,
+			"new_state_file", cfg.SessionStateFile)
+	}
 }
 
 // AddToken adds a token to the pool at runtime (dashboard action): builds
@@ -289,9 +312,20 @@ func (p *Pool) TokenCount() int {
 // SetSessionStore injects the shared session-state store used by runtime
 // token additions (AddToken) and bridge entries. Call before the pool
 // starts serving requests; the fixed-token session managers are built by the
-// caller and must use the same store instance.
+// caller and must use the same store instance. A nil store disables
+// persistence. The persistence config is captured here so SetConfig can warn
+// when a later reload tries to change it (that only takes effect on the next
+// restart, when the caller builds a fresh store).
 func (p *Pool) SetSessionStore(store *session.Store) {
 	p.store = store
+	if store == nil {
+		p.storeSessionPersist = false
+		p.storeStateFile = ""
+		return
+	}
+	cfg := p.cfg.Load()
+	p.storeSessionPersist = cfg.SessionPersist
+	p.storeStateFile = cfg.SessionStateFile
 }
 
 // Acquire resolves the model's agent, picks a start token round-robin, and

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -160,6 +160,11 @@ type Pool struct {
 	bridgeMu    sync.Mutex
 	bridge      map[string]*bridgeEntry
 	bridgeOrder []string
+
+	// store persists session state across restarts (SESSION_PERSIST); nil
+	// disables. Injected by the caller (main) via SetSessionStore so there
+	// is exactly one store shared by pooled and bridge entries.
+	store *session.Store
 }
 
 type tokenEntry struct {
@@ -218,7 +223,7 @@ func (p *Pool) AddToken(token string) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("pool: add token: %w", err)
 	}
-	sess := session.NewManager(client)
+	sess := session.NewManagerWithStore(client, p.store)
 	entry := &tokenEntry{
 		session: sess,
 		runs:    runs.NewRunManager(client, sess, p.cfg.Load().RotationInterval),
@@ -279,6 +284,14 @@ func (p *Pool) RemoveAllTokens(ctx context.Context) {
 // TokenCount returns the current fixed-token count.
 func (p *Pool) TokenCount() int {
 	return len(*p.toks.Load())
+}
+
+// SetSessionStore injects the shared session-state store used by runtime
+// token additions (AddToken) and bridge entries. Call before the pool
+// starts serving requests; the fixed-token session managers are built by the
+// caller and must use the same store instance.
+func (p *Pool) SetSessionStore(store *session.Store) {
+	p.store = store
 }
 
 // Acquire resolves the model's agent, picks a start token round-robin, and
@@ -871,8 +884,8 @@ func (p *Pool) Shutdown(ctx context.Context) {
 		if snap := entry.runs.Snapshot(); snap.ActiveRuns > 0 {
 			errs = append(errs, fmt.Sprintf("bridge %s: %d runs left after shutdown", entry.token, snap.ActiveRuns))
 		}
-		if err := entry.session.EndSession(entryCtx); err != nil {
-			errs = append(errs, fmt.Sprintf("bridge %s: end session: %v", entry.token, err))
+		if err := entry.session.Shutdown(entryCtx); err != nil {
+			errs = append(errs, fmt.Sprintf("bridge %s: shutdown session: %v", entry.token, err))
 		}
 		cancel()
 	}
@@ -1101,7 +1114,7 @@ func (p *Pool) bridgeEntryFor(clientToken string) (*bridgeEntry, error) {
 		return nil, fmt.Errorf("bridge: %w", err)
 	}
 	entry := &bridgeEntry{token: clientToken, client: client}
-	entry.session = session.NewManager(client)
+	entry.session = session.NewManagerWithStore(client, p.store)
 	entry.runs = runs.NewRunManager(client, entry.session, p.cfg.Load().RotationInterval)
 	entry.lastUsed = time.Now()
 

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -1,11 +1,14 @@
 package pool
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -949,6 +952,74 @@ func TestSetConfigReloadsDailyLimit(t *testing.T) {
 	}
 	if rle.Limit != 1 {
 		t.Errorf("quota limit = %v, want 1 (reloaded config)", rle.Limit)
+	}
+}
+
+// TestSetConfigWarnsOnPersistenceChange pins the reload warning: session
+// persistence is fixed at startup (the store is built from the boot config
+// and injected via SetSessionStore), so a reloaded config that changes
+// SESSION_PERSIST / SESSION_STATE_FILE must warn that it only takes effect
+// on the next restart instead of silently doing nothing.
+func TestSetConfigWarnsOnPersistenceChange(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+
+	var buf bytes.Buffer
+	testLogger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	p := newTestPoolCfg(t, func(c *config.Config) {
+		c.SessionPersist = true
+		c.SessionStateFile = ".freebuff-session-state.json"
+	}, mock)
+	p.logger = testLogger // internal test: capture the pool's logger
+	p.SetSessionStore(session.NewStore(filepath.Join(t.TempDir(), "state.json")))
+
+	// Same persistence config on reload → no warning.
+	buf.Reset()
+	same := *p.cfg.Load()
+	p.SetConfig(&same)
+	if got := buf.String(); got != "" {
+		t.Fatalf("SetConfig with unchanged persistence logged: %q, want none", got)
+	}
+
+	// Persistence disabled → warn.
+	buf.Reset()
+	disabled := *p.cfg.Load()
+	disabled.SessionPersist = false
+	p.SetConfig(&disabled)
+	if got := buf.String(); !strings.Contains(got, "SESSION_PERSIST") {
+		t.Fatalf("SetConfig disabling persistence logged %q, want SESSION_PERSIST warning", got)
+	}
+
+	// Same persistence, different state file → warn.
+	buf.Reset()
+	moved := *p.cfg.Load()
+	moved.SessionPersist = true
+	moved.SessionStateFile = "elsewhere.json"
+	p.SetConfig(&moved)
+	if got := buf.String(); !strings.Contains(got, "SESSION_PERSIST") || !strings.Contains(got, "elsewhere.json") {
+		t.Fatalf("SetConfig moving the state file logged %q, want SESSION_PERSIST warning with new path", got)
+	}
+}
+
+// TestSetConfigWarnsWhenPersistenceTurnedOn covers the pre-injection state
+// (SetSessionStore never called, store nil): a reload that turns
+// SESSION_PERSIST on cannot build the store at runtime, so it must warn.
+func TestSetConfigWarnsWhenPersistenceTurnedOn(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+
+	var buf bytes.Buffer
+	p := newTestPool(t, mock)
+	p.logger = slog.New(slog.NewTextHandler(&buf, nil))
+	// SetSessionStore never called: recorded persistence is off.
+
+	enabled := *p.cfg.Load()
+	enabled.SessionPersist = true
+	enabled.SessionStateFile = ".freebuff-session-state.json"
+	p.SetConfig(&enabled)
+	if got := buf.String(); !strings.Contains(got, "SESSION_PERSIST") {
+		t.Fatalf("SetConfig enabling persistence logged %q, want SESSION_PERSIST warning", got)
 	}
 }
 

--- a/internal/runs/runs.go
+++ b/internal/runs/runs.go
@@ -286,8 +286,8 @@ func (m *RunManager) Shutdown(ctx context.Context) {
 			errs = append(errs, fmt.Sprintf("finish run %s: %v", run.RunID, err))
 		}
 	}
-	if err := m.session.EndSession(ctx); err != nil {
-		errs = append(errs, fmt.Sprintf("end session: %v", err))
+	if err := m.session.Shutdown(ctx); err != nil {
+		errs = append(errs, fmt.Sprintf("shutdown session: %v", err))
 	}
 	if len(errs) > 0 {
 		slog.Warn("runs: shutdown with errors", "errors", strings.Join(errs, "; "))

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -109,10 +109,23 @@ func NewManagerWithStore(client *upstream.Client, store *Store) *Manager {
 
 // commit replaces the cached state and mirrors it into the store (when
 // configured). Caller must hold m.mu.
+//
+// A nil cs removes the store entry conditionally on the instance id being
+// dropped: the entry is only deleted while it still belongs to the session
+// being invalidated, so a stale commit cannot clobber a persisted slot that
+// was replaced concurrently (e.g. a restart re-adopting a different one).
 func (m *Manager) commit(cs *cachedState) {
+	oldInstance := ""
+	if m.state != nil {
+		oldInstance = m.state.instanceID
+	}
 	m.state = cs
 	if m.store != nil && m.key != "" {
-		m.store.Save(m.key, cs)
+		if cs == nil {
+			m.store.Remove(m.key, oldInstance)
+		} else {
+			m.store.Save(m.key, cs)
+		}
 	}
 }
 
@@ -290,14 +303,21 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string) error {
 		)
 		if cached != nil && cached.status == "queued" && cached.instanceID != "" {
 			st, err = m.client.GetSession(ctx, cached.instanceID)
-		} else {
-			// Resume a persisted session (restart reuse) before creating a
-			// new one: a persisted active slot that is still alive upstream
-			// is adopted instead of burning a fresh session quota.
-			st = m.pollPersisted(ctx)
-			if st == nil {
+		} else if cached == nil {
+			// Fresh manager (first call or restart): resume a persisted
+			// session before creating a new one. A persisted active slot
+			// that is still alive upstream (and model-compatible) is adopted
+			// instead of burning a fresh session quota.
+			st, err = m.pollPersisted(ctx, targetModel)
+			if st == nil && err == nil {
 				st, err = m.client.CreateSessionForModel(ctx, targetModel)
 			}
+		} else {
+			// Live refresh (expired cache or model mismatch): never consult
+			// the store. Re-adopting a persisted slot here would pin the
+			// previous model's session on every refresh; always create for
+			// the requested model (baseline behavior).
+			st, err = m.client.CreateSessionForModel(ctx, targetModel)
 		}
 		if err != nil {
 			return err
@@ -500,66 +520,106 @@ func (m *Manager) EndSession(ctx context.Context) error {
 
 // Shutdown handles session teardown at process shutdown. When persistence is
 // disabled it behaves exactly like EndSession (DELETE upstream). When
-// persistence is enabled it leaves the upstream session alive — so a later
-// restart can resume it — and ensures the current state is flushed to the
-// store. Runs are FINISHed separately by the run manager.
+// persistence is enabled, only a genuinely active + unexpired session is kept
+// alive — so a later restart can resume it — and its state is flushed to the
+// store. Every other state (nil, queued, disabled, expired-active, ended)
+// falls through to the normal EndSession path, which releases the upstream
+// slot and removes the store entry via the CAS commit. Runs are FINISHed
+// separately by the run manager.
 func (m *Manager) Shutdown(ctx context.Context) error {
 	if m.store == nil {
 		return m.EndSession(ctx)
 	}
 	m.mu.Lock()
-	if m.state != nil && m.state.status == "active" && m.state.instanceID != "" {
-		m.store.Save(m.key, m.state)
+	keepAlive := false
+	instanceID := ""
+	if s := m.state; s != nil && s.status == "active" && s.instanceID != "" &&
+		time.Now().Before(s.expiresAt.Add(-expiryMargin)) {
+		keepAlive = true
+		instanceID = s.instanceID
+		m.store.Save(m.key, s)
+		// Surface a failed flush: without the persisted entry a restart
+		// cannot resume the slot, so a write/rename failure must not be
+		// silent. Re-read the FILE through a fresh Store — the in-memory
+		// map is updated before the flush attempt and cannot verify disk.
+		if persisted := NewStore(m.store.path).Load(m.key); persisted == nil || persisted.instanceID != instanceID {
+			slog.Warn("session: keep-alive persist failed", "instance_id", instanceID)
+		}
 	}
 	m.mu.Unlock()
-	slog.Debug("session kept for restart", "instance_id", func() string {
-		m.mu.Lock()
-		defer m.mu.Unlock()
-		if m.state != nil {
-			return m.state.instanceID
-		}
-		return ""
-	}())
-	return nil
+	if keepAlive {
+		slog.Debug("session kept for restart", "instance_id", instanceID)
+		return nil
+	}
+	return m.EndSession(ctx)
 }
 
 // pollPersisted attempts to resume a persisted session before a fresh create
-// (restart reuse). It returns a non-nil SessionState when the persisted slot
-// is still active upstream (adopted), and nil otherwise — either there is no
-// persisted slot, it is expired, or it is dead upstream (in which case it is
-// removed from the store). Transport errors are returned so the caller
-// surfaces them like a failed create.
-func (m *Manager) pollPersisted(ctx context.Context) *upstream.SessionState {
+// (restart reuse). requestedModel is the model the caller is about to create
+// for: a persisted slot bound to a different model is dropped instead of
+// adopted, so a model-mismatch refresh falls through to a create for the
+// requested model.
+//
+// It returns a non-nil SessionState when the persisted slot is still active
+// upstream and model-compatible (adopted), and (nil, nil) otherwise — either
+// there is no persisted slot, it is expired, it is model-incompatible, or it
+// is dead upstream (in which case it is removed from the store). Transport
+// errors are returned so the caller surfaces them like a failed create
+// instead of burning a fresh daily session slot on a merely-flaky upstream.
+func (m *Manager) pollPersisted(ctx context.Context, requestedModel string) (*upstream.SessionState, error) {
 	if m.store == nil || m.key == "" {
-		return nil
+		return nil, nil
 	}
 	cs := m.store.Load(m.key)
 	if cs == nil || cs.status != "active" || cs.instanceID == "" {
-		return nil
+		return nil, nil
 	}
 	// Only resume a slot that is still genuinely active (with the 5s safety
 	// margin). An expired-but-in-grace slot is draining; resume it is not
 	// worth the risk of admitting new work onto a dying session.
 	if cs.expiresAt.IsZero() || !time.Now().Before(cs.expiresAt.Add(-expiryMargin)) {
-		m.store.Remove(m.key)
-		return nil
+		m.store.Remove(m.key, cs.instanceID)
+		return nil, nil
+	}
+	// Model gate (pre-flight): a persisted slot known to be bound to a
+	// different model must never be re-adopted for another model — that
+	// would pin the old model's session forever on every refresh.
+	if cs.model != "" && requestedModel != "" && cs.model != requestedModel {
+		m.store.Remove(m.key, cs.instanceID)
+		return nil, nil
 	}
 
 	st, err := m.client.GetSession(ctx, cs.instanceID)
 	if err != nil {
-		slog.Debug("session resume poll failed", "instance_id", cs.instanceID, "err", err)
-		return nil
+		// Transport error: surface it instead of swallowing and falling
+		// through to a fresh create. The caller retries (single-flight /
+		// TRANSIENT_RETRIES); a create here would burn a session slot.
+		return nil, err
 	}
 	switch st.Status {
 	case "active":
+		// Model gate (post-flight): the upstream may have bound the resumed
+		// slot to a different model than requested. Adopt only when the
+		// resumed model is compatible; otherwise drop the slot and fall
+		// through to a create for the requested model.
+		if st.Model != "" && requestedModel != "" && st.Model != requestedModel {
+			m.store.Remove(m.key, st.InstanceID)
+			return nil, nil
+		}
 		slog.Debug("session resumed from store", "instance_id", st.InstanceID, "expires_at", st.ExpiresAt.Format(time.RFC3339))
-		return st
+		return st, nil
 	case "ended", "superseded", "none", "banned":
-		m.store.Remove(m.key)
-		return nil
+		m.store.Remove(m.key, st.InstanceID)
+		return nil, nil
+	case "country_blocked", "rate_limited", "ip_capped", "spend_limited":
+		// Terminal admission refusals: the persisted slot is dead upstream;
+		// drop it so a restart re-admits from scratch instead of re-polling.
+		m.store.Remove(m.key, st.InstanceID)
+		return nil, nil
 	default:
-		// queued / country_blocked / etc. — not resumable as an active slot.
-		return nil
+		// queued or an unknown status: not resumable as an active slot, but
+		// non-terminal — keep the entry for a later restart.
+		return nil, nil
 	}
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -57,6 +57,12 @@ func (e *WaitingRoomError) Error() string {
 type Manager struct {
 	client *upstream.Client
 
+	// store, when non-nil, persists the cached session state across process
+	// restarts (SESSION_PERSIST). key is the stable store key derived from
+	// the client token (upstream.Client.TokenKey).
+	store *Store
+	key   string
+
 	mu         sync.Mutex
 	state      *cachedState
 	refreshCh  chan struct{} // closed by the in-flight refresher when done
@@ -88,7 +94,26 @@ type cachedState struct {
 
 // NewManager builds a session manager for the given upstream client.
 func NewManager(client *upstream.Client) *Manager {
-	return &Manager{client: client}
+	return NewManagerWithStore(client, nil)
+}
+
+// NewManagerWithStore builds a session manager that also persists its cached
+// state through store (nil disables persistence).
+func NewManagerWithStore(client *upstream.Client, store *Store) *Manager {
+	m := &Manager{client: client, store: store}
+	if client != nil {
+		m.key = client.TokenKey()
+	}
+	return m
+}
+
+// commit replaces the cached state and mirrors it into the store (when
+// configured). Caller must hold m.mu.
+func (m *Manager) commit(cs *cachedState) {
+	m.state = cs
+	if m.store != nil && m.key != "" {
+		m.store.Save(m.key, cs)
+	}
 }
 
 // EnsureSession returns the session instance id for the default model, or ""
@@ -266,7 +291,13 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string) error {
 		if cached != nil && cached.status == "queued" && cached.instanceID != "" {
 			st, err = m.client.GetSession(ctx, cached.instanceID)
 		} else {
-			st, err = m.client.CreateSessionForModel(ctx, targetModel)
+			// Resume a persisted session (restart reuse) before creating a
+			// new one: a persisted active slot that is still alive upstream
+			// is adopted instead of burning a fresh session quota.
+			st = m.pollPersisted(ctx)
+			if st == nil {
+				st, err = m.client.CreateSessionForModel(ctx, targetModel)
+			}
 		}
 		if err != nil {
 			return err
@@ -280,7 +311,7 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string) error {
 				model = targetModel
 			}
 			m.mu.Lock()
-			m.state = &cachedState{
+			m.commit(&cachedState{
 				status:             "active",
 				instanceID:         st.InstanceID,
 				model:              model,
@@ -290,14 +321,14 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string) error {
 				countryCode:        st.CountryCode,
 				countryBlockReason: st.CountryBlockReason,
 				quotaByModel:       st.RateLimitsByModel,
-			}
+			})
 			m.mu.Unlock()
 			slog.Debug("session created", "status", "active", "instance_id", st.InstanceID,
 				"model", model, "expires_at", st.ExpiresAt.Format(time.RFC3339))
 			return nil
 		case "disabled":
 			m.mu.Lock()
-			m.state = &cachedState{status: "disabled"}
+			m.commit(&cachedState{status: "disabled"})
 			m.mu.Unlock()
 			slog.Debug("session created", "status", "disabled", "instance_id", "")
 			return nil
@@ -318,21 +349,21 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string) error {
 				model = targetModel
 			}
 			m.mu.Lock()
-			m.state = &cachedState{
+			m.commit(&cachedState{
 				status:     "queued",
 				instanceID: st.InstanceID,
 				model:      model,
 				position:   st.Position,
 				queueDepth: st.QueueDepth,
 				pollAt:     pollAt,
-			}
+			})
 			m.mu.Unlock()
 			slog.Debug("session queued", "instance_id", st.InstanceID, "model", model,
 				"position", st.Position, "queue_depth", st.QueueDepth, "poll_at", pollAt.Format(time.RFC3339))
 			return nil
 		case "ended", "superseded", "none":
 			m.mu.Lock()
-			m.state = nil
+			m.commit(nil)
 			m.mu.Unlock()
 			slog.Debug("session recreated", "reason", status, "instance_id", st.InstanceID)
 		case "banned", "country_blocked", "rate_limited", "ip_capped", "spend_limited":
@@ -345,7 +376,7 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string) error {
 			if m.state != nil {
 				oldInstance = m.state.instanceID
 			}
-			m.state = nil
+			m.commit(nil)
 			m.mu.Unlock()
 			_ = m.client.EndSession(ctx, oldInstance)
 			slog.Debug("session released on model lock, retrying", "current", st.CurrentModel, "target", targetModel)
@@ -354,7 +385,7 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string) error {
 			slog.Warn("session: model unavailable upstream, falling back to default", "requested", targetModel, "fallback", DefaultFallbackModel)
 			targetModel = DefaultFallbackModel
 			m.mu.Lock()
-			m.state = nil
+			m.commit(nil)
 			m.mu.Unlock()
 		default:
 			return fmt.Errorf("session: unknown upstream status %q", status)
@@ -442,7 +473,7 @@ func (m *Manager) Invalidate() {
 	if m.state != nil {
 		instanceID = m.state.instanceID
 	}
-	m.state = nil
+	m.commit(nil)
 	m.mu.Unlock()
 	slog.Debug("session invalidated", "instance_id", instanceID)
 }
@@ -454,7 +485,7 @@ func (m *Manager) EndSession(ctx context.Context) error {
 	if s := m.state; s != nil {
 		instanceID = s.instanceID
 	}
-	m.state = nil
+	m.commit(nil)
 	m.mu.Unlock()
 
 	if instanceID == "" {
@@ -465,6 +496,71 @@ func (m *Manager) EndSession(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+// Shutdown handles session teardown at process shutdown. When persistence is
+// disabled it behaves exactly like EndSession (DELETE upstream). When
+// persistence is enabled it leaves the upstream session alive — so a later
+// restart can resume it — and ensures the current state is flushed to the
+// store. Runs are FINISHed separately by the run manager.
+func (m *Manager) Shutdown(ctx context.Context) error {
+	if m.store == nil {
+		return m.EndSession(ctx)
+	}
+	m.mu.Lock()
+	if m.state != nil && m.state.status == "active" && m.state.instanceID != "" {
+		m.store.Save(m.key, m.state)
+	}
+	m.mu.Unlock()
+	slog.Debug("session kept for restart", "instance_id", func() string {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if m.state != nil {
+			return m.state.instanceID
+		}
+		return ""
+	}())
+	return nil
+}
+
+// pollPersisted attempts to resume a persisted session before a fresh create
+// (restart reuse). It returns a non-nil SessionState when the persisted slot
+// is still active upstream (adopted), and nil otherwise — either there is no
+// persisted slot, it is expired, or it is dead upstream (in which case it is
+// removed from the store). Transport errors are returned so the caller
+// surfaces them like a failed create.
+func (m *Manager) pollPersisted(ctx context.Context) *upstream.SessionState {
+	if m.store == nil || m.key == "" {
+		return nil
+	}
+	cs := m.store.Load(m.key)
+	if cs == nil || cs.status != "active" || cs.instanceID == "" {
+		return nil
+	}
+	// Only resume a slot that is still genuinely active (with the 5s safety
+	// margin). An expired-but-in-grace slot is draining; resume it is not
+	// worth the risk of admitting new work onto a dying session.
+	if cs.expiresAt.IsZero() || !time.Now().Before(cs.expiresAt.Add(-expiryMargin)) {
+		m.store.Remove(m.key)
+		return nil
+	}
+
+	st, err := m.client.GetSession(ctx, cs.instanceID)
+	if err != nil {
+		slog.Debug("session resume poll failed", "instance_id", cs.instanceID, "err", err)
+		return nil
+	}
+	switch st.Status {
+	case "active":
+		slog.Debug("session resumed from store", "instance_id", st.InstanceID, "expires_at", st.ExpiresAt.Format(time.RFC3339))
+		return st
+	case "ended", "superseded", "none", "banned":
+		m.store.Remove(m.key)
+		return nil
+	default:
+		// queued / country_blocked / etc. — not resumable as an active slot.
+		return nil
+	}
 }
 
 // Heartbeat sends a periodic compact GET with x-freebuff-heartbeat: 1 for active sessions,
@@ -489,7 +585,7 @@ func (m *Manager) Heartbeat(ctx context.Context) error {
 		if st.Status == "banned" {
 			m.mu.Lock()
 			if m.state != nil && m.state.instanceID == instanceID {
-				m.state = nil
+				m.commit(nil)
 				slog.Debug("session dropped during heartbeat", "reason", st.Status, "instance_id", instanceID)
 			}
 			m.mu.Unlock()
@@ -499,7 +595,7 @@ func (m *Manager) Heartbeat(ctx context.Context) error {
 	if st.Status == "ended" || st.Status == "superseded" || st.Status == "none" {
 		m.mu.Lock()
 		if m.state != nil && m.state.instanceID == instanceID {
-			m.state = nil
+			m.commit(nil)
 			slog.Debug("session ended during heartbeat", "reason", st.Status, "instance_id", instanceID)
 		}
 		m.mu.Unlock()

--- a/internal/session/session_persist_test.go
+++ b/internal/session/session_persist_test.go
@@ -1,0 +1,423 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"freebuff-proxy/internal/config"
+	"freebuff-proxy/internal/testutil"
+	"freebuff-proxy/internal/upstream"
+)
+
+// newPersistTestManager builds a manager wired to a store, like
+// newTestManagerWithStore (store_test.go), but returns the store key too so
+// tests can seed/assert the persisted slot. The key is the SHA-256 hash of
+// the token ("tok"), derived the same way the manager derives it.
+func newPersistTestManager(t *testing.T, mock *testutil.MockUpstream, store *Store) (*Manager, string) {
+	t.Helper()
+	client, err := upstream.New("tok", &config.Config{
+		UpstreamBaseURL:    mock.URL(),
+		RequestTimeout:     15 * time.Minute,
+		SessionCallTimeout: 5 * time.Second,
+		RotationInterval:   6 * time.Hour,
+		RegistryRefresh:    6 * time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgr := NewManagerWithStore(client, store)
+	return mgr, client.TokenKey()
+}
+
+// activeSlot is a persisted active cachedState that pollPersisted would
+// consider resumable: unexpired with the grace window still open.
+func activeSlot(instanceID, model string) *cachedState {
+	expiry := time.Now().Add(time.Hour)
+	return &cachedState{
+		status:            "active",
+		instanceID:        instanceID,
+		model:             model,
+		expiresAt:         expiry,
+		gracePeriodEndsAt: expiry.Add(graceWindow),
+	}
+}
+
+// TestPersistResumePollTransportError verifies a transport failure on the
+// resume poll surfaces as a refresh error (single-flight / TRANSIENT_RETRIES
+// territory) instead of being swallowed and falling through to a fresh
+// create that burns a daily session slot. The persisted slot is also left in
+// place: the transport failure did not prove it dead.
+func TestPersistResumePollTransportError(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	store := NewStore(filepath.Join(t.TempDir(), "state.json"))
+	mgr, key := newPersistTestManager(t, mock, store)
+	store.Save(key, activeSlot("inst-abc-123", ""))
+
+	polls, creates := 0, 0
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			polls++
+			// Transport failure: hang up the connection without a response
+			// (verified: the Go transport does not retry, single EOF).
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Errorf("mock server does not support hijacking")
+				return
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Errorf("hijack failed: %v", err)
+				return
+			}
+			_ = conn.Close()
+		case http.MethodPost:
+			creates++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-abc-123","expiresAt":"2030-01-01T00:00:00Z"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	_, err := mgr.EnsureSession(context.Background())
+	if err == nil {
+		t.Fatal("resume poll transport error must surface, got nil")
+	}
+	if creates != 0 {
+		t.Errorf("creates = %d, want 0 (transport error must not fall through to create)", creates)
+	}
+	if polls != 1 {
+		t.Errorf("polls = %d, want 1 (persisted slot polled once)", polls)
+	}
+	if got := store.Load(key); got == nil || got.instanceID != "inst-abc-123" {
+		t.Errorf("store after transport error = %+v, want intact inst-abc-123", got)
+	}
+}
+
+// TestPersistModelMismatchNotAdopted verifies a persisted slot bound to a
+// different model is never re-adopted: it is dropped so the refresh falls
+// through to a create for the requested model. Both the pre-flight gate
+// (persisted model known before the poll) and the post-flight gate (the
+// upstream binds the resumed slot to a model) are exercised.
+func TestPersistModelMismatchNotAdopted(t *testing.T) {
+	t.Run("preflight persisted model mismatch", func(t *testing.T) {
+		mock := testutil.NewMock()
+		defer mock.Close()
+		store := NewStore(filepath.Join(t.TempDir(), "state.json"))
+		mgr, key := newPersistTestManager(t, mock, store)
+		store.Save(key, activeSlot("inst-A", "model/A"))
+
+		var createdModels []string
+		mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				// Not reached: the pre-flight gate rejects before the poll.
+				t.Errorf("unexpected resume poll for a model-mismatched slot")
+			case http.MethodPost:
+				createdModels = append(createdModels, r.Header.Get("x-freebuff-model"))
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-B","model":"`+r.Header.Get("x-freebuff-model")+`","expiresAt":"2030-01-01T00:00:00Z"}`)
+			default:
+				http.NotFound(w, r)
+			}
+		}
+
+		// Direct gate check: pollPersisted must refuse and drop the slot.
+		st, err := mgr.pollPersisted(context.Background(), "model/B")
+		if err != nil {
+			t.Fatalf("pollPersisted: %v", err)
+		}
+		if st != nil {
+			t.Fatalf("pollPersisted adopted %q for model/B, want nil", st.InstanceID)
+		}
+		if got := store.Load(key); got != nil {
+			t.Fatalf("store after mismatch pollPersisted = %+v, want nil (slot dropped)", got)
+		}
+
+		// Integration: the refresh falls through to a create for model/B.
+		store.Save(key, activeSlot("inst-A", "model/A"))
+		instance, err := mgr.EnsureSessionForModel(context.Background(), "model/B")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if instance != "inst-B" {
+			t.Errorf("instance = %q, want inst-B (fresh create for model/B, not inst-A)", instance)
+		}
+		if len(createdModels) != 1 || createdModels[0] != "model/B" {
+			t.Errorf("created models = %v, want [model/B]", createdModels)
+		}
+	})
+
+	t.Run("postflight upstream model mismatch", func(t *testing.T) {
+		// The persisted entry carries no model (e.g. written before model
+		// tracking), but the upstream binds the resumed slot to model/A.
+		mock := testutil.NewMock()
+		defer mock.Close()
+		store := NewStore(filepath.Join(t.TempDir(), "state.json"))
+		mgr, key := newPersistTestManager(t, mock, store)
+		store.Save(key, activeSlot("inst-A", ""))
+
+		polls := 0
+		mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				polls++
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-A","model":"model/A","expiresAt":"2030-01-01T00:00:00Z"}`)
+			case http.MethodPost:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-B","model":"model/B","expiresAt":"2030-01-01T00:00:00Z"}`)
+			default:
+				http.NotFound(w, r)
+			}
+		}
+
+		instance, err := mgr.EnsureSessionForModel(context.Background(), "model/B")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if instance != "inst-B" {
+			t.Errorf("instance = %q, want inst-B (post-flight mismatch → create)", instance)
+		}
+		if polls != 1 {
+			t.Errorf("polls = %d, want 1 (slot polled once, then rejected)", polls)
+		}
+		// The model/A slot was dropped; the store now holds the model/B session.
+		if got := store.Load(key); got == nil || got.instanceID != "inst-B" {
+			t.Errorf("store = %+v, want model/B session inst-B", got)
+		}
+	})
+}
+
+// TestPersistModelMatchAdopted verifies a persisted slot whose model matches
+// the request (or carries no model for a default-model request) is adopted
+// without a fresh create.
+func TestPersistModelMatchAdopted(t *testing.T) {
+	t.Run("same model", func(t *testing.T) {
+		mock := testutil.NewMock()
+		defer mock.Close()
+		store := NewStore(filepath.Join(t.TempDir(), "state.json"))
+		mgr, key := newPersistTestManager(t, mock, store)
+		store.Save(key, activeSlot("inst-A", "model/A"))
+
+		polls, creates := 0, 0
+		mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				polls++
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-A","model":"model/A","expiresAt":"2030-01-01T00:00:00Z"}`)
+			case http.MethodPost:
+				creates++
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-X","expiresAt":"2030-01-01T00:00:00Z"}`)
+			default:
+				http.NotFound(w, r)
+			}
+		}
+
+		instance, err := mgr.EnsureSessionForModel(context.Background(), "model/A")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if instance != "inst-A" {
+			t.Errorf("instance = %q, want inst-A (adopted, not created)", instance)
+		}
+		if creates != 0 {
+			t.Errorf("creates = %d, want 0", creates)
+		}
+		if polls != 1 {
+			t.Errorf("polls = %d, want 1", polls)
+		}
+	})
+
+	t.Run("default model adopts any slot", func(t *testing.T) {
+		mock := testutil.NewMock()
+		defer mock.Close()
+		store := NewStore(filepath.Join(t.TempDir(), "state.json"))
+		mgr, key := newPersistTestManager(t, mock, store)
+		store.Save(key, activeSlot("inst-A", "model/A"))
+
+		creates := 0
+		mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-A","model":"model/A","expiresAt":"2030-01-01T00:00:00Z"}`)
+			case http.MethodPost:
+				creates++
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-X","expiresAt":"2030-01-01T00:00:00Z"}`)
+			default:
+				http.NotFound(w, r)
+			}
+		}
+
+		instance, err := mgr.EnsureSession(context.Background()) // default model ""
+		if err != nil {
+			t.Fatal(err)
+		}
+		if instance != "inst-A" {
+			t.Errorf("instance = %q, want inst-A (default-model request adopts)", instance)
+		}
+		if creates != 0 {
+			t.Errorf("creates = %d, want 0", creates)
+		}
+	})
+}
+
+// TestShutdownKeepAliveOnlyWhenResumable verifies Shutdown keeps the upstream
+// session alive only for genuinely active + unexpired sessions. Every other
+// state falls through to the normal EndSession path (upstream DELETE + store
+// removal via the CAS commit).
+func TestShutdownKeepAliveOnlyWhenResumable(t *testing.T) {
+	t.Run("active unexpired kept", func(t *testing.T) {
+		mock := testutil.NewMock()
+		defer mock.Close()
+		store := NewStore(filepath.Join(t.TempDir(), "state.json"))
+		mgr, key := newPersistTestManager(t, mock, store)
+
+		if _, err := mgr.EnsureSession(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if err := mgr.Shutdown(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if mock.SessionEnds != 0 {
+			t.Errorf("SessionEnds = %d, want 0 (active+unexpired kept for restart)", mock.SessionEnds)
+		}
+		if got := store.Load(key); got == nil || got.instanceID != "inst-abc-123" {
+			t.Errorf("store after Shutdown = %+v, want active inst-abc-123", got)
+		}
+	})
+
+	t.Run("queued ends upstream and drops entry", func(t *testing.T) {
+		mock := testutil.NewMock()
+		defer mock.Close()
+		mock.SessionSequence = []string{"queued"}
+		mock.EstimatedWaitMs = 60000 // pollAt far in the future
+		store := NewStore(filepath.Join(t.TempDir(), "state.json"))
+		mgr, key := newPersistTestManager(t, mock, store)
+
+		if _, err := mgr.EnsureSession(context.Background()); err == nil {
+			t.Fatal("want WaitingRoomError for queued session")
+		} else {
+			var wr *WaitingRoomError
+			if !errors.As(err, &wr) {
+				t.Fatalf("err = %v, want WaitingRoomError", err)
+			}
+		}
+		if got := store.Load(key); got == nil || got.status != "queued" {
+			t.Fatalf("store before Shutdown = %+v, want queued entry", got)
+		}
+
+		if err := mgr.Shutdown(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if mock.SessionEnds != 1 {
+			t.Errorf("SessionEnds = %d, want 1 (queued releases the upstream slot)", mock.SessionEnds)
+		}
+		if got := store.Load(key); got != nil {
+			t.Errorf("store after Shutdown = %+v, want nil (entry removed)", got)
+		}
+	})
+
+	t.Run("expired active ends upstream", func(t *testing.T) {
+		mock := testutil.NewMock()
+		defer mock.Close()
+		store := NewStore(filepath.Join(t.TempDir(), "state.json"))
+		mgr, key := newPersistTestManager(t, mock, store)
+
+		// Craft an active-but-expired cached state (expiry margin already
+		// passed) and persist it the way a live manager would.
+		mgr.mu.Lock()
+		expired := &cachedState{
+			status:     "active",
+			instanceID: "inst-expired",
+			expiresAt:  time.Now().Add(-expiryMargin - time.Second),
+		}
+		mgr.commit(expired)
+		mgr.mu.Unlock()
+
+		if err := mgr.Shutdown(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if mock.SessionEnds != 1 {
+			t.Errorf("SessionEnds = %d, want 1 (expired-active is not resumable)", mock.SessionEnds)
+		}
+		if got := store.Load(key); got != nil {
+			t.Errorf("store after Shutdown = %+v, want nil", got)
+		}
+	})
+}
+
+// TestPersistStoreNotConsultedOnLiveRefresh verifies the store is only
+// consulted when the manager is fresh (cached == nil). A live model-mismatch
+// refresh must create for the requested model without polling the persisted
+// slot — even when a compatible slot is present, adopting it would pin the
+// old model's session on every refresh. The seeded slot carries no model, so
+// any store consultation would be visible as a resume poll (GET).
+func TestPersistStoreNotConsultedOnLiveRefresh(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	store := NewStore(filepath.Join(t.TempDir(), "state.json"))
+	mgr, key := newPersistTestManager(t, mock, store)
+
+	polls := 0
+	var createdModels []string
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			polls++
+			// Compatible with any requested model: adopted whenever the
+			// store is consulted.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-store","expiresAt":"2030-01-01T00:00:00Z"}`)
+		case http.MethodPost:
+			createdModels = append(createdModels, r.Header.Get("x-freebuff-model"))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-created","model":"`+r.Header.Get("x-freebuff-model")+`","expiresAt":"2030-01-01T00:00:00Z"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	// First call: fresh manager → the store is consulted and the persisted
+	// slot adopted.
+	store.Save(key, activeSlot("inst-store", ""))
+	instance, err := mgr.EnsureSessionForModel(context.Background(), "model/A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if instance != "inst-store" {
+		t.Errorf("first call instance = %q, want inst-store (fresh manager adopts)", instance)
+	}
+	if polls != 1 {
+		t.Errorf("polls after first call = %d, want 1", polls)
+	}
+
+	// Live manager, model mismatch: the store must NOT be consulted even
+	// though a compatible slot is present (re-seeded model-less so the
+	// pre-flight gate cannot hide a consultation).
+	store.Save(key, activeSlot("inst-store", ""))
+	instance, err = mgr.EnsureSessionForModel(context.Background(), "model/B")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if instance != "inst-created" {
+		t.Errorf("mismatch refresh instance = %q, want inst-created (created, not adopted)", instance)
+	}
+	if polls != 1 {
+		t.Errorf("polls after mismatch refresh = %d, want still 1 (store not consulted)", polls)
+	}
+	if len(createdModels) != 1 || createdModels[0] != "model/B" {
+		t.Errorf("created models = %v, want [model/B]", createdModels)
+	}
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -14,6 +14,10 @@ import (
 // a stale file is ignored instead of mis-parsed.
 const storeVersion = 1
 
+// maxStoreFileSize caps the on-disk store file; anything larger is treated
+// as empty instead of being read into memory wholesale.
+const maxStoreFileSize = 8 << 20 // 8 MiB
+
 // persistedState is the on-disk shape of one token's cached session. The
 // instance id + expiry are the fields that matter for restart-resume; the
 // rest are carried so a resumed session keeps its tier/country/queue view.
@@ -60,28 +64,54 @@ func (s *Store) loadLocked() {
 	if s.loaded {
 		return
 	}
-	s.loaded = true
 	s.data = make(map[string]persistedState)
+
+	// Reject oversized files before reading them into memory.
+	if fi, err := os.Stat(s.path); err == nil && fi.Size() > maxStoreFileSize {
+		slog.Warn("session store: file too large, ignoring", "path", s.path, "bytes", fi.Size())
+		s.loaded = true
+		return
+	}
 
 	data, err := os.ReadFile(s.path)
 	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			slog.Warn("session store: read failed", "path", s.path, "err", err)
+		if errors.Is(err, os.ErrNotExist) {
+			// First run: a missing file is a valid empty store.
+			s.loaded = true
+		} else {
+			// Leave loaded=false so the next Load (or Save) retries the
+			// read instead of permanently freezing an empty view that a
+			// later Save would flush over the on-disk file, destroying
+			// other tokens' persisted sessions.
+			slog.Warn("session store: read failed, will retry on next access", "path", s.path, "err", err)
 		}
 		return
 	}
 	var file storeFile
 	if err := json.Unmarshal(data, &file); err != nil {
+		// The file is genuinely bad: remember that so we stop re-parsing it
+		// and proceed empty (a later Save replaces it).
 		slog.Warn("session store: parse failed, ignoring", "path", s.path, "err", err)
+		s.loaded = true
 		return
 	}
 	if file.Version != storeVersion {
 		slog.Warn("session store: version mismatch, ignoring", "path", s.path, "version", file.Version)
+		s.loaded = true
 		return
 	}
 	if file.Sessions != nil {
-		s.data = file.Sessions
+		for key, ps := range file.Sessions {
+			// An "active" entry without an instance id cannot be resumed and
+			// would poison the resume path; drop it on load.
+			if ps.Status == "active" && ps.InstanceID == "" {
+				slog.Warn("session store: dropping active entry with empty instance id", "path", s.path, "key", key)
+				continue
+			}
+			s.data[key] = ps
+		}
 	}
+	s.loaded = true
 }
 
 // Load returns the persisted cached state for key, or nil when absent or
@@ -148,8 +178,26 @@ func (s *Store) Save(key string, cs *cachedState) {
 }
 
 // Remove drops key from the store (session invalidated/ended at runtime).
-func (s *Store) Remove(key string) {
-	s.Save(key, nil)
+// When expectedInstanceID is non-empty the entry is only removed if its
+// stored instance id matches, so a stale invalidation cannot clobber a newer
+// resumed session; an empty expectedInstanceID removes unconditionally.
+func (s *Store) Remove(key, expectedInstanceID string) {
+	if key == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.loadLocked()
+
+	ps, ok := s.data[key]
+	if !ok {
+		return
+	}
+	if expectedInstanceID != "" && ps.InstanceID != expectedInstanceID {
+		return
+	}
+	delete(s.data, key)
+	s.flushLocked()
 }
 
 // flushLocked writes the current map atomically. Caller holds s.mu.
@@ -162,19 +210,43 @@ func (s *Store) flushLocked() {
 	}
 
 	dir := filepath.Dir(s.path)
-	if dir != "" {
-		if err := os.MkdirAll(dir, 0o700); err != nil {
-			slog.Warn("session store: mkdir failed", "dir", dir, "err", err)
-			return
-		}
+	if dir == "" {
+		dir = "."
+	} else if err := os.MkdirAll(dir, 0o700); err != nil {
+		slog.Warn("session store: mkdir failed", "dir", dir, "err", err)
+		return
 	}
-	tmp := s.path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+
+	// Write a temp file in the target directory, then rename it over the
+	// target so a crash mid-write never leaves a truncated state file.
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(s.path)+".tmp*")
+	if err != nil {
+		slog.Warn("session store: temp create failed", "dir", dir, "err", err)
+		return
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
 		slog.Warn("session store: write failed", "path", s.path, "err", err)
 		return
 	}
-	if err := os.Rename(tmp, s.path); err != nil {
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		slog.Warn("session store: close failed", "path", s.path, "err", err)
+		return
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		if _, statErr := os.Stat(s.path); statErr == nil {
+			// The target exists but rename-over-existing failed (e.g.
+			// Windows without MOVEFILE_REPLACE_EXISTING): fall back to
+			// removing the target first, then renaming.
+			_ = os.Remove(s.path)
+			if err := os.Rename(tmpName, s.path); err == nil {
+				return
+			}
+		}
+		_ = os.Remove(tmpName)
 		slog.Warn("session store: rename failed", "path", s.path, "err", err)
-		_ = os.Remove(tmp)
 	}
 }

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -1,0 +1,180 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// storeVersion guards the on-disk format; bump it when the schema changes so
+// a stale file is ignored instead of mis-parsed.
+const storeVersion = 1
+
+// persistedState is the on-disk shape of one token's cached session. The
+// instance id + expiry are the fields that matter for restart-resume; the
+// rest are carried so a resumed session keeps its tier/country/queue view.
+type persistedState struct {
+	InstanceID         string    `json:"instance_id"`
+	Model              string    `json:"model"`
+	Status             string    `json:"status"`
+	ExpiresAt          time.Time `json:"expires_at"`
+	GracePeriodEndsAt  time.Time `json:"grace_period_ends_at"`
+	Position           int       `json:"position"`
+	QueueDepth         int       `json:"queue_depth"`
+	PollAt             time.Time `json:"poll_at"`
+	AccessTier         string    `json:"access_tier"`
+	CountryCode        string    `json:"country_code"`
+	CountryBlockReason string    `json:"country_block_reason"`
+}
+
+type storeFile struct {
+	Version  int                       `json:"version"`
+	Sessions map[string]persistedState `json:"sessions"`
+}
+
+// Store persists cached session state to a single JSON file so a proxy
+// restart can resume an unexpired upstream session instead of burning a new
+// session slot. Keys are token hashes (upstream.Client.TokenKey), never raw
+// tokens. All methods are safe for concurrent use; writes are atomic
+// (temp file + rename) and the file is created with mode 0600.
+type Store struct {
+	path string
+
+	mu     sync.Mutex
+	data   map[string]persistedState
+	loaded bool
+}
+
+// NewStore builds a store backed by path. The file is read lazily on the
+// first Load; NewStore never fails (a missing/unreadable file is treated as
+// empty and a later Save overwrites it).
+func NewStore(path string) *Store {
+	return &Store{path: path}
+}
+
+func (s *Store) loadLocked() {
+	if s.loaded {
+		return
+	}
+	s.loaded = true
+	s.data = make(map[string]persistedState)
+
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			slog.Warn("session store: read failed", "path", s.path, "err", err)
+		}
+		return
+	}
+	var file storeFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		slog.Warn("session store: parse failed, ignoring", "path", s.path, "err", err)
+		return
+	}
+	if file.Version != storeVersion {
+		slog.Warn("session store: version mismatch, ignoring", "path", s.path, "version", file.Version)
+		return
+	}
+	if file.Sessions != nil {
+		s.data = file.Sessions
+	}
+}
+
+// Load returns the persisted cached state for key, or nil when absent or
+// already expired beyond the grace window. Load never performs upstream
+// calls; it only filters obviously-dead entries.
+func (s *Store) Load(key string) *cachedState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.loadLocked()
+	ps, ok := s.data[key]
+	if !ok {
+		return nil
+	}
+	// Drop entries whose grace window is already closed: resuming them is
+	// impossible and keeping them only delays the inevitable re-create.
+	if !ps.GracePeriodEndsAt.IsZero() && time.Now().After(ps.GracePeriodEndsAt) {
+		delete(s.data, key)
+		return nil
+	}
+	return &cachedState{
+		status:             ps.Status,
+		instanceID:         ps.InstanceID,
+		model:              ps.Model,
+		expiresAt:          ps.ExpiresAt,
+		gracePeriodEndsAt:  ps.GracePeriodEndsAt,
+		position:           ps.Position,
+		queueDepth:         ps.QueueDepth,
+		pollAt:             ps.PollAt,
+		accessTier:         ps.AccessTier,
+		countryCode:        ps.CountryCode,
+		countryBlockReason: ps.CountryBlockReason,
+	}
+}
+
+// Save persists cs under key. A nil cs removes the key. Disabled sessions
+// (no instance id, no expiry) are not persisted: there is nothing to resume.
+func (s *Store) Save(key string, cs *cachedState) {
+	if key == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.loadLocked()
+
+	if cs == nil || (cs.instanceID == "" && cs.status != "queued") {
+		delete(s.data, key)
+		s.flushLocked()
+		return
+	}
+	s.data[key] = persistedState{
+		InstanceID:         cs.instanceID,
+		Model:              cs.model,
+		Status:             cs.status,
+		ExpiresAt:          cs.expiresAt,
+		GracePeriodEndsAt:  cs.gracePeriodEndsAt,
+		Position:           cs.position,
+		QueueDepth:         cs.queueDepth,
+		PollAt:             cs.pollAt,
+		AccessTier:         cs.accessTier,
+		CountryCode:        cs.countryCode,
+		CountryBlockReason: cs.countryBlockReason,
+	}
+	s.flushLocked()
+}
+
+// Remove drops key from the store (session invalidated/ended at runtime).
+func (s *Store) Remove(key string) {
+	s.Save(key, nil)
+}
+
+// flushLocked writes the current map atomically. Caller holds s.mu.
+func (s *Store) flushLocked() {
+	file := storeFile{Version: storeVersion, Sessions: s.data}
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		slog.Warn("session store: marshal failed", "path", s.path, "err", err)
+		return
+	}
+
+	dir := filepath.Dir(s.path)
+	if dir != "" {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			slog.Warn("session store: mkdir failed", "dir", dir, "err", err)
+			return
+		}
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		slog.Warn("session store: write failed", "path", s.path, "err", err)
+		return
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		slog.Warn("session store: rename failed", "path", s.path, "err", err)
+		_ = os.Remove(tmp)
+	}
+}

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -1,0 +1,214 @@
+package session
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"freebuff-proxy/internal/config"
+	"freebuff-proxy/internal/testutil"
+	"freebuff-proxy/internal/upstream"
+)
+
+func newTestManagerWithStore(t *testing.T, mock *testutil.MockUpstream, store *Store) *Manager {
+	t.Helper()
+	client, err := upstream.New("tok", &config.Config{
+		UpstreamBaseURL:    mock.URL(),
+		RequestTimeout:     15 * time.Minute,
+		SessionCallTimeout: 5 * time.Second,
+		RotationInterval:   6 * time.Hour,
+		RegistryRefresh:    6 * time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return NewManagerWithStore(client, store)
+}
+
+func TestStoreRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	store := NewStore(path)
+
+	if got := store.Load("key"); got != nil {
+		t.Fatalf("Load on empty store = %+v, want nil", got)
+	}
+
+	expiry := time.Now().Add(time.Hour).UTC().Truncate(time.Millisecond)
+	store.Save("key", &cachedState{
+		status:            "active",
+		instanceID:        "inst-1",
+		model:             "m",
+		expiresAt:         expiry,
+		gracePeriodEndsAt: expiry.Add(graceWindow),
+		accessTier:        "limited",
+		countryCode:       "US",
+	})
+
+	// A second Store instance over the same file must see the write.
+	store2 := NewStore(path)
+	got := store2.Load("key")
+	if got == nil {
+		t.Fatal("Load after Save = nil")
+	}
+	if got.instanceID != "inst-1" || got.status != "active" {
+		t.Errorf("Load = %+v, want inst-1/active", got)
+	}
+	if !got.expiresAt.Equal(expiry) {
+		t.Errorf("expiresAt = %v, want %v", got.expiresAt, expiry)
+	}
+
+	store.Remove("key")
+	if got := NewStore(path).Load("key"); got != nil {
+		t.Errorf("Load after Remove = %+v, want nil", got)
+	}
+}
+
+func TestStoreDropsExpiredGrace(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "state.json"))
+	store.Save("key", &cachedState{
+		status:            "active",
+		instanceID:        "inst-1",
+		expiresAt:         time.Now().Add(-40 * time.Minute),
+		gracePeriodEndsAt: time.Now().Add(-10 * time.Minute), // grace already closed
+	})
+	if got := store.Load("key"); got != nil {
+		t.Fatalf("Load of expired entry = %+v, want nil", got)
+	}
+}
+
+func TestShutdownKeepsSessionWhenPersist(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	store := NewStore(filepath.Join(t.TempDir(), "state.json"))
+	mgr := newTestManagerWithStore(t, mock, store)
+
+	if _, err := mgr.EnsureSession(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if mock.SessionCreates != 1 {
+		t.Fatalf("SessionCreates = %d, want 1", mock.SessionCreates)
+	}
+
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if mock.SessionEnds != 0 {
+		t.Errorf("SessionEnds = %d, want 0 (session kept alive for restart)", mock.SessionEnds)
+	}
+	if got := store.Load(mgr.key); got == nil || got.instanceID != "inst-abc-123" {
+		t.Errorf("store after Shutdown = %+v, want active inst-abc-123", got)
+	}
+}
+
+func TestShutdownEndsSessionWithoutPersist(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mgr := newTestManager(t, mock)
+
+	if _, err := mgr.EnsureSession(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if mock.SessionEnds != 1 {
+		t.Errorf("SessionEnds = %d, want 1 (no persistence → DELETE upstream)", mock.SessionEnds)
+	}
+}
+
+func TestResumePersistedOnRestart(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	path := filepath.Join(t.TempDir(), "state.json")
+
+	// First process: create a session and shut down (keeps it alive).
+	mgr1 := newTestManagerWithStore(t, mock, NewStore(path))
+	if _, err := mgr1.EnsureSession(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr1.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if mock.SessionCreates != 1 {
+		t.Fatalf("SessionCreates after first process = %d, want 1", mock.SessionCreates)
+	}
+
+	// Second process (same token → same store key): must resume, not create.
+	mgr2 := newTestManagerWithStore(t, mock, NewStore(path))
+	instance, err := mgr2.EnsureSession(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if instance != "inst-abc-123" {
+		t.Errorf("resumed instance = %q, want inst-abc-123", instance)
+	}
+	if mock.SessionCreates != 1 {
+		t.Errorf("SessionCreates after resume = %d, want still 1 (no new quota burned)", mock.SessionCreates)
+	}
+	if mock.SessionPolls != 1 {
+		t.Errorf("SessionPolls = %d, want 1 (resume poll)", mock.SessionPolls)
+	}
+}
+
+func TestResumeSkipsDeadPersistedSession(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	path := filepath.Join(t.TempDir(), "state.json")
+	store := NewStore(path)
+
+	// The upstream reports the persisted slot as ended, then serves a fresh
+	// active session for the re-create.
+	mock.SessionSequence = []string{"ended", "active"}
+
+	client, err := upstream.New("tok", &config.Config{
+		UpstreamBaseURL:    mock.URL(),
+		RequestTimeout:     15 * time.Minute,
+		SessionCallTimeout: 5 * time.Second,
+		RotationInterval:   6 * time.Hour,
+		RegistryRefresh:    6 * time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgr := NewManagerWithStore(client, store)
+	store.Save(mgr.key, &cachedState{
+		status:            "active",
+		instanceID:        "inst-dead",
+		expiresAt:         time.Now().Add(time.Hour),
+		gracePeriodEndsAt: time.Now().Add(time.Hour + graceWindow),
+	})
+
+	if _, err := mgr.EnsureSession(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// The dead slot must have been discarded and a fresh session created.
+	if mock.SessionCreates != 1 {
+		t.Errorf("SessionCreates = %d, want 1 (dead slot re-created)", mock.SessionCreates)
+	}
+	got := store.Load(mgr.key)
+	if got == nil || got.instanceID != "inst-abc-123" {
+		t.Errorf("store after re-create = %+v, want fresh active inst-abc-123", got)
+	}
+}
+
+func TestStoreFileMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	store := NewStore(path)
+	store.Save("key", &cachedState{status: "active", instanceID: "i", expiresAt: time.Now().Add(time.Hour)})
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Unix enforces 0600; Windows ignores the perm bits (only the read-only
+	// attribute is honored), so the mode assertion is Unix-only.
+	if runtime.GOOS != "windows" {
+		if perm := fi.Mode().Perm(); perm != 0o600 {
+			t.Errorf("state file mode = %o, want 600", perm)
+		}
+	}
+}

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -1,10 +1,14 @@
 package session
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -61,7 +65,7 @@ func TestStoreRoundtrip(t *testing.T) {
 		t.Errorf("expiresAt = %v, want %v", got.expiresAt, expiry)
 	}
 
-	store.Remove("key")
+	store.Remove("key", "")
 	if got := NewStore(path).Load("key"); got != nil {
 		t.Errorf("Load after Remove = %+v, want nil", got)
 	}
@@ -210,5 +214,206 @@ func TestStoreFileMode(t *testing.T) {
 		if perm := fi.Mode().Perm(); perm != 0o600 {
 			t.Errorf("state file mode = %o, want 600", perm)
 		}
+	}
+}
+
+func TestStoreRemoveCAS(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	store := NewStore(path)
+	expiry := time.Now().Add(time.Hour).UTC()
+	store.Save("key", &cachedState{status: "active", instanceID: "inst-1", expiresAt: expiry})
+
+	// Wrong instance id: the entry must survive untouched.
+	store.Remove("key", "inst-other")
+	if got := store.Load("key"); got == nil || got.instanceID != "inst-1" {
+		t.Fatalf("Remove with wrong instance = %+v, want inst-1", got)
+	}
+	// A fresh store over the same file must agree (no-op must not flush).
+	if got := NewStore(path).Load("key"); got == nil || got.instanceID != "inst-1" {
+		t.Fatalf("fresh Load after wrong-instance Remove = %+v, want inst-1", got)
+	}
+
+	// Matching instance id: the entry is removed.
+	store.Remove("key", "inst-1")
+	if got := store.Load("key"); got != nil {
+		t.Fatalf("Remove with matching instance = %+v, want nil", got)
+	}
+	if got := NewStore(path).Load("key"); got != nil {
+		t.Fatalf("fresh Load after matching Remove = %+v, want nil", got)
+	}
+
+	// Empty expected instance id removes unconditionally.
+	store.Save("key2", &cachedState{status: "active", instanceID: "inst-2", expiresAt: expiry})
+	store.Remove("key2", "")
+	if got := store.Load("key2"); got != nil {
+		t.Fatalf("unconditional Remove = %+v, want nil", got)
+	}
+
+	// Removing an absent key is a no-op, not an error.
+	store.Remove("absent", "anything")
+}
+
+func TestStoreConcurrentSaveLoadRemove(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	store := NewStore(path)
+
+	const workers = 16
+	const keysPerWorker = 8
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for k := 0; k < keysPerWorker; k++ {
+				key := fmt.Sprintf("w%d-k%d", w, k)
+				store.Save(key, &cachedState{
+					status:     "active",
+					instanceID: "inst-" + key,
+					expiresAt:  time.Now().Add(time.Hour),
+				})
+				if got := store.Load(key); got == nil || got.instanceID != "inst-"+key {
+					t.Errorf("Load(%q) after Save = %+v", key, got)
+				}
+				// Even keys are removed again by their own writer; the CAS
+				// matches, so the removal must stick.
+				if k%2 == 0 {
+					store.Remove(key, "inst-"+key)
+					if got := store.Load(key); got != nil {
+						t.Errorf("Load(%q) after Remove = %+v, want nil", key, got)
+					}
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// A fresh store over the final file must see exactly the keys that were
+	// saved but not removed: the odd keys of every worker.
+	fresh := NewStore(path)
+	for w := 0; w < workers; w++ {
+		for k := 0; k < keysPerWorker; k++ {
+			key := fmt.Sprintf("w%d-k%d", w, k)
+			got := fresh.Load(key)
+			if k%2 == 0 {
+				if got != nil {
+					t.Errorf("fresh Load(%q) = %+v, want nil (removed)", key, got)
+				}
+			} else if got == nil || got.instanceID != "inst-"+key {
+				t.Errorf("fresh Load(%q) = %+v, want inst-%s", key, got, key)
+			}
+		}
+	}
+}
+
+func TestStoreCorruptFileLoadAndOverwrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewStore(path)
+	if got := store.Load("key"); got != nil {
+		t.Fatalf("Load on corrupt file = %+v, want nil", got)
+	}
+
+	// A Save after a corrupt read must succeed and replace the broken file
+	// with a valid one carrying the new entry.
+	store.Save("key", &cachedState{status: "active", instanceID: "inst-1", expiresAt: time.Now().Add(time.Hour)})
+	if got := NewStore(path).Load("key"); got == nil || got.instanceID != "inst-1" {
+		t.Fatalf("Load after Save over corrupt file = %+v, want inst-1", got)
+	}
+}
+
+func TestStoreReadErrorDoesNotClobberFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not enforced on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses permission bits")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	seed := NewStore(path)
+	seed.Save("a", &cachedState{status: "active", instanceID: "inst-a", expiresAt: time.Now().Add(time.Hour)})
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Block access to the directory so both the read and the later write
+	// fail: a Save must not clobber a file it could not read.
+	if err := os.Chmod(dir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			t.Errorf("restoring dir perms: %v", err)
+		}
+	}()
+
+	store := NewStore(path)
+	if got := store.Load("a"); got != nil {
+		t.Fatalf("Load on unreadable store = %+v, want nil", got)
+	}
+	// The Save fails gracefully (temp creation is blocked) and leaves the
+	// on-disk file untouched instead of replacing it with an empty view.
+	store.Save("b", &cachedState{status: "active", instanceID: "inst-b", expiresAt: time.Now().Add(time.Hour)})
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatalf("Save clobbered an unreadable file: got %d bytes, want %d", len(after), len(before))
+	}
+
+	// Restore access before the final assertions; the deferred restore is
+	// only a safety net for temp-dir cleanup.
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Once access is restored the store must re-read the file (the failed
+	// read must not have been cached as an empty store) and see the seed.
+	if got := store.Load("a"); got == nil || got.instanceID != "inst-a" {
+		t.Fatalf("Load after perms restored = %+v, want inst-a", got)
+	}
+}
+
+func TestStoreIgnoresOversizedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	if err := os.WriteFile(path, make([]byte, maxStoreFileSize+1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := NewStore(path)
+	if got := store.Load("key"); got != nil {
+		t.Fatalf("Load on oversized file = %+v, want nil", got)
+	}
+}
+
+func TestStoreDropsActiveEntryWithoutInstanceID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	file := storeFile{
+		Version: storeVersion,
+		Sessions: map[string]persistedState{
+			"bad":  {Status: "active", InstanceID: "", ExpiresAt: time.Now().Add(time.Hour)},
+			"good": {Status: "active", InstanceID: "inst-1", ExpiresAt: time.Now().Add(time.Hour)},
+		},
+	}
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewStore(path)
+	if got := store.Load("bad"); got != nil {
+		t.Errorf("Load of invalid active entry = %+v, want nil", got)
+	}
+	if got := store.Load("good"); got == nil || got.instanceID != "inst-1" {
+		t.Errorf("Load of valid entry = %+v, want inst-1", got)
 	}
 }

--- a/internal/upstream/client.go
+++ b/internal/upstream/client.go
@@ -13,6 +13,8 @@ import (
 	"compress/gzip"
 	"context"
 	cryptoRand "crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
@@ -330,6 +332,14 @@ type Client struct {
 	// retryBackoff overrides the randomized 200-600ms pre-retry sleep (test
 	// seam; nil uses the crypto/rand jitter).
 	retryBackoff func() time.Duration
+}
+
+// TokenKey returns a stable, non-secret key derived from the client token
+// for session-state persistence. The key is a SHA-256 hex digest of the raw
+// token, so the token itself never appears in the persisted file.
+func (c *Client) TokenKey() string {
+	sum := sha256.Sum256([]byte(c.token))
+	return hex.EncodeToString(sum[:])
 }
 
 // cliUserAgent mirrors the official CLI / SDK user agent. The upstream


### PR DESCRIPTION
Supersedes #35 with a full review-fix pass: same feature (opt-in `SESSION_PERSIST` session-state persistence for restart-resume), same design, plus every blocking and high-value finding from a 4-reviewer pass, rebased on current `main` (includes the atomic-cfg pool refactor).

## What (unchanged from #35)
When `SESSION_PERSIST=true`, the proxy writes cached upstream session state (instance id, expiry, grace window, queue position, tier/country) to a JSON file keyed by a SHA-256 hash of the token (raw token never on disk, mode 0600). On restart it polls the persisted slot first and only creates a fresh session if the slot is dead — avoiding burning a new free-tier daily session slot on every restart. Off by default; behavior is byte-for-byte unchanged when unset.

## Review fixes applied (all P1s + P2s + cheap P3s)
- **P1 model gate** (`session.go`): the store is now consulted only on a fresh manager (`cached == nil`), and adoption is gated on model compatibility pre- and post-flight. Previously any active persisted slot was adopted regardless of the requested model, pinning the old model's session forever (upstream `session_model_mismatch`) and breaking multi-model-per-token routing whenever the flag was on.
- **P1 error propagation** (`session.go`): `GetSession` transport errors during the resume poll were swallowed (log + nil) and fell through to `CreateSessionForModel`, burning a fresh daily slot on a merely-flaky upstream at restart. The error is now surfaced so single-flight / `TRANSIENT_RETRIES` retry the resume.
- **P2 atomic writes** (`store.go`): fixed `.tmp` + `os.WriteFile` replaced with the repo's `os.CreateTemp` pattern (temp removed on every error path, remove-then-rename fallback) — no symlink planting, no interleaved writes between overlapping processes.
- **P2 read retry** (`store.go`): `loaded` is set only after a successful read+parse; a transient read error no longer freezes an empty view that the next Save would flush over the on-disk file (which destroyed other tokens' slots).
- **P2 CAS removal** (`store.go` + `session.go`): `Remove(key, expectedInstanceID)` — a stale nil-commit from an overlapping process cannot delete a slot it does not own.
- **P2 reload warning** (`pool.go`): a dashboard save or `/admin/reload` that toggles persistence is no longer a silent no-op — `SetConfig` logs `SESSION_PERSIST/SESSION_STATE_FILE changed via reload; takes effect on the next restart`.
- **P2 shutdown gating** (`session.go`): keep-alive now applies only to genuinely active + unexpired sessions; queued/disabled/expired states fall through to the normal `EndSession` (release upstream slot + remove entry).
- **P3**: absolute state-file path + cwd warning in main; dead persisted entries removed on terminal statuses; 8 MiB read cap; entry validation on load; README privacy note (bridge token hashes + tier/country persist; opt-out via unset).

## Tests
- New: resume-poll transport error (create NOT called), model mismatch pre/post-flight rejection, model match adoption, shutdown keep-alive gating (active kept / queued + expired ended), fresh-manager-only gate, store CAS, concurrent save/load/remove, corrupt-file overwrite, oversized-file ignore, active-entry-without-instance validation, config defaults/validation/bool parsing, reload-warning firing.
- Verified: `go build ./...`, `go vet ./...`, `go test ./...` — all packages green except `internal/server`'s 5 dashboard tests, which fail **identically on `origin/main`** (pre-existing/environmental, not from this change). Cross-compiles clean for linux/windows/darwin amd64.

## Commits
- `d9f72cd` original PR commit (cherry-picked, authorship preserved)
- `8e87487` fix(session): model gate + resume-poll error propagation + shutdown gating + CAS removal
- `9abe251` fix(session): store hardening (CreateTemp, read retry, CAS, input caps)
- `4a6eac1` fix(pool): reload persistence-change warning; config validation pins
- `543c74b` fix(main): absolute state-file path + cwd warning; README privacy note
