### PR TITLE
feat(anthropic): implement local messages token counting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,13 @@ require (
 	github.com/andybalholm/brotli v1.2.2
 	github.com/klauspost/compress v1.19.2
 	github.com/refraction-networking/utls v1.8.2
+	github.com/tiktoken-go/tokenizer v0.8.1
 	golang.org/x/net v0.58.0
 	golang.org/x/sys v0.47.0
 )
 
 require (
+	github.com/dlclark/regexp2/v2 v2.5.1 // indirect
 	github.com/xyproto/randomstring v1.2.0 // indirect
 	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/text v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,13 @@
 github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=
 github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
+github.com/dlclark/regexp2/v2 v2.5.1 h1:E5Ug7Dh264W1ymdySmiHNcDG7fmsR307APCE5R07a20=
+github.com/dlclark/regexp2/v2 v2.5.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/klauspost/compress v1.19.2 h1:hMRETovs/pu/dVWN7zIT1PGG8t509MwT6bO7XSi26R8=
 github.com/klauspost/compress v1.19.2/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/refraction-networking/utls v1.8.2 h1:j4Q1gJj0xngdeH+Ox/qND11aEfhpgoEvV+S9iJ2IdQo=
 github.com/refraction-networking/utls v1.8.2/go.mod h1:jkSOEkLqn+S/jtpEHPOsVv/4V4EVnelwbMQl4vCWXAM=
+github.com/tiktoken-go/tokenizer v0.8.1 h1:4obDoB6/dhdBt9xMweX4nww5cjdOq/nYF4ecwPq2+mg=
+github.com/tiktoken-go/tokenizer v0.8.1/go.mod h1:eLA0t6nGvn9mDc7gt90qt7pMat+gE9ViqwQ6l9B+tA4=
 github.com/xyproto/randomstring v1.2.0 h1:y7PXAEBM3XlwJjPG2JQg4voxBYZ4+hPgRdGKCfU8wik=
 github.com/xyproto/randomstring v1.2.0/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=

--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -90,15 +90,62 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleMessagesCountTokens answers POST /v1/messages/count_tokens with a
-// structured unsupported error. Documented choice: the proxy does not
-// bundle a tokenizer (zero new dependencies), and a rough estimate would
-// mislead Claude clients' context management — so counting is refused
-// explicitly (501, code count_tokens_unsupported) rather than answered
-// with wrong numbers. Chat itself works via POST /v1/messages.
+// local estimate of the request's input tokens. The estimate mirrors the
+// FreeBuff upstream context estimator (o200k_base tokenization scaled by its
+// multiplier, per-message overhead, flat image cost, structured tool
+// counting) and is fully local: no session, quota, or upstream call. The
+// result is an estimate for context planning, not a provider-exact token
+// count — Anthropic documents its own count endpoint the same way.
 func (s *Server) handleMessagesCountTokens(w http.ResponseWriter, r *http.Request) {
-	s.writeJSONError(w, http.StatusNotImplemented,
-		"count_tokens is not supported: this proxy serves chat completions only and does not bundle a tokenizer, so an estimate would mislead context management. POST /v1/messages works for chat; token counts are unavailable.",
-		"unsupported_endpoint", "count_tokens_unsupported", 0)
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBody)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			s.writeJSONError(w, http.StatusRequestEntityTooLarge,
+				"request body exceeds the 32MB limit", "invalid_request_error", "content_too_large", 0)
+		} else {
+			s.writeJSONError(w, http.StatusBadRequest,
+				"failed to read request body: "+err.Error(), "invalid_request_error", "invalid_json", 0)
+		}
+		return
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		s.writeJSONError(w, http.StatusBadRequest,
+			"request body must be a valid JSON object", "invalid_request_error", "invalid_json", 0)
+		return
+	}
+	rawModel, _ := raw["model"].(string)
+	if rawModel == "" {
+		s.writeJSONError(w, http.StatusBadRequest,
+			"missing required field \"model\"; available: "+strings.Join(s.reg.Models(), ", "),
+			"invalid_request_error", "model_not_found", 0)
+		return
+	}
+	// Reject unknown models the way the chat path does (registry
+	// ErrModelNotFound → 400 model_not_found) without acquiring a session
+	// or touching upstream.
+	if _, err := s.reg.AgentForModel(rawModel); err != nil {
+		s.writeJSONError(w, http.StatusBadRequest,
+			err.Error()+"; available: "+strings.Join(s.reg.Models(), ", "),
+			"invalid_request_error", "model_not_found", 0)
+		return
+	}
+	if s.tokenEstimator == nil {
+		s.writeJSONError(w, http.StatusInternalServerError,
+			"token estimator unavailable", "server_error", "estimator_unavailable", 0)
+		return
+	}
+	count, err := s.tokenEstimator.CountAnthropicRequest(raw)
+	if err != nil {
+		s.writeJSONError(w, http.StatusBadRequest,
+			"invalid messages request: "+err.Error(), "invalid_request_error", "invalid_json", 0)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]any{"input_tokens": count})
 }
 
 // --- request conversion ---

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -50,6 +50,7 @@ import (
 	"freebuff-proxy/internal/registry"
 	"freebuff-proxy/internal/runs"
 	"freebuff-proxy/internal/session"
+	"freebuff-proxy/internal/tokenestimate"
 	"freebuff-proxy/internal/updatecheck"
 	"freebuff-proxy/internal/upstream"
 )
@@ -93,6 +94,9 @@ type Server struct {
 	// token-less upstream client whose transport/stealth wiring matches the
 	// pooled clients. nil disables the wizard endpoints with 503.
 	authClient *upstream.Client
+	// tokenEstimator counts tokens locally for /v1/messages/count_tokens
+	// (nil only if the embedded codec failed to initialize at startup).
+	tokenEstimator *tokenestimate.Estimator
 	// loginFlows is the in-flight login-flow registry keyed by flow id
 	// (fingerprint): start POSTs /api/auth/cli/code, status polls it until
 	// the authToken lands (then AddToken + persist).
@@ -149,6 +153,13 @@ func New(cfg *config.Config, p *pool.Pool, reg *registry.Registry, logger *slog.
 	}
 	s := &Server{pool: p, reg: reg, logger: logger, started: time.Now(), configPath: configPath, loginFlows: make(map[string]*loginFlow)}
 	s.cfg.Store(cfg)
+	// The token estimator shares one o200k_base codec process-wide, so
+	// count_tokens requests never rebuild the vocabulary.
+	est, err := tokenestimate.New()
+	if err != nil {
+		logger.Error("token estimator unavailable; /v1/messages/count_tokens will fail", "err", err)
+	}
+	s.tokenEstimator = est
 	for _, opt := range opts {
 		opt(s)
 	}

--- a/internal/server/server_api_test.go
+++ b/internal/server/server_api_test.go
@@ -611,15 +611,115 @@ func TestMessagesStreamToolUse(t *testing.T) {
 	}
 }
 
-func TestMessagesCountTokensUnsupported(t *testing.T) {
+// countTokensResult is the success envelope of /v1/messages/count_tokens.
+type countTokensResult struct {
+	InputTokens int `json:"input_tokens"`
+}
+
+// TestMessagesCountTokens pins the count_tokens contract: a local 200 with
+// an Anthropic-shaped {input_tokens} estimate and zero upstream contact.
+// The estimate is computed by the golden-reference table in the
+// tokenestimate package; here we assert the handler contract end-to-end.
+func TestMessagesCountTokens(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	ts, _ := newTestServer(t, nil, mock)
 
-	body := `{"model":"` + modelA + `","messages":[{"role":"user","content":"hi"}]}`
+	body := `{"model":"` + modelA + `","messages":[{"role":"user","content":"hello"}]}`
 	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/messages/count_tokens", []byte(body), nil)
-	if resp.StatusCode != http.StatusNotImplemented {
-		t.Fatalf("status = %d, want 501: %s", resp.StatusCode, truncate(string(data), 200))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, truncate(string(data), 200))
+	}
+	var out countTokensResult
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	// 8 per-message overhead + 1 for "hello" (o200k_base reference).
+	if out.InputTokens != 9 {
+		t.Errorf("input_tokens = %d, want 9", out.InputTokens)
+	}
+	if mock.Requests != 0 {
+		t.Errorf("upstream requests = %d, want 0 (local estimate only)", mock.Requests)
+	}
+}
+
+// TestMessagesCountTokensComplexRequest exercises a mixed request (system,
+// thinking, tool_use, tool_result, tools) against the golden total 93 from
+// the Python tiktoken reference — proving the estimator's composition, not
+// just the trivial one-message case.
+func TestMessagesCountTokensComplexRequest(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	ts, _ := newTestServer(t, nil, mock)
+
+	body := `{
+		"model":"` + modelA + `",
+		"system":"You are a helpful assistant.",
+		"messages":[
+			{"role":"user","content":"hello"},
+			{"role":"assistant","content":[{"type":"thinking","thinking":"Let me think about this."}]},
+			{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"get_weather","input":{"city":"Jakarta"}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"text","text":"3 files"}]}]}
+		],
+		"tools":[{"name":"get_weather","input_schema":{"type":"object","properties":{"city":{"type":"string"}}}}]
+	}`
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/messages/count_tokens", []byte(body), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, truncate(string(data), 200))
+	}
+	var out countTokensResult
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	if out.InputTokens != 93 {
+		t.Errorf("input_tokens = %d, want 93 (golden reference)", out.InputTokens)
+	}
+	if mock.Requests != 0 {
+		t.Errorf("upstream requests = %d, want 0", mock.Requests)
+	}
+}
+
+// TestMessagesCountTokensDeterministic sends the same request twice: the
+// estimator must be byte-stable (no random hashing, no cache-dependent
+// drift), so repeated calls return identical counts.
+func TestMessagesCountTokensDeterministic(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	ts, _ := newTestServer(t, nil, mock)
+
+	body := []byte(`{"model":"` + modelA + `","messages":[{"role":"user","content":"hello world"}]}`)
+	var first int
+	for i := 0; i < 5; i++ {
+		resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/messages/count_tokens", body, nil)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("iteration %d status = %d: %s", i, resp.StatusCode, truncate(string(data), 200))
+		}
+		var out countTokensResult
+		if err := json.Unmarshal(data, &out); err != nil {
+			t.Fatalf("iteration %d body not JSON: %v", i, err)
+		}
+		if i == 0 {
+			first = out.InputTokens
+			continue
+		}
+		if out.InputTokens != first {
+			t.Fatalf("iteration %d input_tokens = %d, want %d (deterministic)", i, out.InputTokens, first)
+		}
+	}
+	if mock.Requests != 0 {
+		t.Errorf("upstream requests = %d, want 0", mock.Requests)
+	}
+}
+
+func TestMessagesCountTokensMissingModel(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	ts, _ := newTestServer(t, nil, mock)
+
+	body := `{"messages":[{"role":"user","content":"hi"}]}`
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/messages/count_tokens", []byte(body), nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, truncate(string(data), 200))
 	}
 	var out struct {
 		Error struct {
@@ -630,9 +730,146 @@ func TestMessagesCountTokensUnsupported(t *testing.T) {
 	if err := json.Unmarshal(data, &out); err != nil {
 		t.Fatalf("error body not JSON: %v", err)
 	}
-	if out.Error.Type != "unsupported_endpoint" || out.Error.Code != "count_tokens_unsupported" {
-		t.Errorf("type/code = %q/%q, want unsupported_endpoint/count_tokens_unsupported", out.Error.Type, out.Error.Code)
+	if out.Error.Type != "invalid_request_error" || out.Error.Code != "model_not_found" {
+		t.Errorf("type/code = %q/%q, want invalid_request_error/model_not_found", out.Error.Type, out.Error.Code)
 	}
+	if mock.Requests != 0 {
+		t.Errorf("upstream requests = %d, want 0", mock.Requests)
+	}
+}
+
+func TestMessagesCountTokensUnknownModel(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	ts, _ := newTestServer(t, nil, mock)
+
+	body := `{"model":"no-such-model","messages":[{"role":"user","content":"hi"}]}`
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/messages/count_tokens", []byte(body), nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, truncate(string(data), 200))
+	}
+	var out struct {
+		Error struct {
+			Type string `json:"type"`
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("error body not JSON: %v", err)
+	}
+	if out.Error.Type != "invalid_request_error" || out.Error.Code != "model_not_found" {
+		t.Errorf("type/code = %q/%q, want invalid_request_error/model_not_found", out.Error.Type, out.Error.Code)
+	}
+	if mock.Requests != 0 {
+		t.Errorf("upstream requests = %d, want 0", mock.Requests)
+	}
+}
+
+func TestMessagesCountTokensInvalidJSON(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	ts, _ := newTestServer(t, nil, mock)
+
+	for _, body := range []string{`{not json`, `[]`, `"x"`, ``} {
+		resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/messages/count_tokens", []byte(body), nil)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("body %q status = %d, want 400: %s", body, resp.StatusCode, truncate(string(data), 200))
+		}
+		var out struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(data, &out); err != nil {
+			t.Fatalf("body %q error not JSON: %v", body, err)
+		}
+		if out.Error.Code != "invalid_json" {
+			t.Errorf("body %q code = %q, want invalid_json", body, out.Error.Code)
+		}
+	}
+	if mock.Requests != 0 {
+		t.Errorf("upstream requests = %d, want 0", mock.Requests)
+	}
+}
+
+// TestMessagesCountTokensOversizedBody pins the 32MiB body cap on
+// count_tokens: an oversized payload is rejected with 413 content_too_large
+// before any counting or upstream contact.
+func TestMessagesCountTokensOversizedBody(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	ts, _ := newTestServer(t, nil, mock)
+
+	oversized := bytes.Repeat([]byte("a"), 32<<20+1)
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/messages/count_tokens", oversized, nil)
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413: %s", resp.StatusCode, truncate(string(data), 200))
+	}
+	if !strings.Contains(string(data), "content_too_large") {
+		t.Errorf("body missing content_too_large: %s", truncate(string(data), 200))
+	}
+	if mock.Requests != 0 {
+		t.Errorf("upstream requests = %d, want 0 (oversized body rejected before counting)", mock.Requests)
+	}
+}
+
+// TestMessagesCountTokensDocumentRejected verifies the estimator refuses to
+// guess a token count for PDF/document blocks: the proxy's /v1/messages
+// conversion does not consume documents, so the request is rejected with
+// 400 instead of faking accuracy with a base64 character count.
+func TestMessagesCountTokensDocumentRejected(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	ts, _ := newTestServer(t, nil, mock)
+
+	body := `{"model":"` + modelA + `","messages":[{"role":"user","content":[{"type":"document","source":{"type":"base64","media_type":"application/pdf","data":"JVBERi0="}}]}]}`
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/messages/count_tokens", []byte(body), nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, truncate(string(data), 200))
+	}
+	var out struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("error body not JSON: %v", err)
+	}
+	if out.Error.Code != "invalid_json" {
+		t.Errorf("code = %q, want invalid_json", out.Error.Code)
+	}
+	if mock.Requests != 0 {
+		t.Errorf("upstream requests = %d, want 0", mock.Requests)
+	}
+}
+
+// TestMessagesCountTokensAuth pins that count_tokens sits behind the same
+// requireAuth gate as the rest of the API surface (no key → 401, key → 200).
+func TestMessagesCountTokensAuth(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	ts, _ := newTestServer(t, []string{"sk-test"}, mock)
+	url := ts.URL + "/v1/messages/count_tokens"
+	body := []byte(`{"model":"` + modelA + `","messages":[{"role":"user","content":"hi"}]}`)
+
+	resp, data := doJSON(t, http.MethodPost, url, body, nil)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("no key status = %d, want 401: %s", resp.StatusCode, truncate(string(data), 200))
+	}
+	if !strings.Contains(string(data), "invalid_api_key") {
+		t.Errorf("body missing invalid_api_key: %s", data)
+	}
+
+	resp, data = doJSON(t, http.MethodPost, url, body, map[string]string{"x-api-key": "sk-test"})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("x-api-key status = %d, want 200: %s", resp.StatusCode, truncate(string(data), 200))
+	}
+
+	resp, data = doJSON(t, http.MethodPost, url, body, map[string]string{"Authorization": "Bearer sk-test"})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Bearer status = %d, want 200: %s", resp.StatusCode, truncate(string(data), 200))
+	}
+
 	if mock.Requests != 0 {
 		t.Errorf("upstream requests = %d, want 0", mock.Requests)
 	}

--- a/internal/tokenestimate/estimator.go
+++ b/internal/tokenestimate/estimator.go
@@ -1,0 +1,301 @@
+// Package tokenestimate implements a local, deterministic token estimator
+// aligned with the FreeBuff upstream context estimator (see
+// CodebuffAI/freebuff packages/agent-runtime/src/util/token-counter.ts):
+// a GPT-4o/o200k base tokenizer scaled by a conservative multiplier, plus
+// per-message overhead, a flat per-image cost, and structured counting of
+// tool calls/results so base64 media is never tokenized as plain text.
+//
+// Known divergence: FreeBuff's gpt-tokenizer encodes OpenAI-style special
+// markers (<|endoftext|> etc.) with allowedSpecial="all", collapsing each
+// to a single token. tiktoken-go/tokenizer declares a special-token map but
+// never consults it during tokenization, so those markers are BPE-encoded
+// as ordinary text and therefore conservatively over-counted. The counts
+// stay deterministic and never panic; the exact value is pinned by
+// TestCountTextSpecialMarkers.
+//
+// The result is an estimate for Anthropic-compatible clients, not a
+// provider-exact token count.
+package tokenestimate
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"strings"
+	"sync"
+	"unicode/utf16"
+
+	"github.com/tiktoken-go/tokenizer"
+)
+
+// Constants mirror the FreeBuff upstream estimator as of 2026-08-17
+// (packages/agent-runtime/src/util/token-counter.ts). They are heuristics,
+// not Anthropic-published formula values.
+const (
+	// fudgeFactor is ANTHROPIC_TOKEN_FUDGE_FACTOR: every raw token count is
+	// multiplied so the estimate stays deliberately a touch above the true
+	// count for context budgeting.
+	fudgeFactor = 1.35
+	// perMessageOverhead is PER_MESSAGE_TOKEN_OVERHEAD: role marker and
+	// delimiters Anthropic adds on top of the raw content per message.
+	perMessageOverhead = 8
+	// imageTokenEstimate is IMAGE_TOKEN_ESTIMATE: the ceiling Anthropic bills
+	// for a large image, used flat instead of counting base64 characters.
+	imageTokenEstimate = 1600
+	// fallbackDivisor matches the JS fallback (text.length / 3) used when
+	// tokenizer encoding fails.
+	fallbackDivisor = 3
+)
+
+// errDocument is returned when a document block is present: the proxy's
+// /v1/messages conversion does not consume documents, so this estimator
+// refuses to guess a PDF token count instead of faking accuracy.
+var errDocument = errors.New("document blocks are not supported by this proxy")
+
+// Estimator counts text with a process-shared o200k_base codec. The codec is
+// created once; Count/Encode only read its vocabulary, so the instance is
+// safe for concurrent use.
+type Estimator struct {
+	codec tokenizer.Codec
+}
+
+var (
+	codecOnce sync.Once
+	codec     tokenizer.Codec
+	codecErr  error
+)
+
+// New returns an Estimator backed by a shared o200k_base codec (vocabulary
+// embedded in the binary; no network access).
+func New() (*Estimator, error) {
+	codecOnce.Do(func() {
+		codec, codecErr = tokenizer.Get(tokenizer.O200kBase)
+	})
+	if codecErr != nil {
+		return nil, codecErr
+	}
+	return &Estimator{codec: codec}, nil
+}
+
+// CountText estimates tokens for one text string: the o200k_base token count
+// scaled by the FreeBuff multiplier, or the UTF-16-unit fallback if the
+// tokenizer fails (mirrors the JS text.length/3 path).
+func (e *Estimator) CountText(text string) int {
+	if text == "" {
+		return 0
+	}
+	n, err := e.codec.Count(text)
+	if err != nil {
+		units := len(utf16.Encode([]rune(text)))
+		return (units + fallbackDivisor - 1) / fallbackDivisor
+	}
+	return int(math.Floor(float64(n) * fudgeFactor))
+}
+
+// CountJSON estimates tokens for a value's deterministic JSON encoding. Go's
+// encoding/json sorts map keys, so repeated counts of the same semantic
+// object are stable.
+func (e *Estimator) CountJSON(v any) int {
+	if v == nil {
+		return 0
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return 0
+	}
+	return e.CountText(string(b))
+}
+
+// CountAnthropicRequest estimates input tokens for an Anthropic
+// messages/count_tokens request body: system text + tool definitions + each
+// message (per-message overhead plus structured content), mirroring FreeBuff's
+// estimateContextTokensLocally. It returns an error for request shapes the
+// proxy cannot consume (missing messages, document blocks).
+func (e *Estimator) CountAnthropicRequest(raw map[string]any) (int, error) {
+	total := 0
+	if system, ok := raw["system"]; ok && system != nil {
+		n, err := e.countSystem(system)
+		if err != nil {
+			return 0, err
+		}
+		total += n
+	}
+	rawMessages, ok := raw["messages"].([]any)
+	if !ok {
+		return 0, errors.New(`missing or invalid "messages" (want an array)`)
+	}
+	for _, rawMsg := range rawMessages {
+		msg, ok := rawMsg.(map[string]any)
+		if !ok {
+			// Non-object messages are dropped by /v1/messages conversion and
+			// never reach the model, so they add nothing here either.
+			continue
+		}
+		total += perMessageOverhead
+		n, err := e.countContent(msg["content"])
+		if err != nil {
+			return 0, err
+		}
+		total += n
+	}
+	if tools, ok := raw["tools"].([]any); ok {
+		total += e.CountJSON(e.toolsForCount(tools))
+	}
+	return total, nil
+}
+
+// countSystem counts the top-level system field: a plain string directly, an
+// array via its text blocks (JSON fallback for anything else recognized by
+// the conversion surface).
+func (e *Estimator) countSystem(system any) (int, error) {
+	switch typed := system.(type) {
+	case string:
+		return e.CountText(typed), nil
+	case []any:
+		total := 0
+		for _, rawPart := range typed {
+			part, ok := rawPart.(map[string]any)
+			if !ok {
+				continue
+			}
+			switch strings.ToLower(asString(part["type"])) {
+			case "text":
+				total += e.CountText(asString(part["text"]))
+			case "document":
+				return 0, errDocument
+			default:
+				total += e.CountJSON(part)
+			}
+		}
+		return total, nil
+	default:
+		// Non-string/non-array system values are dropped by the conversion,
+		// so nothing is counted.
+		return 0, nil
+	}
+}
+
+// countContent counts one message's content: a string directly, an array of
+// content blocks structurally, or a conservative JSON fallback for any other
+// accepted shape.
+func (e *Estimator) countContent(content any) (int, error) {
+	switch typed := content.(type) {
+	case nil:
+		return 0, nil
+	case string:
+		return e.CountText(typed), nil
+	case []any:
+		total := 0
+		for _, rawPart := range typed {
+			part, ok := rawPart.(map[string]any)
+			if !ok {
+				continue
+			}
+			n, err := e.countContentPart(part)
+			if err != nil {
+				return 0, err
+			}
+			total += n
+		}
+		return total, nil
+	default:
+		return e.CountJSON(typed), nil
+	}
+}
+
+// countContentPart counts one Anthropic content block. Types the /v1/messages
+// conversion does not understand get a JSON fallback so accepted structures
+// never silently under-count.
+func (e *Estimator) countContentPart(part map[string]any) (int, error) {
+	switch strings.ToLower(asString(part["type"])) {
+	case "text":
+		return e.CountText(asString(part["text"])), nil
+	case "thinking":
+		// The conversion accepts the thinking field, falling back to text.
+		text := asString(part["thinking"])
+		if text == "" {
+			text = asString(part["text"])
+		}
+		return e.CountText(text), nil
+	case "tool_use", "server_tool_use":
+		return e.CountText(asString(part["name"])) + e.CountJSON(part["input"]), nil
+	case "tool_result":
+		return e.countToolResult(part)
+	case "image":
+		return imageTokenEstimate, nil
+	case "document":
+		return 0, errDocument
+	default:
+		return e.CountJSON(part), nil
+	}
+}
+
+// countToolResult counts a tool_result part: textual or structured result
+// content, with images billed flat instead of tokenizing base64.
+func (e *Estimator) countToolResult(part map[string]any) (int, error) {
+	return e.countToolResultContent(part["content"])
+}
+
+func (e *Estimator) countToolResultContent(content any) (int, error) {
+	switch typed := content.(type) {
+	case nil:
+		return 0, nil
+	case string:
+		return e.CountText(typed), nil
+	case []any:
+		total := 0
+		for _, rawItem := range typed {
+			switch item := rawItem.(type) {
+			case string:
+				total += e.CountText(item)
+			case map[string]any:
+				switch strings.ToLower(asString(item["type"])) {
+				case "text":
+					total += e.CountText(asString(item["text"]))
+				case "image":
+					total += imageTokenEstimate
+				case "document":
+					return 0, errDocument
+				default:
+					total += e.CountJSON(item)
+				}
+			default:
+				total += e.CountJSON(item)
+			}
+		}
+		return total, nil
+	default:
+		return e.CountJSON(typed), nil
+	}
+}
+
+// anthropicToolCount is the tool representation the model effectively
+// receives, kept in the same field order FreeBuff counts ({name,
+// description, input_schema}) so the JSON is byte-stable.
+type anthropicToolCount struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	InputSchema any    `json:"input_schema,omitempty"`
+}
+
+func (e *Estimator) toolsForCount(tools []any) []anthropicToolCount {
+	out := make([]anthropicToolCount, 0, len(tools))
+	for _, rawTool := range tools {
+		tool, ok := rawTool.(map[string]any)
+		if !ok {
+			continue
+		}
+		tc := anthropicToolCount{Name: asString(tool["name"])}
+		tc.Description = asString(tool["description"])
+		if schema, ok := tool["input_schema"]; ok && schema != nil {
+			tc.InputSchema = schema
+		}
+		out = append(out, tc)
+	}
+	return out
+}
+
+func asString(v any) string {
+	s, _ := v.(string)
+	return s
+}

--- a/internal/tokenestimate/estimator_test.go
+++ b/internal/tokenestimate/estimator_test.go
@@ -1,0 +1,493 @@
+package tokenestimate_test
+
+// Golden values in this file were computed with the independent Python
+// reference (OpenAI tiktoken 0.13.0, o200k_base, allowed_special="all",
+// floor(raw * 1.35)) — see token_ref/reference.py in the starter root. Go
+// counts are asserted against those numbers so the estimator's o200k_base
+// tokenization is cross-validated against the reference implementation.
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"freebuff-proxy/internal/tokenestimate"
+)
+
+func mustNew(t *testing.T) *tokenestimate.Estimator {
+	t.Helper()
+	e, err := tokenestimate.New()
+	if err != nil {
+		t.Fatalf("New(): %v", err)
+	}
+	return e
+}
+
+func TestCountTextGolden(t *testing.T) {
+	// Values from token_ref/reference.py: floor(raw * 1.35), o200k_base.
+	const codeFixture = `func (e *Estimator) CountText(text string) int {
+	if text == "" {
+		return 0
+	}
+	n, err := e.codec.Count(text)
+	if err != nil {
+		units := len(utf16.Encode([]rune(text)))
+		return (units + fallbackDivisor - 1) / fallbackDivisor
+	}
+	return int(math.Floor(float64(n) * fudgeFactor))
+}`
+	cases := []struct {
+		name string
+		text string
+		want int
+	}{
+		{"empty", "", 0},
+		{"hello", "hello", 1},
+		{"hello world", "hello world", 2},
+		{"Hello, world!", "Hello, world!", 5},
+		{"indonesian", "Saya sedang menguji penghitung token untuk aplikasi ini.", 14},
+		{"cjk", "你好世界，这是一个测试。", 8},
+		{"emoji combining", "👨\u200d💻🚀 café naïve e\u0301", 16},
+		{"go code", codeFixture, 116},
+		{"long", strings.Repeat("The quick brown fox jumps over the lazy dog. ", 60), 811},
+	}
+	e := mustNew(t)
+	for _, tc := range cases {
+		if got := e.CountText(tc.text); got != tc.want {
+			t.Errorf("%s: CountText = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestCountTextSpecialMarkers pins the behavior of OpenAI-style special
+// markers. tiktoken-go/tokenizer has no special-token encoder: markers are
+// BPE-encoded as regular text instead of collapsing to one token (the Python
+// reference with allowed_special="all" yields 1 for <|endoftext|>). The
+// estimator must not panic and must stay deterministic; the exact overcount
+// is a documented deviation of the local port.
+func TestCountTextSpecialMarkers(t *testing.T) {
+	e := mustNew(t)
+	for _, s := range []string{"<|endoftext|>", "<|endofprompt|>", "<|fim_prefix|>"} {
+		first := e.CountText(s)
+		if first < 1 {
+			t.Errorf("CountText(%q) = %d, want >= 1", s, first)
+		}
+		if second := e.CountText(s); second != first {
+			t.Errorf("CountText(%q) not deterministic: %d then %d", s, first, second)
+		}
+	}
+}
+
+func TestCountJSONGolden(t *testing.T) {
+	// Canonical Go json.Marshal output (sorted map keys, no spaces).
+	cases := []struct {
+		name  string
+		value any
+		want  int
+	}{
+		{"tool_input_small", map[string]any{"city": "Jakarta"}, 8},
+		{"tool_input_big", map[string]any{
+			"city":  "Jakarta",
+			"extra": strings.Repeat("a", 64),
+			"unit":  "celsius",
+		}, 29},
+		{"unknown_block", map[string]any{"foo": "bar", "type": "weird"}, 13},
+		{"json_ok", "ok", 4},
+	}
+	e := mustNew(t)
+	for _, tc := range cases {
+		if got := e.CountJSON(tc.value); got != tc.want {
+			t.Errorf("%s: CountJSON = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestCountAnthropicRequestGolden(t *testing.T) {
+	// The full mixed request from the reference fixture. Expected total:
+	//   system "You are a helpful assistant."                      = 8
+	//   user "hello"                                   8 + 1      = 9
+	//   assistant thinking "Let me think about this."  8 + 8      = 16
+	//   assistant tool_use (name+input)                8 + 2 + 8  = 18
+	//   user tool_result [{text "3 files"}]            8 + 2      = 10
+	//   tools (tools_minimal JSON)                                = 32
+	//                                                             = 93
+	req := map[string]any{
+		"model":  "z-ai/glm-5.2",
+		"system": "You are a helpful assistant.",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "hello"},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "thinking", "thinking": "Let me think about this."},
+			}},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "t1", "name": "get_weather", "input": map[string]any{"city": "Jakarta"}},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "t1", "content": []any{
+					map[string]any{"type": "text", "text": "3 files"},
+				}},
+			}},
+		},
+		"tools": []any{
+			map[string]any{"name": "get_weather", "input_schema": map[string]any{
+				"type": "object", "properties": map[string]any{"city": map[string]any{"type": "string"}},
+			}},
+		},
+	}
+	e := mustNew(t)
+	got, err := e.CountAnthropicRequest(req)
+	if err != nil {
+		t.Fatalf("CountAnthropicRequest: %v", err)
+	}
+	if got != 93 {
+		t.Errorf("CountAnthropicRequest = %d, want 93", got)
+	}
+}
+
+func TestCountAnthropicRequestPerMessageOverhead(t *testing.T) {
+	e := mustNew(t)
+	one := map[string]any{"messages": []any{
+		map[string]any{"role": "user", "content": "hi"},
+	}}
+	got, err := e.CountAnthropicRequest(one)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 9 { // 8 overhead + 1 for "hi"
+		t.Errorf("1 message = %d, want 9", got)
+	}
+	two := map[string]any{"messages": []any{
+		map[string]any{"role": "user", "content": "hi"},
+		map[string]any{"role": "assistant", "content": "hi"},
+	}}
+	got, err = e.CountAnthropicRequest(two)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 18 { // 2 * (8 + 1)
+		t.Errorf("2 messages = %d, want 18", got)
+	}
+}
+
+// TestCountAnthropicRequestImageFlat pins the flat per-image cost: base64
+// length must never influence the count (images are never tokenized), and
+// both base64 and URL sources bill the same 1600/image.
+func TestCountAnthropicRequestImageFlat(t *testing.T) {
+	e := mustNew(t)
+	short := "aGVsbG8="
+	long := strings.Repeat("QUJD", 4096) // 16KiB of base64
+	for _, tc := range []struct {
+		name   string
+		req    map[string]any
+		images int
+	}{
+		{"short base64", imageRequest("base64", short), 1},
+		{"long base64", imageRequest("base64", long), 1},
+		{"url", imageRequest("url", "https://example.com/pic.png"), 1},
+		{"two images", map[string]any{"messages": []any{
+			map[string]any{"role": "user", "content": []any{
+				imagePart("base64", short),
+				imagePart("base64", short),
+			}},
+		}}, 2},
+	} {
+		got, err := e.CountAnthropicRequest(tc.req)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if want := 8 + tc.images*1600; got != want {
+			t.Errorf("%s: count = %d, want %d", tc.name, got, want)
+		}
+	}
+}
+
+func imageRequest(sourceType, data string) map[string]any {
+	return map[string]any{"messages": []any{
+		map[string]any{"role": "user", "content": []any{imagePart(sourceType, data)}},
+	}}
+}
+
+func imagePart(sourceType, data string) map[string]any {
+	return map[string]any{"type": "image", "source": map[string]any{
+		"type": sourceType, "media_type": "image/png", "data": data,
+	}}
+}
+
+func TestCountAnthropicRequestToolsGolden(t *testing.T) {
+	// tools_minimal / tools_rich / tools_two canonical JSON from
+	// token_ref/reference.py; each request has one empty user message
+	// (8 overhead, 0 content) plus the tool definitions.
+	emptyMsg := []any{map[string]any{"role": "user"}}
+	cases := []struct {
+		name string
+		req  map[string]any
+		want int
+	}{
+		{"no tools", map[string]any{"messages": emptyMsg}, 8},
+		{"tools_minimal", map[string]any{"messages": emptyMsg, "tools": []any{
+			map[string]any{"name": "get_weather", "input_schema": map[string]any{
+				"type": "object", "properties": map[string]any{"city": map[string]any{"type": "string"}},
+			}},
+		}}, 8 + 32},
+		{"tools_rich", map[string]any{"messages": emptyMsg, "tools": []any{
+			map[string]any{
+				"name":        "get_weather",
+				"description": "Get current weather",
+				"input_schema": map[string]any{
+					"type":     "object",
+					"required": []any{"city"},
+					"properties": map[string]any{
+						"city": map[string]any{"description": "City name", "type": "string"},
+						"unit": map[string]any{"enum": []any{"celsius", "fahrenheit"}, "type": "string"},
+					},
+				},
+			},
+		}}, 8 + 75},
+		{"tools_two", map[string]any{"messages": emptyMsg, "tools": []any{
+			map[string]any{
+				"name":        "get_weather",
+				"description": "Get current weather",
+				"input_schema": map[string]any{
+					"type": "object", "properties": map[string]any{"city": map[string]any{"type": "string"}},
+				},
+			},
+			map[string]any{"name": "search_docs", "input_schema": map[string]any{
+				"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string"}},
+			}},
+		}}, 8 + 70},
+	}
+	e := mustNew(t)
+	for _, tc := range cases {
+		got, err := e.CountAnthropicRequest(tc.req)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Errorf("%s: count = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestCountAnthropicRequestToolKeyOrder proves map-key insertion order does
+// not change the count: Go's json.Marshal sorts keys, so the same tool
+// object counted in any construction order is byte-stable.
+func TestCountAnthropicRequestToolKeyOrder(t *testing.T) {
+	e := mustNew(t)
+	base := map[string]any{"messages": []any{map[string]any{"role": "user"}}}
+	a := map[string]any{"messages": base["messages"], "tools": []any{
+		map[string]any{
+			"name":        "get_weather",
+			"description": "Get current weather",
+			"input_schema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"city": map[string]any{"type": "string", "description": "City name"},
+					"unit": map[string]any{"type": "string", "enum": []any{"celsius", "fahrenheit"}},
+				},
+			},
+		},
+	}}
+	b := map[string]any{"messages": base["messages"], "tools": []any{
+		map[string]any{
+			"description": "Get current weather",
+			"input_schema": map[string]any{
+				"properties": map[string]any{
+					"unit": map[string]any{"enum": []any{"celsius", "fahrenheit"}, "type": "string"},
+					"city": map[string]any{"description": "City name", "type": "string"},
+				},
+				"type": "object",
+			},
+			"name": "get_weather",
+		},
+	}}
+	gotA, err := e.CountAnthropicRequest(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotB, err := e.CountAnthropicRequest(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotA != gotB {
+		t.Errorf("key order changed count: %d vs %d", gotA, gotB)
+	}
+}
+
+func TestCountAnthropicRequestErrors(t *testing.T) {
+	e := mustNew(t)
+	doc := map[string]any{"type": "document", "source": map[string]any{
+		"type": "base64", "media_type": "application/pdf", "data": "JVBERi0=",
+	}}
+	cases := []struct {
+		name string
+		req  map[string]any
+	}{
+		{"missing messages", map[string]any{"model": "x"}},
+		{"messages not array", map[string]any{"messages": "hi"}},
+		{"document in system array", map[string]any{
+			"system":   []any{doc},
+			"messages": []any{map[string]any{"role": "user", "content": "hi"}},
+		}},
+		{"document in messages", map[string]any{"messages": []any{
+			map[string]any{"role": "user", "content": []any{doc}},
+		}}},
+		{"document in tool_result", map[string]any{"messages": []any{
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "content": []any{doc}},
+			}},
+		}}},
+	}
+	for _, tc := range cases {
+		if _, err := e.CountAnthropicRequest(tc.req); err == nil {
+			t.Errorf("%s: want error, got nil", tc.name)
+		}
+	}
+}
+
+func TestCountAnthropicRequestContentShapes(t *testing.T) {
+	e := mustNew(t)
+	msg := func(content any) map[string]any {
+		return map[string]any{"messages": []any{map[string]any{"role": "user", "content": content}}}
+	}
+	cases := []struct {
+		name string
+		req  map[string]any
+		want int
+	}{
+		{"nil content", msg(nil), 8},
+		{"empty content", msg(""), 8},
+		{"string content", msg("hello"), 9},
+		{"unknown block JSON fallback", msg([]any{map[string]any{"foo": "bar", "type": "weird"}}), 8 + 13},
+		{"text block", msg([]any{map[string]any{"type": "text", "text": "hello"}}), 9},
+		{"thinking uses thinking field", msg([]any{map[string]any{"type": "thinking", "thinking": "Let me think about this."}}), 8 + 8},
+		{"thinking falls back to text", msg([]any{map[string]any{"type": "thinking", "text": "Let me think about this."}}), 8 + 8},
+		{"tool_use name and input", msg([]any{map[string]any{"type": "tool_use", "name": "get_weather", "input": map[string]any{"city": "Jakarta"}}}), 8 + 2 + 8},
+		{"tool_result string", msg([]any{map[string]any{"type": "tool_result", "content": "3 files"}}), 8 + 2},
+		{"tool_result structured text", msg([]any{map[string]any{"type": "tool_result", "content": []any{
+			map[string]any{"type": "text", "text": "3 files"},
+		}}}), 8 + 2},
+		{"tool_result structured image", msg([]any{map[string]any{"type": "tool_result", "content": []any{
+			map[string]any{"type": "image", "source": map[string]any{"type": "base64", "data": "aGVsbG8="}},
+		}}}), 8 + 1600},
+	}
+	for _, tc := range cases {
+		got, err := e.CountAnthropicRequest(tc.req)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Errorf("%s: count = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestCountAnthropicRequestSystemShapes(t *testing.T) {
+	e := mustNew(t)
+	sysReq := func(system any) map[string]any {
+		return map[string]any{"system": system, "messages": []any{map[string]any{"role": "user", "content": ""}}}
+	}
+	cases := []struct {
+		name   string
+		system any
+		want   int
+	}{
+		{"string", "You are a helpful assistant.", 8 + 8},
+		{"text block array", []any{map[string]any{"type": "text", "text": "You are a helpful assistant."}}, 8 + 8},
+		{"null", nil, 8},
+		{"non-string non-array dropped", 42, 8},
+	}
+	for _, tc := range cases {
+		got, err := e.CountAnthropicRequest(sysReq(tc.system))
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Errorf("%s: count = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestCountAnthropicRequestNonObjectMessage pins that non-object entries in
+// the messages array are skipped (the /v1/messages conversion drops them),
+// matching the one-message overhead arithmetic for the valid entry only.
+func TestCountAnthropicRequestNonObjectMessage(t *testing.T) {
+	e := mustNew(t)
+	req := map[string]any{"messages": []any{
+		map[string]any{"role": "user", "content": "hi"},
+		42,
+		"not an object",
+	}}
+	got, err := e.CountAnthropicRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 9 {
+		t.Errorf("count = %d, want 9 (only the object message counts)", got)
+	}
+}
+
+func TestDeterminism(t *testing.T) {
+	e := mustNew(t)
+	req := map[string]any{
+		"system": "You are a helpful assistant.",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "hello"},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "name": "get_weather", "input": map[string]any{"city": "Jakarta"}},
+			}},
+		},
+		"tools": []any{map[string]any{"name": "get_weather", "input_schema": map[string]any{
+			"type": "object", "properties": map[string]any{"city": map[string]any{"type": "string"}},
+		}}},
+	}
+	first, err := e.CountAnthropicRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 50; i++ {
+		again, err := e.CountAnthropicRequest(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if again != first {
+			t.Fatalf("iteration %d: count = %d, want %d", i, again, first)
+		}
+	}
+}
+
+// TestConcurrentUse runs CountText and CountAnthropicRequest from many
+// goroutines against the shared codec; the -race detector validates the
+// estimator is safe for concurrent use (Count/Encode are read-only).
+func TestConcurrentUse(t *testing.T) {
+	e := mustNew(t)
+	req := map[string]any{
+		"system": "You are a helpful assistant.",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "hello"},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "name": "get_weather", "input": map[string]any{"city": "Jakarta"}},
+			}},
+		},
+		"tools": []any{map[string]any{"name": "get_weather", "input_schema": map[string]any{
+			"type": "object", "properties": map[string]any{"city": map[string]any{"type": "string"}},
+		}}},
+	}
+	var wg sync.WaitGroup
+	for g := 0; g < 16; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				if _, err := e.CountAnthropicRequest(req); err != nil {
+					t.Errorf("CountAnthropicRequest: %v", err)
+					return
+				}
+				if got := e.CountText("hello world"); got != 2 {
+					t.Errorf("CountText = %d, want 2", got)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Implement `POST /v1/messages/count_tokens` as a fully local token estimator for the Anthropic-compatible Messages API.

The endpoint previously returned `501 count_tokens_unsupported`. This change replaces that with a deterministic estimate aligned with FreeBuff's own context-token accounting strategy.

### What changed

- add local `o200k_base` token estimation
- apply FreeBuff's current `1.35` text multiplier
- include `8` tokens of structural overhead per message
- use a flat `1600` estimate per image instead of tokenizing base64
- count system prompts
- count text and thinking blocks
- count tool definitions and input schemas
- count `tool_use`, `server_tool_use`, and `tool_result` content
- conservatively count unknown structured blocks as JSON
- reject document/PDF blocks rather than pretending to support them
- preserve the existing 32 MiB request-body limit
- preserve normal API authentication and model validation

## Why

The endpoint previously returned 501 because the proxy did not bundle a tokenizer and a simple character heuristic would be misleading for client-side context management.

FreeBuff itself now uses a local structured estimator for context budgeting:

- GPT-4o/o200k-style tokenization
- `1.35` multiplier
- `8` tokens per message
- `1600` tokens per image/file/media
- structured tool and tool-result accounting

This implementation follows that same strategy instead of using a `chars / 4` approximation.

## No upstream side effects

Token counting is entirely local.

A `/v1/messages/count_tokens` request does **not**:

- acquire a FreeBuff session
- create a run
- consume account quota
- contact FreeBuff
- contact Anthropic

The API tests explicitly assert zero upstream requests.

## Compatibility

Successful requests return the Anthropic-compatible shape:

```json
{
  "input_tokens": 1234
}
```

The result is intentionally an **estimate**, not a provider-exact Anthropic token count.

Document/PDF blocks are currently rejected because the proxy's `/v1/messages` conversion does not support them either.

## Tokenizer dependency

This adds:

```text
github.com/tiktoken-go/tokenizer v0.8.1
```

The tokenizer is pure Go and keeps the estimator fully offline; no vocabulary is downloaded at runtime.

One known difference from FreeBuff's JavaScript tokenizer is special-token handling. FreeBuff uses `allowedSpecial: "all"`, while the Go tokenizer treats markers such as `<|endoftext|>` as ordinary BPE text. This can conservatively over-count those uncommon marker strings, and the behavior is covered by tests.

The embedded vocabulary also increases the tested Windows binary size by roughly 12–13 MiB. I evaluated alternative pure-Go approaches and an o200k-only fork could reduce part of that increase, but it would require maintaining a private/vendor tokenizer implementation. I kept the upstream dependency to avoid that maintenance burden.

## Manual verification

I also verified the endpoint manually against a local `freebuff-proxy` instance using `curl`.

Observed results:

```text
Indonesian text:
"Saya sedang menguji penghitung token untuk aplikasi ini."
→ {"input_tokens":22}

Short text:
"halo"
→ {"input_tokens":9}

CJK text:
"你好世界，这是一个测试。"
→ {"input_tokens":16}

Prompt + tool definition:
"What is the weather?" + get_weather tool schema
→ {"input_tokens":54}
```

The tests demonstrate that the endpoint returns structured local estimates for multilingual text and tool definitions instead of the previous `501 count_tokens_unsupported`.

<!-- After opening the PR, drag/drop the screenshot into the GitHub PR description,
     then replace the placeholder below with the generated GitHub image URL. -->

![Manual curl verification]
<img width="1540" height="298" alt="Manual curl verification proof" src="https://github.com/user-attachments/assets/bc26a9d2-9c08-4b61-8d3c-47637b1b2190" />

## Validation

Completed successfully:

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- `golangci-lint run`
- `git diff --check`
- manual `/v1/messages/count_tokens` testing

Coverage includes:

- English and Indonesian text
- CJK
- emoji / Unicode
- code
- system prompts
- multi-message conversations
- tools and input schemas
- tool calls and tool results
- thinking blocks
- images and base64-size invariance
- malformed requests
- authentication
- model validation
- deterministic repeated counts
- concurrent use / race detection
- zero upstream requests
