### PR TITLE
fix(anti-ban): align wire behavior with official CLI — P1 #103-#115 + P2 #116-#126

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,8 +60,8 @@ TRANSIENT_RETRIES=1
 # the request rides the old session while the refresh runs in the
 # background; the next request gets the fresh instance.
 #SESSION_RE_ADMIT_LEAD=60s
-# Reuse the last successful session state (skip heartbeat GETs) within this
-# window after a successful admission/poll.
+# Reuse the last successful session state (skip redundant session poll GETs)
+# within this window after a successful admission/poll.
 #SESSION_PROBE_CACHE_TTL=15s
 # Bound concurrent in-flight session admissions (wait-or-503) globally and
 # per model — a burst of requests cannot hammer the upstream create.

--- a/.env.example
+++ b/.env.example
@@ -85,10 +85,13 @@ TRANSIENT_RETRIES=1
 # accounts get 402 "Out of credits". Do not change this.
 COST_MODE=free
 
-# Optional FreeBuff account id (CLI parity): sent on every chat call as
-# x-freebuff-acting-user-id — the real CLI sends it and the free-mode gate
-# expects it. Leave empty to omit the header.
-#USER_ID=
+# Optional FreeBuff account id: sent on every chat call as
+# x-freebuff-acting-user-id. BAN RISK: the CLI sends the account's OWN id
+# (derived from GET /api/v1/me), and the server honors the header only for
+# the FreeBuff Web service account — any value other than the token's own
+# account id impersonates another user. Only safe value: the token's own
+# account id. (Pre-rename name USER_ID still works.) Leave empty to omit.
+#ACTING_USER_ID=
 
 # ── Daily cap ────────────────────────────────────────────────────────────
 # Per-token successful chats per 24h. 0 = unlimited — safe: the proxy locks

--- a/.env.full-example
+++ b/.env.full-example
@@ -36,10 +36,13 @@ MAX_MESSAGES_PER_DAY=0
 # Browser TLS stealth fingerprint (auto, chrome126, firefox128, safari18, edge126)
 TLS_FINGERPRINT=auto
 
-# Optional FreeBuff account id (CLI parity): sent on every chat call as
-# x-freebuff-acting-user-id — the real CLI sends it and the free-mode gate
-# expects it. Empty = header omitted.
-#USER_ID=
+# Optional FreeBuff account id: sent on every chat call as
+# x-freebuff-acting-user-id. BAN RISK: only the token's own account id is
+# safe (the CLI derives it from /api/v1/me; the server honors the header
+# only for the FreeBuff Web service account) — any other value
+# impersonates another user. (Pre-rename name USER_ID still works.)
+# Empty = header omitted.
+#ACTING_USER_ID=
 
 # Persist session state across restarts (resume unexpired sessions instead of
 # burning a new daily slot). Opt-in.

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ All keys can be set via environment variables or the JSON config file passed to 
 | `SESSION_PERSIST` | `false` | Persist session state AND active agent runs to disk so a restart resumes them instead of re-creating (new daily slot / re-START) |
 | `SESSION_STATE_FILE` | `.freebuff-session-state.json` | Path of the session state file (used when `SESSION_PERSIST=true`; token-keyed, `0600`) |
 | `SESSION_RE_ADMIT_LEAD` | `60s` | Re-admit a session pre-emptively when less than this remains: the request rides the old session while the refresh runs in the background |
-| `SESSION_PROBE_CACHE_TTL` | `15s` | Reuse the last successful session state (skip redundant heartbeat GETs) within this window |
+| `SESSION_PROBE_CACHE_TTL` | `15s` | Reuse the last successful session state (skip redundant session poll GETs) within this window |
 | `SESSION_CREATE_MAX_PARALLEL_GLOBAL` | `128` | Cap on concurrent in-flight session admissions (wait-or-503) |
 | `SESSION_CREATE_MAX_PARALLEL_PER_MODEL` | `32` | Per-model cap on concurrent in-flight session admissions |
 | `RUN_FINISH_QUEUE_SIZE` | `64` | Bounded deferred-FINISH worker queue for rotated/drained runs |

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ All keys can be set via environment variables or the JSON config file passed to 
 | `SESSION_CALL_TIMEOUT` | `30s` | Session call timeout |
 | `REGISTRY_REFRESH` | `6h` | Model catalog refresh interval |
 | `COST_MODE` | `free` | `free` (free-tier) or paid billing mode |
-| `USER_ID` | `""` | Optional FreeBuff account id; sent on every chat call as `x-freebuff-acting-user-id` (the real CLI sends it and the free-mode gate expects it). Empty = header omitted |
+| `ACTING_USER_ID` | `""` | Optional FreeBuff account id; sent on every chat call as `x-freebuff-acting-user-id`. BAN RISK: only the token's own account id is safe (the CLI derives it from `GET /api/v1/me`; the server honors the header only for the FreeBuff Web service account) — any other value impersonates another user. Pre-rename name `USER_ID` still works. Empty = header omitted |
 | `TLS_FINGERPRINT` | `auto` | `auto`, `chrome120`, `chrome126`, `safari17`, `safari18`, `firefox120`, `firefox128`, `edge126`, `random` |
 | `DEBUG_DUMP` | `false` | Persist redacted traffic dumps to `./dump/` (mode 0600) |
 | `LOG_FILE` | `""` | Append log lines to a file (e.g. `./logs/proxy.log`) |

--- a/cmd/freebuff-proxy/main.go
+++ b/cmd/freebuff-proxy/main.go
@@ -237,16 +237,14 @@ func main() {
 	// Prewarm + the 60s maintain loop run until ctx is canceled (shutdown).
 	p.Start(ctx)
 
-	// Egress probing: report the country/IP the direct outbound path appears
-	// to come from (ban-avoidance diagnostics; the upstream hard-blocks
-	// proxy/VPN egress, so the direct route is the only outbound path).
-	// Results are cached and refreshed every 10 minutes; failures are
-	// logged and cached with Err set (fail-open).
-	egressCache := egress.NewCache()
-	if paths := egressPaths(); len(paths) > 0 {
-		go egress.RunLoop(ctx, logger, egressCache, paths, egress.ProbeTimeout, egress.DefaultTTL)
-		logger.Info("egress probes started", "paths", len(paths))
-	}
+	// Egress probing is deliberately NOT wired into startup (#123): the
+	// official CLI never talks to cloudflare.com (the probe target), and
+	// the background loop's risk-engine feed has no consumer (Score()
+	// reads only upstream privacy signals + ip-cap ratios, never the
+	// probe's IP/country). The probe still runs on demand — `-doctor`
+	// re-probes with its own cache (doctor.go egressRegionRow) — so
+	// operators keep the "Egress region" readout without an extra
+	// recurring request the CLI would never make.
 
 	// Issue #62: the dashboard login wizard drives the same headless OAuth
 	// flow as the CLI against the proxy's own transport/stealth wiring; the
@@ -287,8 +285,12 @@ func main() {
 		"log_level", level.String(),
 		"verbose", *verbose,
 	)
-	if cfg.UserID != "" {
-		logger.Info("acting user id set — x-freebuff-acting-user-id will be sent on chat calls", "user_id", cfg.UserID)
+	if cfg.ActingUserID != "" {
+		// #126: the header is only safe with the token's OWN account id (the
+		// CLI derives it from /api/v1/me; the server honors it only for the
+		// FreeBuff Web service account) — any other value impersonates a
+		// foreign user and can flag the account.
+		logger.Info("acting user id set — x-freebuff-acting-user-id will be sent on chat calls (only safe with the token's own account id; any other value impersonates another user)", "acting_user_id", cfg.ActingUserID)
 	}
 	// /admin/reload and the admin dashboard are open in default deployments
 	// (no API_KEYS, or bridge mode): warn loudly so operators can decide
@@ -451,10 +453,13 @@ func ignoredExeAdjacentEnv(cwd, exePath string) string {
 	return p
 }
 
-// egressPaths returns the outbound probe paths: the direct connection only
-// (proxy routes were removed — the upstream hard-blocks proxy/VPN egress,
-// so any proxied path is pure ban risk). The risk engine's geo feed and the
-// doctor's "Egress region" row read results back from the shared cache.
+// egressPaths returns the outbound probe paths for on-demand probing: the
+// direct connection only (proxy routes were removed — the upstream
+// hard-blocks proxy/VPN egress, so any proxied path is pure ban risk).
+// The background RunLoop is no longer wired into startup (#123 — the CLI
+// never talks to cloudflare.com and the risk-engine geo feed has no
+// reader); `-doctor` re-probes with its own cache, and this stays as the
+// canonical path list for that on-demand use / future opt-in.
 func egressPaths() []egress.Path {
 	return []egress.Path{{Key: "direct", Dialer: egress.DirectDialer(egress.ProbeTimeout)}}
 }

--- a/cmd/freebuff-proxy/refresh_token.go
+++ b/cmd/freebuff-proxy/refresh_token.go
@@ -172,7 +172,9 @@ func runTokenRefresh(configPath string, index int, autoYes bool) {
 		case <-ctx.Done():
 			fmt.Fprintln(os.Stderr, "freebuff-proxy: login timed out")
 			os.Exit(1)
-		case <-time.After(3 * time.Second):
+		// 5s matches the CLI's pollLoginStatus intervalMs=5000 (#125; the
+		// upstream const loginPollInterval is the same value).
+		case <-time.After(5 * time.Second):
 		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,17 +24,27 @@ import (
 
 // Config is the fully-resolved, validated runtime configuration.
 type Config struct {
-	ListenAddr            string
-	UpstreamBaseURL       string
-	AuthTokens            []string
-	RotationInterval      time.Duration
-	RequestTimeout        time.Duration
-	SessionCallTimeout    time.Duration
-	APIKeys               []string
-	AdminToken            string // bearer token required for POST /admin/reload ("" = unauthenticated in default deployments)
-	HTTP2Upstream         bool   // true = negotiate HTTP/2 with the upstream so the ALPN matches real browsers (HTTP2_UPSTREAM); false forces HTTP/1.1 (#51)
-	CostMode              string // "" (omit) or "free"; A/B pending, PRD §8
-	UserID                string // optional FreeBuff account id sent as x-freebuff-acting-user-id (CLI parity; empty = omitted)
+	ListenAddr         string
+	UpstreamBaseURL    string
+	AuthTokens         []string
+	RotationInterval   time.Duration
+	RequestTimeout     time.Duration
+	SessionCallTimeout time.Duration
+	APIKeys            []string
+	AdminToken         string // bearer token required for POST /admin/reload ("" = unauthenticated in default deployments)
+	HTTP2Upstream      bool   // true = negotiate HTTP/2 with the upstream so the ALPN matches real browsers (HTTP2_UPSTREAM); false forces HTTP/1.1 (#51)
+	CostMode           string // "" (omit) or "free"; A/B pending, PRD §8
+	// ActingUserID is the optional FreeBuff account id sent as
+	// x-freebuff-acting-user-id (ACTING_USER_ID; empty = header omitted).
+	// BAN RISK: the official CLI sends the account's OWN id here, derived
+	// from GET /api/v1/me (sdk/src/run.ts:649-658), and the server honors
+	// the header only for the FreeBuff Web service account
+	// (common/src/constants/freebuff-models.ts:1180-1183). Any value other
+	// than the token's own account id impersonates another user — a flag.
+	// The only safe value is the token's own account id. (True CLI parity —
+	// auto-deriving each token's own id once via GET /api/v1/me — is
+	// deferred; see the gap analysis item 24.)
+	ActingUserID          string
 	TLSFingerprint        string // "" (plain Go transport) | chrome120 | chrome126 | safari17 | safari18 | firefox120 | firefox128 | edge126 | random | auto
 	RegistryRefresh       time.Duration
 	DebugDump             bool
@@ -157,45 +167,48 @@ type rawConfig struct {
 	// explicitly-empty AUTH_TOKENS means the operator chose bridge mode, so
 	// CLI auto-discovery must not refill it (runtime mode switch persists
 	// "AUTH_TOKENS=" to .env and relies on this).
-	AuthTokensSet                    bool     `json:"-"`
-	RotationInterval                 string   `json:"ROTATION_INTERVAL"`
-	RequestTimeout                   string   `json:"REQUEST_TIMEOUT"`
-	SessionCallTimeout               string   `json:"SESSION_CALL_TIMEOUT"`
-	APIKeys                          []string `json:"API_KEYS"`
-	AdminToken                       string   `json:"ADMIN_TOKEN"`
-	CostMode                         string   `json:"COST_MODE"`
-	UserID                           string   `json:"USER_ID"`
-	TLSFingerprint                   string   `json:"TLS_FINGERPRINT"`
-	RegistryRefresh                  string   `json:"REGISTRY_REFRESH"`
-	DebugDump                        bool     `json:"DEBUG_DUMP"`
-	LogFile                          string   `json:"LOG_FILE"`
-	LogLevel                         string   `json:"LOG_LEVEL"`
-	MaxMessagesPerDay                *int     `json:"MAX_MESSAGES_PER_DAY"`
-	IdleRotationTimeout              string   `json:"IDLE_ROTATION_TIMEOUT"`
-	SafeMode                         bool     `json:"SAFE_MODE"`
-	HybridMode                       bool     `json:"HYBRID_MODE"`
-	ModelsHideUnavailable            bool     `json:"MODELS_HIDE_UNAVAILABLE"`
-	CORSAllowedOrigin                string   `json:"CORS_ALLOWED_ORIGIN"`
-	RequestJitter                    string   `json:"REQUEST_JITTER"`
-	CLIVersion                       string   `json:"CLI_VERSION"`
-	ModelAliases                     string   `json:"MODEL_ALIASES"`
-	TransientRetries                 *int     `json:"TRANSIENT_RETRIES"`
-	SessionPersist                   bool     `json:"SESSION_PERSIST"`
-	SessionStateFile                 string   `json:"SESSION_STATE_FILE"`
-	HTTP2Upstream                    bool     `json:"HTTP2_UPSTREAM"`
-	SessionCreateMaxParallelGlobal   *int     `json:"SESSION_CREATE_MAX_PARALLEL_GLOBAL"`
-	SessionCreateMaxParallelPerModel *int     `json:"SESSION_CREATE_MAX_PARALLEL_PER_MODEL"`
-	RunFinishQueueSize               *int     `json:"RUN_FINISH_QUEUE_SIZE"`
-	RunFinishInlineTimeout           string   `json:"RUN_FINISH_INLINE_TIMEOUT"`
-	RunsDrainQueueCap                *int     `json:"RUNS_DRAIN_QUEUE_CAP"`
-	RunsDrainTTL                     string   `json:"RUNS_DRAIN_TTL"`
-	SessionReAdmitLead               string   `json:"SESSION_RE_ADMIT_LEAD"`
-	SessionProbeCacheTTL             string   `json:"SESSION_PROBE_CACHE_TTL"`
-	WebhookURL                       string   `json:"WEBHOOK_URL"`
-	FallbackAfter                    string   `json:"FALLBACK_AFTER_MS"`
-	FallbackModels                   string   `json:"FALLBACK_MODEL"`
-	AdoptCLISession                  bool     `json:"ADOPT_CLI_SESSION"`
-	WaitingRoomChain                 bool     `json:"WAITING_ROOM_CHAIN"`
+	AuthTokensSet      bool     `json:"-"`
+	RotationInterval   string   `json:"ROTATION_INTERVAL"`
+	RequestTimeout     string   `json:"REQUEST_TIMEOUT"`
+	SessionCallTimeout string   `json:"SESSION_CALL_TIMEOUT"`
+	APIKeys            []string `json:"API_KEYS"`
+	AdminToken         string   `json:"ADMIN_TOKEN"`
+	CostMode           string   `json:"COST_MODE"`
+	ActingUserID       string   `json:"ACTING_USER_ID"`
+	// LegacyActingUserID is the pre-rename JSON key (USER_ID) — merged at
+	// the end of Load when no ACTING_USER_ID source set a value (#126).
+	LegacyActingUserID               string `json:"USER_ID"`
+	TLSFingerprint                   string `json:"TLS_FINGERPRINT"`
+	RegistryRefresh                  string `json:"REGISTRY_REFRESH"`
+	DebugDump                        bool   `json:"DEBUG_DUMP"`
+	LogFile                          string `json:"LOG_FILE"`
+	LogLevel                         string `json:"LOG_LEVEL"`
+	MaxMessagesPerDay                *int   `json:"MAX_MESSAGES_PER_DAY"`
+	IdleRotationTimeout              string `json:"IDLE_ROTATION_TIMEOUT"`
+	SafeMode                         bool   `json:"SAFE_MODE"`
+	HybridMode                       bool   `json:"HYBRID_MODE"`
+	ModelsHideUnavailable            bool   `json:"MODELS_HIDE_UNAVAILABLE"`
+	CORSAllowedOrigin                string `json:"CORS_ALLOWED_ORIGIN"`
+	RequestJitter                    string `json:"REQUEST_JITTER"`
+	CLIVersion                       string `json:"CLI_VERSION"`
+	ModelAliases                     string `json:"MODEL_ALIASES"`
+	TransientRetries                 *int   `json:"TRANSIENT_RETRIES"`
+	SessionPersist                   bool   `json:"SESSION_PERSIST"`
+	SessionStateFile                 string `json:"SESSION_STATE_FILE"`
+	HTTP2Upstream                    bool   `json:"HTTP2_UPSTREAM"`
+	SessionCreateMaxParallelGlobal   *int   `json:"SESSION_CREATE_MAX_PARALLEL_GLOBAL"`
+	SessionCreateMaxParallelPerModel *int   `json:"SESSION_CREATE_MAX_PARALLEL_PER_MODEL"`
+	RunFinishQueueSize               *int   `json:"RUN_FINISH_QUEUE_SIZE"`
+	RunFinishInlineTimeout           string `json:"RUN_FINISH_INLINE_TIMEOUT"`
+	RunsDrainQueueCap                *int   `json:"RUNS_DRAIN_QUEUE_CAP"`
+	RunsDrainTTL                     string `json:"RUNS_DRAIN_TTL"`
+	SessionReAdmitLead               string `json:"SESSION_RE_ADMIT_LEAD"`
+	SessionProbeCacheTTL             string `json:"SESSION_PROBE_CACHE_TTL"`
+	WebhookURL                       string `json:"WEBHOOK_URL"`
+	FallbackAfter                    string `json:"FALLBACK_AFTER_MS"`
+	FallbackModels                   string `json:"FALLBACK_MODEL"`
+	AdoptCLISession                  bool   `json:"ADOPT_CLI_SESSION"`
+	WaitingRoomChain                 bool   `json:"WAITING_ROOM_CHAIN"`
 }
 
 func defaultRawConfig() rawConfig {
@@ -351,7 +364,13 @@ func Load(configPath string) (Config, error) {
 	overrideCSV(&raw.APIKeys, "API_KEYS")
 	overrideString(&raw.AdminToken, "ADMIN_TOKEN")
 	overrideString(&raw.CostMode, "COST_MODE")
-	overrideString(&raw.UserID, "USER_ID")
+	overrideString(&raw.ActingUserID, "ACTING_USER_ID")
+	// Backward-compat alias (#126): the pre-rename USER_ID knob still works
+	// when the new name is unset/empty (an operator .env keeps sending the
+	// header after upgrade). ACTING_USER_ID always wins when both are set.
+	if raw.ActingUserID == "" {
+		overrideString(&raw.ActingUserID, "USER_ID")
+	}
 	overrideString(&raw.TLSFingerprint, "TLS_FINGERPRINT")
 	overrideString(&raw.RegistryRefresh, "REGISTRY_REFRESH")
 	overrideBool(&raw.DebugDump, "DEBUG_DUMP")
@@ -547,6 +566,13 @@ func Load(configPath string) (Config, error) {
 		fallbackModels = defaultFallbackModels()
 	}
 
+	// Backward-compat (#126): a JSON config carrying the pre-rename USER_ID
+	// key still works when no ACTING_USER_ID source (env/.env/JSON) set a
+	// value. Weakest source — env and .env override it via the aliases above.
+	if raw.ActingUserID == "" {
+		raw.ActingUserID = raw.LegacyActingUserID
+	}
+
 	cfg := Config{
 		ListenAddr:                       strings.TrimSpace(raw.ListenAddr),
 		UpstreamBaseURL:                  upstreamBaseURL,
@@ -558,7 +584,7 @@ func Load(configPath string) (Config, error) {
 		AdminToken:                       strings.TrimSpace(raw.AdminToken),
 		HTTP2Upstream:                    raw.HTTP2Upstream,
 		CostMode:                         strings.TrimSpace(raw.CostMode),
-		UserID:                           strings.TrimSpace(raw.UserID),
+		ActingUserID:                     strings.TrimSpace(raw.ActingUserID),
 		TLSFingerprint:                   strings.TrimSpace(raw.TLSFingerprint),
 		RegistryRefresh:                  registryRefresh,
 		DebugDump:                        raw.DebugDump,
@@ -868,7 +894,10 @@ func applyDotenv(raw *rawConfig, path string) error {
 	overrideCSVFrom(&raw.APIKeys, get, "API_KEYS")
 	overrideStringFrom(&raw.AdminToken, get, "ADMIN_TOKEN")
 	overrideStringFrom(&raw.CostMode, get, "COST_MODE")
-	overrideStringFrom(&raw.UserID, get, "USER_ID")
+	overrideStringFrom(&raw.ActingUserID, get, "ACTING_USER_ID")
+	if raw.ActingUserID == "" {
+		overrideStringFrom(&raw.ActingUserID, get, "USER_ID")
+	}
 	overrideStringFrom(&raw.TLSFingerprint, get, "TLS_FINGERPRINT")
 	overrideStringFrom(&raw.RegistryRefresh, get, "REGISTRY_REFRESH")
 	overrideBoolFrom(&raw.DebugDump, get, "DEBUG_DUMP")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,7 +80,7 @@ type Config struct {
 	SessionReAdmitLead time.Duration
 	// SessionProbeCacheTTL is how long the last successful session state is
 	// reused before a fresh upstream poll (issue #60, SESSION_PROBE_CACHE_TTL
-	// default 15s): heartbeat GETs within the TTL are skipped.
+	// default 15s): session poll GETs within the TTL are skipped.
 	SessionProbeCacheTTL time.Duration
 	// WebhookURL fires best-effort alert POSTs when the token pool is
 	// exhausted or a token is classified banned (issue #48, WEBHOOK_URL;

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,7 +16,7 @@ import (
 // them all first so machine-level env can never leak into assertions.
 var envKeys = []string{
 	"LISTEN_ADDR", "UPSTREAM_BASE_URL", "AUTH_TOKENS", "ROTATION_INTERVAL",
-	"REQUEST_TIMEOUT", "SESSION_CALL_TIMEOUT", "API_KEYS", "COST_MODE", "USER_ID",
+	"REQUEST_TIMEOUT", "SESSION_CALL_TIMEOUT", "API_KEYS", "COST_MODE", "ACTING_USER_ID", "USER_ID",
 	"TLS_FINGERPRINT", "REGISTRY_REFRESH", "DEBUG_DUMP", "LOG_FILE", "LOG_LEVEL",
 	"MAX_MESSAGES_PER_DAY", "IDLE_ROTATION_TIMEOUT", "SAFE_MODE", "HYBRID_MODE",
 	"MODELS_HIDE_UNAVAILABLE", "CORS_ALLOWED_ORIGIN", "REQUEST_JITTER", "CLI_VERSION", "MODEL_ALIASES",
@@ -1769,11 +1769,13 @@ func TestReadDotenvQuotingAndComments(t *testing.T) {
 	}
 }
 
-// ── Wave 1 issue tests (#79: USER_ID) ────────────────────────────────────
+// ── Wave 1 issue tests (#79: ACTING_USER_ID) ─────────────────────────────
 
-// TestUserID verifies USER_ID resolves from the environment, the .env file,
-// and the JSON config (optional key; empty default), issue #79.
-func TestUserID(t *testing.T) {
+// TestActingUserID verifies ACTING_USER_ID resolves from the environment,
+// the .env file, and the JSON config (optional key; empty default), issue
+// #79, and that the pre-rename USER_ID knob still works as a backward-compat
+// alias (#126; the new name always wins when both are set).
+func TestActingUserID(t *testing.T) {
 	t.Run("default empty", func(t *testing.T) {
 		clearEnv(t)
 		t.Setenv("AUTH_TOKENS", "tok-1")
@@ -1781,46 +1783,97 @@ func TestUserID(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if cfg.UserID != "" {
-			t.Errorf("UserID = %q, want empty default", cfg.UserID)
+		if cfg.ActingUserID != "" {
+			t.Errorf("ActingUserID = %q, want empty default", cfg.ActingUserID)
 		}
 	})
 	t.Run("env override", func(t *testing.T) {
 		clearEnv(t)
 		t.Setenv("AUTH_TOKENS", "tok-1")
-		t.Setenv("USER_ID", "user-abc")
+		t.Setenv("ACTING_USER_ID", "user-abc")
 		cfg, err := Load("")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if cfg.UserID != "user-abc" {
-			t.Errorf("UserID = %q, want user-abc", cfg.UserID)
+		if cfg.ActingUserID != "user-abc" {
+			t.Errorf("ActingUserID = %q, want user-abc", cfg.ActingUserID)
+		}
+	})
+	t.Run("env legacy alias", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("AUTH_TOKENS", "tok-1")
+		t.Setenv("USER_ID", "user-legacy")
+		cfg, err := Load("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.ActingUserID != "user-legacy" {
+			t.Errorf("ActingUserID = %q, want user-legacy (USER_ID alias)", cfg.ActingUserID)
+		}
+	})
+	t.Run("new name wins over legacy", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("AUTH_TOKENS", "tok-1")
+		t.Setenv("ACTING_USER_ID", "user-new")
+		t.Setenv("USER_ID", "user-legacy")
+		cfg, err := Load("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.ActingUserID != "user-new" {
+			t.Errorf("ActingUserID = %q, want user-new (ACTING_USER_ID wins)", cfg.ActingUserID)
 		}
 	})
 	t.Run("dotenv", func(t *testing.T) {
 		clearEnv(t)
-		if err := os.WriteFile(".env", []byte("AUTH_TOKENS=tok-1\nUSER_ID=user-dotenv\n"), 0o644); err != nil {
+		if err := os.WriteFile(".env", []byte("AUTH_TOKENS=tok-1\nACTING_USER_ID=user-dotenv\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 		cfg, err := Load("")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if cfg.UserID != "user-dotenv" {
-			t.Errorf("UserID = %q, want user-dotenv (from .env)", cfg.UserID)
+		if cfg.ActingUserID != "user-dotenv" {
+			t.Errorf("ActingUserID = %q, want user-dotenv (from .env)", cfg.ActingUserID)
+		}
+	})
+	t.Run("dotenv legacy alias", func(t *testing.T) {
+		clearEnv(t)
+		if err := os.WriteFile(".env", []byte("AUTH_TOKENS=tok-1\nUSER_ID=user-dotenv-legacy\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := Load("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.ActingUserID != "user-dotenv-legacy" {
+			t.Errorf("ActingUserID = %q, want user-dotenv-legacy (USER_ID alias in .env)", cfg.ActingUserID)
 		}
 	})
 	t.Run("JSON config", func(t *testing.T) {
 		clearEnv(t)
-		if err := os.WriteFile("cfg.json", []byte(`{"AUTH_TOKENS":["tok-1"],"USER_ID":"user-json"}`), 0o644); err != nil {
+		if err := os.WriteFile("cfg.json", []byte(`{"AUTH_TOKENS":["tok-1"],"ACTING_USER_ID":"user-json"}`), 0o644); err != nil {
 			t.Fatal(err)
 		}
 		cfg, err := Load("cfg.json")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if cfg.UserID != "user-json" {
-			t.Errorf("UserID = %q, want user-json (from JSON config)", cfg.UserID)
+		if cfg.ActingUserID != "user-json" {
+			t.Errorf("ActingUserID = %q, want user-json (from JSON config)", cfg.ActingUserID)
+		}
+	})
+	t.Run("JSON legacy key", func(t *testing.T) {
+		clearEnv(t)
+		if err := os.WriteFile("cfg.json", []byte(`{"AUTH_TOKENS":["tok-1"],"USER_ID":"user-json-legacy"}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := Load("cfg.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.ActingUserID != "user-json-legacy" {
+			t.Errorf("ActingUserID = %q, want user-json-legacy (legacy USER_ID JSON key)", cfg.ActingUserID)
 		}
 	})
 }

--- a/internal/convert/convert.go
+++ b/internal/convert/convert.go
@@ -102,10 +102,11 @@ func ExtractReasoningEffort(payload map[string]any) string {
 }
 
 // ---------------------------------------------------------------------------
-// Reasoning effort normalization (issue #65 clamp + #101 DeepSeek thinking).
+// Reasoning effort normalization (issue #65 clamp + #111 plain wire field).
 // Ported from freebuff/common/src/constants/reasoning-effort.ts
-// (clampReasoningEffort) and codebuff-fork/web/src/llm-api/
-// deepseek-request-body.ts (toDeepSeekReasoningEffort / thinking block).
+// (clampReasoningEffort). The DeepSeek thinking translation is server-side
+// (codebuff-fork/web/src/llm-api/deepseek-request-body.ts), so the proxy
+// never emits a thinking block — plain reasoning_effort goes on the wire.
 // ---------------------------------------------------------------------------
 
 // reasoningLadder is the one reasoning-effort vocabulary, strictly ascending.
@@ -117,16 +118,18 @@ var reasoningLadder = [...]string{"minimal", "low", "medium", "high", "xhigh", "
 const defaultReasoningEffort = "high"
 
 // modelReasoningEfforts is the per-model effort allowance, mirroring
-// freebuff2api-workers/worker.js MODEL_EFFORTS and freebuff-models.ts:
-// deepseek-v4-flash exposes [low, high, max] (no medium), deepseek-v4-pro
-// [high, max], gpt-5.6-luna low..max, muse-spark low..xhigh. Models absent
-// from the table get the full ladder (no clamping). The table is refreshable
-// at runtime via SetModelEffortLookup.
+// freebuff-models.ts (08/13 catalog): deepseek-v4-flash AND deepseek-v4-pro
+// expose [low, high, max] (Pro gained low on 08/13; medium intentionally
+// absent — rewritten to high, see normalizeReasoning), gpt-5.6-luna
+// EFFORTS_THROUGH_MAX low..max (xhigh included), muse-spark
+// EFFORTS_THROUGH_XHIGH minimal..xhigh. Models absent from the table get the
+// full ladder (no clamping). The table is refreshable at runtime via
+// SetModelEffortLookup.
 var modelReasoningEfforts = map[string][]string{
 	"deepseek/deepseek-v4-flash":      {"low", "high", "max"},
-	"deepseek/deepseek-v4-pro":        {"high", "max"},
-	"openai/gpt-5.6-luna":             {"low", "medium", "high", "max"},
-	"meta/muse-spark-1.2-contributor": {"low", "medium", "high", "xhigh"},
+	"deepseek/deepseek-v4-pro":        {"low", "high", "max"},
+	"openai/gpt-5.6-luna":             {"low", "medium", "high", "xhigh", "max"},
+	"meta/muse-spark-1.2-contributor": {"minimal", "low", "medium", "high", "xhigh"},
 }
 
 // modelEffortLookup, when set, overrides modelReasoningEfforts for the model
@@ -208,19 +211,10 @@ func clampReasoningEffort(requested string, allowed []string, fallback string) s
 	return lowest
 }
 
-// toDeepSeekReasoningEffort maps an effort onto the DeepSeek vocabulary:
-// max/xhigh → "max", everything else → "high" (codebuff-fork
-// toDeepSeekReasoningEffort).
-func toDeepSeekReasoningEffort(effort string) string {
-	if effort == "max" || effort == "xhigh" {
-		return "max"
-	}
-	return "high"
-}
-
-// isDeepSeekModel reports whether the route is one of the DeepSeek V4 models
-// that speak the thinking block and accept prompt-cache hints. Tolerates
-// both the registry's full ids and bare model ids.
+// isDeepSeekModel reports whether the route is one of the DeepSeek V4 models.
+// DeepSeek routes accept prompt-cache hints (#84) and rewrite requested
+// "medium" to "high" (#112). Tolerates both the registry's full ids and bare
+// model ids.
 func isDeepSeekModel(model string) bool {
 	return strings.HasSuffix(model, "deepseek-v4-flash") || strings.HasSuffix(model, "deepseek-v4-pro")
 }
@@ -228,14 +222,14 @@ func isDeepSeekModel(model string) bool {
 // normalizeReasoning rewrites the outbound reasoning_effort for the target
 // model:
 //
-//   - DeepSeek models: reasoning_effort is translated into the thinking block
-//     ({type: enabled|disabled, reasoning_effort: high|max}) per issue #101
-//     (codebuff-fork buildDeepSeekRequestBody), with the effort first clamped
-//     to the model's allowance per issue #65.
-//   - Other models: reasoning_effort is clamped to the model's allowed rungs
-//     (down-nearest, never rejected; unknown efforts fall back to "high").
+//   - reasoning_effort is always sent PLAIN, clamped to the model's allowed
+//     rungs (down-nearest, never rejected; unknown efforts fall back to
+//     "high"). The DeepSeek thinking translation is server-side per issue
+//     #111 — the proxy never emits a thinking block.
+//   - "medium" on a DeepSeek route rewrites to "high" first (CLI
+//     resolveFreebuffReasoningEffort: medium → high on Flash/Pro, #112).
 //   - reasoning.enabled === false or thinking.type "disabled" suppresses the
-//     effort entirely (DeepSeek: thinking {type: "disabled"}).
+//     effort entirely (no reasoning_effort, no thinking field).
 func normalizeReasoning(payload, out map[string]any) {
 	model, _ := out["model"].(string)
 	eff := ""
@@ -264,23 +258,20 @@ func normalizeReasoning(payload, out map[string]any) {
 
 	switch {
 	case disabled:
-		if isDeepSeekModel(model) {
-			out["thinking"] = map[string]any{"type": "disabled"}
-		}
 		delete(out, "reasoning_effort")
 	case eff == "" || eff == "none" || eff == "disabled":
 		// No effort requested: leave the body untouched.
 	default:
-		clamped := clampReasoningEffort(eff, effortsForModel(model), defaultReasoningEffort)
-		if isDeepSeekModel(model) {
-			out["thinking"] = map[string]any{
-				"type":             "enabled",
-				"reasoning_effort": toDeepSeekReasoningEffort(clamped),
-			}
-			delete(out, "reasoning_effort")
+		var clamped string
+		if isDeepSeekModel(model) && eff == "medium" {
+			// CLI resolveFreebuffReasoningEffort: medium is intentionally
+			// absent from the DeepSeek ladders and rewrites to high — never
+			// down to low (the generic clamp would say low).
+			clamped = "high"
 		} else {
-			out["reasoning_effort"] = clamped
+			clamped = clampReasoningEffort(eff, effortsForModel(model), defaultReasoningEffort)
 		}
+		out["reasoning_effort"] = clamped
 	}
 }
 

--- a/internal/convert/convert_test.go
+++ b/internal/convert/convert_test.go
@@ -948,8 +948,9 @@ func TestExtractReasoningEffort(t *testing.T) {
 }
 
 func TestNormalizeRequestReasoningEffort(t *testing.T) {
-	// DeepSeek models (#101): nested reasoning.effort "max" is clamped (#65)
-	// and translated into the thinking block, replacing reasoning_effort.
+	// DeepSeek models (#111): nested reasoning.effort "max" is clamped (#65)
+	// and sent as PLAIN reasoning_effort — no client-side thinking block; the
+	// DeepSeek thinking translation is server-side.
 	body := map[string]any{
 		"model":     "deepseek/deepseek-v4-flash",
 		"messages":  []any{map[string]any{"role": "user", "content": "hello"}},
@@ -960,18 +961,11 @@ func TestNormalizeRequestReasoningEffort(t *testing.T) {
 		t.Fatalf("NormalizeRequest: %v", err)
 	}
 	got := decode(t, out)
-	if _, ok := got["reasoning_effort"]; ok {
-		t.Errorf("reasoning_effort kept for deepseek model: %v", got["reasoning_effort"])
+	if gotEff, ok := got["reasoning_effort"].(string); !ok || gotEff != "max" {
+		t.Errorf("reasoning_effort = %v, want \"max\"", got["reasoning_effort"])
 	}
-	thinking, ok := got["thinking"].(map[string]any)
-	if !ok {
-		t.Fatalf("thinking block missing for deepseek model: %v", got)
-	}
-	if thinking["type"] != "enabled" {
-		t.Errorf("thinking.type = %v, want enabled", thinking["type"])
-	}
-	if thinking["reasoning_effort"] != "max" {
-		t.Errorf("thinking.reasoning_effort = %v, want max", thinking["reasoning_effort"])
+	if _, ok := got["thinking"]; ok {
+		t.Error("thinking block emitted for deepseek model")
 	}
 
 	// Non-DeepSeek models keep reasoning_effort (clamped to the model's
@@ -1602,25 +1596,25 @@ func TestNormalizeRequestCacheControlInjection(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Issue #101 — DeepSeek thinking-block translation.
+// Issue #111 — plain reasoning_effort on DeepSeek routes (no thinking block).
 // ---------------------------------------------------------------------------
 
-func TestDeepSeekThinkingTranslation(t *testing.T) {
+func TestDeepSeekPlainReasoningEffort(t *testing.T) {
 	cases := []struct {
-		name     string
-		model    string
-		effort   string
-		wantType string
-		wantEff  string
+		name   string
+		model  string
+		effort string
+		want   string
 	}{
-		{"flash low maps to high", "deepseek/deepseek-v4-flash", "low", "enabled", "high"},
-		{"flash medium clamps down to low then high", "deepseek/deepseek-v4-flash", "medium", "enabled", "high"},
-		{"flash high stays high", "deepseek/deepseek-v4-flash", "high", "enabled", "high"},
-		{"flash max stays max", "deepseek/deepseek-v4-flash", "max", "enabled", "max"},
-		{"flash xhigh clamps down to high", "deepseek/deepseek-v4-flash", "xhigh", "enabled", "high"},
-		{"pro low clamps up to high", "deepseek/deepseek-v4-pro", "low", "enabled", "high"},
-		{"pro max stays max", "deepseek/deepseek-v4-pro", "max", "enabled", "max"},
-		{"bare model id tolerated", "deepseek-v4-flash", "max", "enabled", "max"},
+		{"flash low stays low", "deepseek/deepseek-v4-flash", "low", "low"},
+		{"flash medium rewrites to high", "deepseek/deepseek-v4-flash", "medium", "high"},
+		{"flash high stays high", "deepseek/deepseek-v4-flash", "high", "high"},
+		{"flash max stays max", "deepseek/deepseek-v4-flash", "max", "max"},
+		{"flash xhigh clamps down to high", "deepseek/deepseek-v4-flash", "xhigh", "high"},
+		{"pro low stays low", "deepseek/deepseek-v4-pro", "low", "low"},
+		{"pro medium rewrites to high", "deepseek/deepseek-v4-pro", "medium", "high"},
+		{"pro max stays max", "deepseek/deepseek-v4-pro", "max", "max"},
+		{"bare model id tolerated", "deepseek-v4-flash", "max", "max"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1634,23 +1628,16 @@ func TestDeepSeekThinkingTranslation(t *testing.T) {
 				t.Fatalf("NormalizeRequest: %v", err)
 			}
 			got := decode(t, out)
-			if _, ok := got["reasoning_effort"]; ok {
-				t.Errorf("reasoning_effort kept for deepseek model: %v", got["reasoning_effort"])
+			if gotEff, ok := got["reasoning_effort"].(string); !ok || gotEff != tc.want {
+				t.Errorf("reasoning_effort = %v, want %q", got["reasoning_effort"], tc.want)
 			}
-			thinking, ok := got["thinking"].(map[string]any)
-			if !ok {
-				t.Fatalf("thinking block missing: %v", got)
-			}
-			if thinking["type"] != tc.wantType {
-				t.Errorf("thinking.type = %v, want %q", thinking["type"], tc.wantType)
-			}
-			if thinking["reasoning_effort"] != tc.wantEff {
-				t.Errorf("thinking.reasoning_effort = %v, want %q", thinking["reasoning_effort"], tc.wantEff)
+			if _, ok := got["thinking"]; ok {
+				t.Errorf("thinking block emitted for deepseek model: %v", got["thinking"])
 			}
 		})
 	}
 
-	t.Run("reasoning.enabled=false disables thinking", func(t *testing.T) {
+	t.Run("reasoning.enabled=false suppresses effort", func(t *testing.T) {
 		body := map[string]any{
 			"model":     "deepseek/deepseek-v4-flash",
 			"messages":  []any{map[string]any{"role": "user", "content": "hi"}},
@@ -1661,18 +1648,31 @@ func TestDeepSeekThinkingTranslation(t *testing.T) {
 			t.Fatalf("NormalizeRequest: %v", err)
 		}
 		got := decode(t, out)
-		thinking, ok := got["thinking"].(map[string]any)
-		if !ok {
-			t.Fatalf("thinking block missing: %v", got)
-		}
-		if thinking["type"] != "disabled" {
-			t.Errorf("thinking.type = %v, want disabled", thinking["type"])
-		}
-		if _, hasEff := thinking["reasoning_effort"]; hasEff {
-			t.Errorf("disabled thinking carries an effort: %v", thinking)
-		}
 		if _, ok := got["reasoning_effort"]; ok {
-			t.Error("reasoning_effort kept alongside disabled thinking")
+			t.Error("reasoning_effort kept alongside reasoning.enabled=false")
+		}
+		if _, ok := got["thinking"]; ok {
+			t.Error("thinking block emitted alongside reasoning.enabled=false")
+		}
+	})
+
+	t.Run("thinking.type=disabled suppresses effort", func(t *testing.T) {
+		body := map[string]any{
+			"model":            "deepseek/deepseek-v4-flash",
+			"messages":         []any{map[string]any{"role": "user", "content": "hi"}},
+			"reasoning_effort": "max",
+			"thinking":         map[string]any{"type": "disabled"},
+		}
+		out, err := NormalizeRequest(mustJSON(t, body), "")
+		if err != nil {
+			t.Fatalf("NormalizeRequest: %v", err)
+		}
+		got := decode(t, out)
+		if _, ok := got["reasoning_effort"]; ok {
+			t.Error("reasoning_effort kept alongside thinking.type=disabled")
+		}
+		if _, ok := got["thinking"]; ok {
+			t.Error("thinking block emitted alongside thinking.type=disabled")
 		}
 	})
 
@@ -1726,8 +1726,16 @@ func TestEffortsForModel(t *testing.T) {
 	if got := effortsForModel("deepseek/deepseek-v4-flash"); !reflect.DeepEqual(got, []string{"low", "high", "max"}) {
 		t.Errorf("flash efforts = %v", got)
 	}
-	if got := effortsForModel("deepseek/deepseek-v4-pro"); !reflect.DeepEqual(got, []string{"high", "max"}) {
+	if got := effortsForModel("deepseek/deepseek-v4-pro"); !reflect.DeepEqual(got, []string{"low", "high", "max"}) {
 		t.Errorf("pro efforts = %v", got)
+	}
+	// Luna EFFORTS_THROUGH_MAX includes xhigh; muse EFFORTS_THROUGH_XHIGH
+	// includes minimal (08/13 catalog).
+	if got := effortsForModel("openai/gpt-5.6-luna"); !reflect.DeepEqual(got, []string{"low", "medium", "high", "xhigh", "max"}) {
+		t.Errorf("luna efforts = %v", got)
+	}
+	if got := effortsForModel("meta/muse-spark-1.2-contributor"); !reflect.DeepEqual(got, []string{"minimal", "low", "medium", "high", "xhigh"}) {
+		t.Errorf("muse efforts = %v", got)
 	}
 	// Unlisted models get the full ladder (no clamping).
 	if got := effortsForModel("minimax/minimax-m3"); !reflect.DeepEqual(got, reasoningLadder[:]) {
@@ -1764,9 +1772,22 @@ func TestNormalizeRequestEffortClamp(t *testing.T) {
 		return decode(t, out)["reasoning_effort"].(string)
 	}
 
-	// gpt-5.6-luna tops out at max: xhigh clamps down to high.
-	if got := effortFor("openai/gpt-5.6-luna", "xhigh"); got != "high" {
-		t.Errorf("gpt-5.6-luna xhigh = %q, want high", got)
+	// gpt-5.6-luna EFFORTS_THROUGH_MAX includes xhigh: it passes through.
+	if got := effortFor("openai/gpt-5.6-luna", "xhigh"); got != "xhigh" {
+		t.Errorf("gpt-5.6-luna xhigh = %q, want xhigh", got)
+	}
+	// muse-spark EFFORTS_THROUGH_XHIGH includes minimal: it passes through.
+	if got := effortFor("meta/muse-spark-1.2-contributor", "minimal"); got != "minimal" {
+		t.Errorf("muse-spark minimal = %q, want minimal", got)
+	}
+	// deepseek-v4-pro gained low on 08/13: it passes through unclamped.
+	if got := effortFor("deepseek/deepseek-v4-pro", "low"); got != "low" {
+		t.Errorf("deepseek-v4-pro low = %q, want low", got)
+	}
+	// medium on a DeepSeek route rewrites to high (resolveFreebuffReasoningEffort),
+	// never down to low.
+	if got := effortFor("deepseek/deepseek-v4-flash", "medium"); got != "high" {
+		t.Errorf("deepseek-v4-flash medium = %q, want high", got)
 	}
 	// Unlisted models pass every rung through.
 	if got := effortFor("minimax/minimax-m3", "ultra"); got != "ultra" {

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -20,6 +20,8 @@ package pool
 
 import (
 	"context"
+	cryptoRand "crypto/rand"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -40,8 +42,29 @@ import (
 )
 
 // maintainInterval is how often the background job rotates aged runs and
-// advances queued sessions (PRD §3: 60s maintain ticker).
+// advances queued sessions (PRD §3: 60s maintain ticker). Session-liveness
+// polls run on their own jittered schedule (see sessionPoll* below), not on
+// this coarse grid.
 const maintainInterval = time.Minute
+
+// Session-liveness poll cadence (gap #2; reference/freebuff sdk
+// polling-backoff.ts): while active the CLI polls the compact session every
+// 30s ±20% (24–36s), capped to remaining+1s near expiry so the poll lands
+// just after expires_at; on failure it backs off 20s → 300s (×2 per
+// consecutive failure), never scheduling a retry before the server's
+// Retry-After floor.
+const (
+	// sessionPollCheckInterval is the maintain loop's fine-grained wake-up
+	// grid for due session polls; rotation/queued-advance stay on
+	// maintainInterval.
+	sessionPollCheckInterval = 2 * time.Second
+	// sessionPollBaseInterval is the CLI's active poll cadence (30s).
+	sessionPollBaseInterval = 30 * time.Second
+	// sessionPollBackoffBase is the first failure backoff (20s); each
+	// consecutive failure doubles it up to sessionPollBackoffMax (300s).
+	sessionPollBackoffBase = 20 * time.Second
+	sessionPollBackoffMax  = 300 * time.Second
+)
 
 // usageWindow is the rolling window for the per-token daily message cap
 // (MAX_MESSAGES_PER_DAY): a token may send at most N successful chat
@@ -102,6 +125,10 @@ type bridgeEntry struct {
 	// spend is the per-client-token spend ledger (issue #87); guarded by
 	// Pool.bridgeMu like usage.
 	spend *spendLedger
+	// nextPollAt / pollFailures carry the session-liveness poll schedule
+	// (gap #2), touched only by the maintain goroutine (bridgeSessionPollTick).
+	nextPollAt   time.Time
+	pollFailures int
 }
 
 // TokenSnapshot is one token's healthz view.
@@ -245,6 +272,15 @@ type tokenEntry struct {
 	session *session.Manager
 	runs    *runs.RunManager
 	client  *upstream.Client
+
+	// Session-liveness poll schedule (gap #2): nextPollAt is when the next
+	// compact poll is due (zero = due on the next sessionPollTick pass);
+	// pollFailures counts consecutive poll failures for the 20s→300s backoff.
+	// Touched only by the maintain goroutine (sessionPollTick), so no lock is
+	// needed — AddToken entries are appended to a fresh slice the poll loop
+	// has not loaded yet.
+	nextPollAt   time.Time
+	pollFailures int
 }
 
 // New builds the pool over the configured tokens. len(clients) and
@@ -1021,7 +1057,7 @@ func (p *Pool) AcquireBridge(ctx context.Context, clientToken, model string) (*L
 	// Track the activity and end any idle-maintenance pause, mirroring
 	// Acquire: without this, IDLE_ROTATION_TIMEOUT was dead config in
 	// bridge mode — lastActive stayed zero forever, so the pool never
-	// idle-paused and bridge entries were maintained, heartbeated, and
+	// idle-paused and bridge entries were maintained, polled, and
 	// queued-advanced every pass indefinitely.
 	p.lastActiveMu.Lock()
 	p.lastActive = time.Now()
@@ -1084,10 +1120,11 @@ func (p *Pool) LeaseAbandon(lease *Lease) {
 	(*toks)[lease.Token].runs.ReleaseAbandoned(lease.Run)
 }
 
-// RecordRunStep records a completed chat step upstream (issue #91, CLI
-// parity): the server fires it after a successful chat with the response
-// message id. Best-effort through the bounded finish queue — failures are
-// logged, never surfaced.
+// RecordRunStep records a completed chat step on the lease's run (issue
+// #114): steps are accumulated in memory and sent WITH FINISH — recording
+// is local-only and never an upstream call (the CLI has no /steps
+// endpoint). The server fires it after a successful chat with the response
+// message id ("" when the stream never carried one).
 func (p *Pool) RecordRunStep(lease *Lease, messageID string) {
 	if lease == nil || lease.Run == nil {
 		return
@@ -1105,6 +1142,30 @@ func (p *Pool) RecordRunStep(lease *Lease, messageID string) {
 		return
 	}
 	(*toks)[lease.Token].runs.RecordStep(lease.Run, messageID)
+}
+
+// MarkRunFailed marks the lease's run as failed for its eventual FINISH
+// (issue #114): the server calls it when a chat dies on a terminal upstream
+// error so the run does not FINISH as completed (a gateway with zero failed
+// runs looks synthetic). The run stays active; only its terminal status is
+// recorded. Nil-safe (an acquire failure leaves no lease).
+func (p *Pool) MarkRunFailed(lease *Lease) {
+	if lease == nil || lease.Run == nil {
+		return
+	}
+	if lease.Bridge != nil {
+		lease.Bridge.runs.MarkFailed(lease.Run)
+		return
+	}
+	if lease.entry != nil {
+		lease.entry.runs.MarkFailed(lease.Run)
+		return
+	}
+	toks := p.toks.Load()
+	if lease.Token < 0 || lease.Token >= len(*toks) {
+		return
+	}
+	(*toks)[lease.Token].runs.MarkFailed(lease.Run)
 }
 
 // RecordSpend adds tokens to the lease's backing token spend ledger (issue
@@ -1957,22 +2018,30 @@ func (p *Pool) prewarm(ctx context.Context, agentIDs []string) {
 }
 
 // maintainLoop ticks every maintainInterval: per token, rotate aged runs and
-// refresh the session (advances queued sessions past pollAt). When
-// IDLE_ROTATION_TIMEOUT is set, the pool pauses this activity after it has
-// been idle past the timeout: one pass FINISHes all runs (so no
-// rotation/session-refresh activity continues upstream) and every further
-// pass is skipped until the next request — Acquire re-creates runs on
-// demand.
+// advance queued sessions. Session-liveness polls run on their own finer
+// jittered schedule (sessionPollTick fires when a token's nextPollAt is
+// due; see the sessionPoll* constants). When IDLE_ROTATION_TIMEOUT is set,
+// the pool pauses this activity after it has been idle past the timeout:
+// one pass FINISHes all runs (so no rotation/session-refresh activity
+// continues upstream) and every further pass is skipped until the next
+// request — Acquire re-creates runs on demand.
 func (p *Pool) maintainLoop(ctx context.Context) {
 	defer p.wg.Done()
 	ticker := time.NewTicker(maintainInterval)
 	defer ticker.Stop()
+	// The poll grid is finer than maintainInterval so the per-token jittered
+	// ~30s liveness polls (gap #2) are not quantized onto the 60s rotation
+	// grid — a due poll fires on the first grid point at/after nextPollAt.
+	pollTicker := time.NewTicker(sessionPollCheckInterval)
+	defer pollTicker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			p.maintainTick(ctx)
+		case <-pollTicker.C:
+			p.sessionPollTick(ctx)
 		}
 	}
 }
@@ -2019,25 +2088,24 @@ func (p *Pool) maintainTick(ctx context.Context) {
 	}
 	for i, tok := range *toks {
 		// Cooldown: skip all per-token maintain work (rotate, draining
-		// FINISH, heartbeat, queued-session advance). Upstream calls during
-		// a cooldown look like abuse; the skip is silent — the cooldown
-		// itself is already surfaced elsewhere (Acquire logs the skip).
+		// FINISH, queued-session advance). Upstream calls during a cooldown
+		// look like abuse; the skip is silent — the cooldown itself is
+		// already surfaced elsewhere (Acquire logs the skip).
 		if time.Now().Before(tok.runs.CooldownUntil()) {
 			continue
 		}
 		mCtx, cancel := context.WithTimeout(ctx, cfg.RequestTimeout)
 		tok.runs.Maintain(mCtx)
-		// Advance queued sessions (GET poll) and send heartbeats for active
-		// sessions. Skipped while a chat is in flight: the upstream allows
-		// one client per account at a time, and a poll/heartbeat GET that
-		// lands mid-chat can kick the active session (428 waiting_room).
-		// Mirror the reference session manager's in-flight gate
-		// (reference/freebuff-proxy-hengxin session-manager.js:37-49,
-		// 259-260).
+		// Advance queued sessions (GET poll). Skipped while a chat is in
+		// flight: the upstream allows one client per account at a time, and
+		// a poll GET that lands mid-chat can kick the active session (428
+		// waiting_room). Mirror the reference session manager's in-flight
+		// gate (reference/freebuff-proxy-hengxin session-manager.js:37-49,
+		// 259-260). Active-session liveness polls are NOT part of this pass
+		// — they run on the jittered sessionPollTick schedule (gap #2).
 		if tok.runs.InflightCount() == 0 {
 			snap := tok.session.Snapshot()
-			switch snap.Status {
-			case "queued":
+			if snap.Status == "queued" {
 				if _, err := tok.session.EnsureSession(mCtx); err != nil {
 					p.logger.Debug("pool: maintain session not ready", "token", i+1, "err", err)
 				} else {
@@ -2049,10 +2117,6 @@ func (p *Pool) maintainTick(ctx context.Context) {
 						_ = tok.runs.Precreate(mCtx, agentID)
 					}
 				}
-			case "active":
-				if err := tok.session.Heartbeat(mCtx); err != nil {
-					p.logger.Debug("pool: maintain session heartbeat failed", "token", i+1, "err", err)
-				}
 			}
 		}
 		cancel()
@@ -2060,6 +2124,177 @@ func (p *Pool) maintainTick(ctx context.Context) {
 	// Bridge sweep: drop entries idle past bridgeIdleEvict (runs FINISHed
 	// best-effort), maintain the rest like the fixed tokens above.
 	p.bridgeMaintain(ctx, false)
+}
+
+// sessionPollTick runs the per-token session-liveness polls on their own
+// jittered schedule (see the sessionPoll* constants): an active (or
+// in-grace ended) session is compact-polled every ~30s ±20% — capped to
+// remaining+1s near expiry — with 20s→300s failure backoff honoring the
+// server's Retry-After, mirroring the CLI's liveness fingerprint (gap #2;
+// reference/freebuff sdk polling-backoff.ts). Rotation and queued-session
+// advance stay on the coarse maintainInterval ticker (maintainTick). The
+// poll is skipped while a chat is in flight (the upstream allows one client
+// per account at a time; a poll landing mid-chat can kick the active
+// session with 428) and while the token cools down, exactly like
+// maintainTick.
+func (p *Pool) sessionPollTick(ctx context.Context) {
+	cfg := p.cfg.Load()
+	if cfg.IdleRotationTimeout > 0 && p.idleFor() > cfg.IdleRotationTimeout {
+		// Session polls pause with the fixed tokens while idle (the
+		// maintain pass already FINISHed every run upstream).
+		return
+	}
+	toks := p.toks.Load()
+	for i, tok := range *toks {
+		if time.Now().Before(tok.runs.CooldownUntil()) {
+			// Cooldown: no session poll (same rule as maintainTick).
+			continue
+		}
+		if tok.runs.InflightCount() > 0 {
+			// Mid-chat in-flight gate (same rule as maintainTick): a poll
+			// GET can kick the active session (428 waiting_room). Leave the
+			// schedule due; the next pass polls once the lease drains.
+			continue
+		}
+		now := time.Now()
+		if !tok.nextPollAt.IsZero() && now.Before(tok.nextPollAt) {
+			continue
+		}
+		mCtx, cancel := context.WithTimeout(ctx, cfg.RequestTimeout)
+		err := tok.session.Poll(mCtx)
+		cancel()
+		var delay time.Duration
+		if err != nil {
+			tok.pollFailures++
+			delay = sessionPollBackoffDelay(tok.pollFailures, sessionPollRetryAfter(err))
+			p.logger.Debug("pool: session poll failed", "token", i+1, "err", err, "retry_in", delay)
+		} else {
+			tok.pollFailures = 0
+			delay = sessionPollSuccessDelay(tok.session.Snapshot())
+		}
+		tok.nextPollAt = time.Now().Add(delay)
+	}
+	p.bridgeSessionPollTick(ctx, cfg)
+}
+
+// bridgeSessionPollTick polls the bridge cache's active sessions on the same
+// jittered schedule as the fixed tokens (gap #2). The sweep/eviction half
+// stays in bridgeMaintain; only the per-entry session poll runs here so its
+// timing is not quantized onto the 60s rotation grid.
+func (p *Pool) bridgeSessionPollTick(ctx context.Context, cfg *config.Config) {
+	p.bridgeMu.Lock()
+	entries := make([]*bridgeEntry, 0, len(p.bridge))
+	for _, entry := range p.bridge {
+		entries = append(entries, entry)
+	}
+	p.bridgeMu.Unlock()
+
+	for _, entry := range entries {
+		if time.Now().Before(entry.runs.CooldownUntil()) {
+			continue
+		}
+		if entry.runs.InflightCount() > 0 {
+			continue
+		}
+		now := time.Now()
+		if !entry.nextPollAt.IsZero() && now.Before(entry.nextPollAt) {
+			continue
+		}
+		mCtx, cancel := context.WithTimeout(ctx, cfg.RequestTimeout)
+		err := entry.session.Poll(mCtx)
+		cancel()
+		var delay time.Duration
+		if err != nil {
+			entry.pollFailures++
+			delay = sessionPollBackoffDelay(entry.pollFailures, sessionPollRetryAfter(err))
+			p.logger.Debug("pool: bridge session poll failed", "err", err, "retry_in", delay)
+		} else {
+			entry.pollFailures = 0
+			delay = sessionPollSuccessDelay(entry.session.Snapshot())
+		}
+		entry.nextPollAt = time.Now().Add(delay)
+	}
+}
+
+// sessionPollSuccessDelay returns the delay before the next liveness poll
+// after a SUCCESSFUL poll: ~30s ±20% jitter, capped so a poll near expiry
+// lands ~1s after expires_at (the CLI observes the status flip then;
+// reference/freebuff sdk polling-backoff.ts). Sessions already inside the
+// grace drain poll at the plain jittered cadence.
+func sessionPollSuccessDelay(snap session.SessionSnapshot) time.Duration {
+	d := sessionPollJittered(sessionPollBaseInterval)
+	if !snap.ExpiresAt.IsZero() {
+		if rem := time.Until(snap.ExpiresAt); rem > 0 && rem+time.Second < d {
+			d = rem + time.Second
+		}
+	}
+	return d
+}
+
+// sessionPollBackoffDelay returns the delay after a FAILED poll: 20s ×2 per
+// consecutive failure (cap 300s) with equal jitter over the lower half of
+// the window, and never before the server's Retry-After floor (multiplied
+// by 1 ± 0.2 jitter, capped 300s) — polling-backoff.ts semantics.
+func sessionPollBackoffDelay(failures int, retryAfter time.Duration) time.Duration {
+	if failures < 1 {
+		failures = 1
+	}
+	d := sessionPollBackoffBase << min(failures-1, 5)
+	if d > sessionPollBackoffMax {
+		d = sessionPollBackoffMax
+	}
+	d = d/2 + time.Duration(sessionRand()%uint64(d/2))
+	if retryAfter > 0 {
+		ra := retryAfter - retryAfter/5 + time.Duration(sessionRand()%uint64(2*retryAfter/5))
+		if ra > d {
+			d = ra
+		}
+		if d > sessionPollBackoffMax {
+			d = sessionPollBackoffMax
+		}
+	}
+	return d
+}
+
+// sessionPollJittered applies the CLI's symmetric ±20% jitter around d.
+func sessionPollJittered(d time.Duration) time.Duration {
+	span := d / 5
+	return d - span + time.Duration(sessionRand()%uint64(2*span+1))
+}
+
+// sessionRand draws one uint64 from crypto/rand (the pool's jitter source,
+// matching the upstream client's pattern). A read failure is unrecoverable
+// in practice; fall back to the clock rather than panicking in a background
+// loop.
+func sessionRand() uint64 {
+	var b [8]byte
+	if _, err := cryptoRand.Read(b[:]); err != nil {
+		return uint64(time.Now().UnixNano())
+	}
+	return binary.BigEndian.Uint64(b[:])
+}
+
+// sessionPollRetryAfter extracts the server's Retry-After floor from a
+// failed session poll error (0 when the error carries none). The backoff
+// never schedules a retry before this floor.
+func sessionPollRetryAfter(err error) time.Duration {
+	var ue *upstream.UpstreamError
+	if errors.As(err, &ue) {
+		return ue.RetryAfter
+	}
+	var rle *upstream.RateLimitError
+	if errors.As(err, &rle) {
+		return rle.RetryAfter
+	}
+	var wrr *upstream.WaitingRoomRequiredError
+	if errors.As(err, &wrr) {
+		return wrr.RetryAfter
+	}
+	var wr *session.WaitingRoomError
+	if errors.As(err, &wr) {
+		return wr.RetryAfter
+	}
+	return 0
 }
 
 // pruneRetired drops retired tokens that hold no leases and have been
@@ -2084,9 +2319,11 @@ func (p *Pool) pruneRetired() {
 // stay idle. The remaining entries get the per-token maintain work — rotate
 // aged runs and advance queued sessions, bounded by the same RequestTimeout
 // ctx as the fixed-token loop. On idle passes (idle=true) only the sweep
-// runs: the per-entry heartbeat/queued-advance pauses with the fixed
-// tokens, and the idle-sweep keeps bridge entries from staying admitted
-// upstream past bridgeIdleEvict while the pool stays idle.
+// runs: the per-entry queued-advance pauses with the fixed tokens, and the
+// idle-sweep keeps bridge entries from staying admitted upstream past
+// bridgeIdleEvict while the pool stays idle. Active-session liveness polls
+// are NOT part of this pass — they run on the jittered
+// bridgeSessionPollTick schedule (gap #2).
 func (p *Pool) bridgeMaintain(ctx context.Context, idle bool) {
 	cfg := p.cfg.Load()
 	var toEvict []*bridgeEntry
@@ -2129,21 +2366,21 @@ func (p *Pool) bridgeMaintain(ctx context.Context, idle bool) {
 			// tokens; only the idle-eviction sweep above runs.
 			continue
 		}
-		// Same cooldown skip as the fixed-token loop: no heartbeat, no
-		// queued-session EnsureSession, no rotation while cooling down.
+		// Same cooldown skip as the fixed-token loop: no queued-session
+		// EnsureSession, no rotation while cooling down.
 		if time.Now().Before(entry.runs.CooldownUntil()) {
 			continue
 		}
 		mCtx, cancel := context.WithTimeout(ctx, cfg.RequestTimeout)
 		entry.runs.Maintain(mCtx)
-		// Same in-flight gate as the fixed-token loop: skip the session
-		// poll/heartbeat GETs while a chat is in flight so they cannot kick
-		// the active session (reference/freebuff-proxy-hengxin
-		// session-manager.js:37-49, 259-260).
+		// Same in-flight gate as the fixed-token loop: skip the queued-
+		// session GET while a chat is in flight so it cannot kick the active
+		// session (reference/freebuff-proxy-hengxin session-manager.js:37-49,
+		// 259-260). Active-session liveness polls run on the jittered
+		// bridgeSessionPollTick schedule instead.
 		if entry.runs.InflightCount() == 0 {
 			snap := entry.session.Snapshot()
-			switch snap.Status {
-			case "queued":
+			if snap.Status == "queued" {
 				if _, err := entry.session.EnsureSession(mCtx); err != nil {
 					p.logger.Debug("pool: bridge maintain session not ready", "err", err)
 				} else {
@@ -2154,10 +2391,6 @@ func (p *Pool) bridgeMaintain(ctx context.Context, idle bool) {
 					if agentID, err := p.reg.AgentForModel(after.Model); err == nil && agentID != "" {
 						_ = entry.runs.Precreate(mCtx, agentID)
 					}
-				}
-			case "active":
-				if err := entry.session.Heartbeat(mCtx); err != nil {
-					p.logger.Debug("pool: bridge maintain session heartbeat failed", "err", err)
 				}
 			}
 		}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -146,9 +146,10 @@ type TokenSnapshot struct {
 	UsagePct             int    // percentage of daily limit used (0 when unlimited)
 	RiskLevel            string // "low", "moderate", "high", "critical" account safety indicator (#6)
 	// Spend24h / SpendDay / SpendWeek / SpendMonth are the local per-token
-	// spend ledger (issue #87): tokens spent in the rolling 24h window and
-	// the current UTC day/week/month buckets (with rollover). Fed by
-	// pool.RecordSpend from chat usage blocks; surfaced next to Messages24h.
+	// spend ledger (issue #87): tokens spent in the rolling 24h window, the
+	// Pacific-midnight day bucket (issue #122) and the UTC week/month
+	// buckets (with rollover). Fed by pool.RecordSpend from chat usage
+	// blocks; surfaced next to Messages24h.
 	Spend24h        int64
 	SpendDay        int64
 	SpendWeek       int64
@@ -1170,7 +1171,11 @@ func (p *Pool) MarkRunFailed(lease *Lease) {
 
 // RecordSpend adds tokens to the lease's backing token spend ledger (issue
 // #87): the server reports the usage block of a completed chat. Non-positive
-// deltas are ignored.
+// deltas are ignored. Production caller: chatCore feeds the relay's observed
+// usage total once per successful chat completion (#122). The daily $15/$5/
+// $0.50 ceilings are server-enforced and cohort-dependent, so this
+// token-count ledger is a heuristic proxy, not exact USD accounting — see
+// spend.go's package comment.
 func (p *Pool) RecordSpend(lease *Lease, tokens int64) {
 	if lease == nil || tokens <= 0 {
 		return
@@ -1283,9 +1288,12 @@ func (p *Pool) CooldownTokenRateLimit(token int, rle *upstream.RateLimitError) {
 	(*toks)[token].runs.CooldownRateLimit(rle)
 }
 
-// CooldownTokenIpCapped applies an ip_capped cooldown to token, bounded to
-// the error's RetryAfter ONLY (no Pacific-midnight fallback — ip_capped is
-// admission-only, not a quota reset). Out-of-range tokens are ignored.
+// CooldownTokenIpCapped applies an ip_capped cooldown to token via
+// runs.CooldownIpCapped: each hit backs off the error's RetryAfter + ±20%
+// jitter, with a per-token daily re-admission cap (#118 — the 3rd hit in a
+// rolling window locks until the Pacific-midnight reset and surfaces
+// 429 ip_capped; upstream itself is admission-only, not a quota reset).
+// Out-of-range tokens are ignored.
 func (p *Pool) CooldownTokenIpCapped(token int, ice *upstream.IpCappedError) {
 	toks := p.toks.Load()
 	if token < 0 || token >= len(*toks) || ice == nil {
@@ -1353,8 +1361,9 @@ func (p *Pool) CooldownBridgeRateLimit(lease *Lease, rle *upstream.RateLimitErro
 	lease.Bridge.runs.CooldownRateLimit(rle)
 }
 
-// CooldownBridgeIpCapped applies an ip_capped cooldown to the bridge entry,
-// bounded to the error's RetryAfter ONLY (no Pacific-midnight fallback).
+// CooldownBridgeIpCapped applies an ip_capped cooldown to the bridge entry
+// via runs.CooldownIpCapped (full RetryAfter + jitter, per-token daily cap
+// until Pacific midnight — #118).
 func (p *Pool) CooldownBridgeIpCapped(lease *Lease, ice *upstream.IpCappedError) {
 	if lease == nil || lease.Bridge == nil || ice == nil {
 		return

--- a/internal/pool/pool_edge_test.go
+++ b/internal/pool/pool_edge_test.go
@@ -2,7 +2,7 @@ package pool
 
 // Edge-case and E2E tests for the pool: live failover matrix, bridge daily
 // cap, idle handling in bridge mode, RemoveLastToken drain + race, maintain
-// queued-advance/heartbeat, runtime token actions, and exact daily-cap
+// queued-advance/session-poll, runtime token actions, and exact daily-cap
 // accounting. Regression guards for the audit's pool bugs (AcquireBridge
 // idle tracking, RemoveLastToken drain/TOCTOU, Cooldown ban memory, idle
 // bridge sweep).
@@ -233,7 +233,7 @@ func TestBridgeDailyMessageCap(t *testing.T) {
 // TestBridgeIdlePause is the regression guard for the P1 bridge idle bug:
 // AcquireBridge never updated p.lastActive, so IDLE_ROTATION_TIMEOUT was
 // dead config in bridge mode — lastActive stayed zero, the pool never
-// idle-paused, and bridge entries were heartbeated/queued-advanced every
+// idle-paused, and bridge entries were polled/queued-advanced every
 // maintain pass indefinitely. Bridge traffic must mark the pool active, and
 // once idle a maintain pass must not touch the upstream at all. Fails
 // before the fix (lastActive stays zero → every pass maintains the entry).
@@ -272,7 +272,7 @@ func TestBridgeIdlePause(t *testing.T) {
 	p.lastActive = time.Now().Add(-time.Second)
 	p.lastActiveMu.Unlock()
 
-	// Idle passes must not touch the upstream (no heartbeat / queued
+	// Idle passes must not touch the upstream (no session poll / queued
 	// advance / rotation) and must not evict the recently-used entry.
 	reqs := mock.Requests
 	p.maintainTick(context.Background())
@@ -290,7 +290,7 @@ func TestBridgeIdlePause(t *testing.T) {
 // in mixed mode bridge entries idle past bridgeIdleEvict were never swept
 // while the pool stayed idle — their sessions stayed admitted upstream until
 // expiry. An idle pass must still run the bridge sweep (only the per-token
-// heartbeat/queued-advance pauses). Fails before the fix (the idle branch
+// session-poll/queued-advance pauses). Fails before the fix (the idle branch
 // returns before the sweep).
 func TestBridgeMaintainRunsOnIdlePass(t *testing.T) {
 	mock := testutil.NewMock()
@@ -596,11 +596,12 @@ func TestRemoveLastTokenRaceHammer(t *testing.T) {
 	}
 }
 
-// TestMaintainTickAdvancesQueuedAndHeartbeatsActive is the first E2E
-// coverage of the maintain pass's session work: a queued session is advanced
+// TestMaintainTickAdvancesQueuedAndPollsActive is the first E2E coverage of
+// the maintain pass's session work: a queued session is advanced
 // (EnsureSession polls upstream) once its pollAt passes, and an active
-// session is heartbeated. Both are observable via mock.SessionPolls.
-func TestMaintainTickAdvancesQueuedAndHeartbeatsActive(t *testing.T) {
+// session is liveness-polled on the jittered sessionPollTick schedule. Both
+// are observable via mock.SessionPolls.
+func TestMaintainTickAdvancesQueuedAndPollsActive(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	mock.SessionSequence = []string{"queued", "active"}
@@ -630,11 +631,12 @@ func TestMaintainTickAdvancesQueuedAndHeartbeatsActive(t *testing.T) {
 		t.Errorf("session status = %q, want active after queued advance", got)
 	}
 
-	// Once active, a maintain pass heartbeats (another poll).
+	// Once active, a sessionPollTick pass with a due schedule polls again
+	// (the plain compact poll — no heartbeat header; gap #2).
 	polls := mock.SessionPolls
-	p.maintainTick(context.Background())
+	p.sessionPollTick(context.Background())
 	if got := mock.SessionPolls; got <= polls {
-		t.Errorf("session polls = %d, want > %d (heartbeat on active)", got, polls)
+		t.Errorf("session polls = %d, want > %d (poll on active)", got, polls)
 	}
 }
 

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -2542,10 +2542,10 @@ func TestSessionPollSchedule(t *testing.T) {
 			min      time.Duration
 			max      time.Duration
 		}{
-			{1, 10 * time.Second, 20 * time.Second},      // 20s, lower-half jitter
-			{2, 20 * time.Second, 40 * time.Second},      // 40s
-			{3, 40 * time.Second, 80 * time.Second},      // 80s
-			{6, 150 * time.Second, 300 * time.Second},    // capped at 300s
+			{1, 10 * time.Second, 20 * time.Second},   // 20s, lower-half jitter
+			{2, 20 * time.Second, 40 * time.Second},   // 40s
+			{3, 40 * time.Second, 80 * time.Second},   // 80s
+			{6, 150 * time.Second, 300 * time.Second}, // capped at 300s
 		}
 		for _, tc := range cases {
 			d := sessionPollBackoffDelay(tc.failures, 0)

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -24,13 +24,14 @@ import (
 // Test models must map to agents with EXCLUSIVE ownership in the registry
 // FALLBACK map (see internal/registry/registry_test.go expectedFallback):
 // the five base2-free models are first-seen-assigned to the generic
-// base2-free agent, while glm-5.2 and laguna-s-2.1 are owned by their
-// dedicated one-model agents. Tests pin the offline (fallback) state.
+// base2-free agent, while glm-5.2 and fable-5 are owned by their dedicated
+// one-model agents (the laguna/ling/greg fixtures were removed upstream on
+// 2026-08-04/08-07, #121). Tests pin the offline (fallback) state.
 const (
 	modelA = "z-ai/glm-5.2"
-	modelB = "poolside/laguna-s-2.1"
+	modelB = "anthropic/claude-fable-5"
 	agentA = "base2-free-glm"
-	agentB = "base2-free-laguna-s-2-1"
+	agentB = "base2-free-fable"
 )
 
 // newTestPool wires one mock upstream per token through real clients and
@@ -2433,16 +2434,16 @@ func TestAcquireIpCappedCooldownBounded(t *testing.T) {
 		t.Errorf("RetryAfter = %s, want 45s (bounded to retryAfterMs)", ice.RetryAfter)
 	}
 
-	// Cooldown is bounded to the retry window, NOT the Pacific midnight
-	// quota lock (which would be many hours away).
+	// Cooldown is bounded to the retry window ±20% jitter (#118), NOT the
+	// Pacific midnight quota lock (which would be many hours away).
 	snap := p.Snapshot()[0]
 	if snap.CooldownUntil.IsZero() {
 		t.Fatal("CooldownUntil zero, want bounded window")
 	}
 	want := time.Now().Add(45 * time.Second)
 	diff := snap.CooldownUntil.Sub(want)
-	if diff < -2*time.Second || diff > 2*time.Second {
-		t.Errorf("CooldownUntil = %v, want ≈ now+45s (bounded), not Pacific midnight", snap.CooldownUntil)
+	if diff < -11*time.Second || diff > 11*time.Second {
+		t.Errorf("CooldownUntil = %v, want ≈ now+45s ±20%% jitter (bounded), not Pacific midnight", snap.CooldownUntil)
 	}
 
 	// While the window is active, a second acquire surfaces the remembered
@@ -2469,8 +2470,8 @@ func TestPoolCooldownTokenIpCappedBounded(t *testing.T) {
 	}
 	want := time.Now().Add(30 * time.Second)
 	diff := snap.CooldownUntil.Sub(want)
-	if diff < -2*time.Second || diff > 2*time.Second {
-		t.Errorf("CooldownUntil = %v, want ≈ now+30s (bounded), not Pacific midnight", snap.CooldownUntil)
+	if diff < -8*time.Second || diff > 8*time.Second {
+		t.Errorf("CooldownUntil = %v, want ≈ now+30s ±20%% jitter (bounded), not Pacific midnight", snap.CooldownUntil)
 	}
 
 	// Out-of-range tokens are ignored without panicking.

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -690,11 +690,16 @@ func TestPoolChat(t *testing.T) {
 		t.Errorf("upstream body missing the leased run id: %s", recorded)
 	}
 	h := mock.RecordedChatHeaders[0]
-	if got := h.Get("x-freebuff-model"); got != modelA {
-		t.Errorf("x-freebuff-model = %q, want %q", got, modelA)
+	// #106: the chat POST carries no model/instance headers — they ride in
+	// the body metadata only.
+	if got := h.Get("x-freebuff-model"); got != "" {
+		t.Errorf("x-freebuff-model = %q on the chat POST, want absent (#106)", got)
 	}
-	if got := h.Get("x-freebuff-instance-id"); got != "inst-abc-123" {
-		t.Errorf("x-freebuff-instance-id = %q, want inst-abc-123", got)
+	if got := h.Get("x-freebuff-instance-id"); got != "" {
+		t.Errorf("x-freebuff-instance-id = %q on the chat POST, want absent (#106)", got)
+	}
+	if !strings.Contains(recorded, `"freebuff_instance_id":"inst-abc-123"`) {
+		t.Errorf("upstream body missing freebuff_instance_id in codebuff_metadata: %s", recorded)
 	}
 
 	// Invalid leases fail without panicking.
@@ -1227,9 +1232,10 @@ func TestMaintainTickSkipsCooldownToken(t *testing.T) {
 	defer mock.Close()
 	p := newTestPool(t, mock)
 
-	// An active session + run: a normal maintain pass would heartbeat the
-	// session (GET) and may rotate the run. With the token cooling down the
-	// pass must not touch the upstream at all.
+	// An active session + run: a normal maintain pass would poll the
+	// session (GET) and may rotate the run. With the token cooling down
+	// neither the maintain pass nor the session-poll pass may touch the
+	// upstream at all.
 	lease, err := p.Acquire(context.Background(), modelA)
 	if err != nil {
 		t.Fatal(err)
@@ -1240,8 +1246,9 @@ func TestMaintainTickSkipsCooldownToken(t *testing.T) {
 
 	before := mock.Requests
 	p.maintainTick(context.Background())
+	p.sessionPollTick(context.Background())
 	if got := mock.Requests; got != before {
-		t.Errorf("upstream requests during cooldown maintain = %d, want %d (no heartbeat/rotate)", got, before)
+		t.Errorf("upstream requests during cooldown maintain = %d, want %d (no poll/rotate)", got, before)
 	}
 }
 func TestBridgeLRUEviction(t *testing.T) {
@@ -2472,11 +2479,11 @@ func TestPoolCooldownTokenIpCappedBounded(t *testing.T) {
 	p.CooldownTokenIpCapped(0, nil)
 }
 
-// TestMaintainTickSkipsHeartbeatWhileChatInFlight verifies #77: the maintain
-// loop skips the session poll/heartbeat GETs while any run holds an
-// in-flight lease (a poll landing mid-chat can kick the active session with
-// 428), and resumes them once the lease drains.
-func TestMaintainTickSkipsHeartbeatWhileChatInFlight(t *testing.T) {
+// TestSessionPollSkipsWhileChatInFlight verifies #77: the session-liveness
+// poll is skipped while any run holds an in-flight lease (a poll landing
+// mid-chat can kick the active session with 428), and resumes once the lease
+// drains.
+func TestSessionPollSkipsWhileChatInFlight(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	p := newTestPool(t, mock)
@@ -2491,15 +2498,83 @@ func TestMaintainTickSkipsHeartbeatWhileChatInFlight(t *testing.T) {
 	}
 
 	before := mock.SessionPolls
-	p.maintainTick(context.Background())
+	p.sessionPollTick(context.Background())
 	if got := mock.SessionPolls; got != before {
-		t.Errorf("session polls during in-flight chat = %d, want %d (heartbeat/advance skipped)", got, before)
+		t.Errorf("session polls during in-flight chat = %d, want %d (poll skipped)", got, before)
 	}
 
-	// Release the lease: the next maintain pass heartbeats again.
+	// Release the lease: the next poll pass polls again.
 	p.LeaseRelease(lease)
-	p.maintainTick(context.Background())
+	p.sessionPollTick(context.Background())
 	if got := mock.SessionPolls; got <= before {
-		t.Errorf("session polls after release = %d, want > %d (heartbeat resumed)", got, before)
+		t.Errorf("session polls after release = %d, want > %d (poll resumed)", got, before)
 	}
+}
+
+// TestSessionPollSchedule pins the liveness-poll cadence helpers (gap #2;
+// reference/freebuff sdk polling-backoff.ts): the success interval is ~30s
+// ±20% jitter capped to remaining+1s near expiry, and the failure backoff
+// grows 20s→300s while never scheduling a retry before the server's
+// Retry-After floor.
+func TestSessionPollSchedule(t *testing.T) {
+	t.Run("success interval jittered around 30s", func(t *testing.T) {
+		for i := 0; i < 50; i++ {
+			d := sessionPollSuccessDelay(session.SessionSnapshot{})
+			if d < 24*time.Second || d > 36*time.Second {
+				t.Fatalf("success delay = %s, want 30s ±20%%", d)
+			}
+		}
+	})
+
+	t.Run("success interval capped near expiry", func(t *testing.T) {
+		rem := 10 * time.Second
+		d := sessionPollSuccessDelay(session.SessionSnapshot{ExpiresAt: time.Now().Add(rem)})
+		// remaining+1s (clock-drift tolerant: allow a few ms either side of
+		// the two time.Now() samples).
+		if d < rem || d > rem+2*time.Second {
+			t.Errorf("success delay near expiry = %s, want ≈ %s (remaining+1s)", d, rem+time.Second)
+		}
+	})
+
+	t.Run("failure backoff doubles and caps at 300s", func(t *testing.T) {
+		cases := []struct {
+			failures int
+			min      time.Duration
+			max      time.Duration
+		}{
+			{1, 10 * time.Second, 20 * time.Second},      // 20s, lower-half jitter
+			{2, 20 * time.Second, 40 * time.Second},      // 40s
+			{3, 40 * time.Second, 80 * time.Second},      // 80s
+			{6, 150 * time.Second, 300 * time.Second},    // capped at 300s
+		}
+		for _, tc := range cases {
+			d := sessionPollBackoffDelay(tc.failures, 0)
+			if d < tc.min || d > tc.max {
+				t.Errorf("backoff(%d) = %s, want [%s, %s]", tc.failures, d, tc.min, tc.max)
+			}
+		}
+	})
+
+	t.Run("failure backoff honors Retry-After floor", func(t *testing.T) {
+		for i := 0; i < 50; i++ {
+			d := sessionPollBackoffDelay(1, 60*time.Second)
+			// retryAfter × (1 ± 0.2) jitter: [48s, 72s], max'd with the 20s
+			// base backoff — never before the floor.
+			if d < 48*time.Second || d > 300*time.Second {
+				t.Errorf("backoff with Retry-After 60s = %s, want ≥ 48s (never before the floor)", d)
+			}
+		}
+	})
+
+	t.Run("retry-after extracted from classified errors", func(t *testing.T) {
+		if got := sessionPollRetryAfter(&upstream.UpstreamError{Status: 503, RetryAfter: 45 * time.Second}); got != 45*time.Second {
+			t.Errorf("UpstreamError RetryAfter = %s, want 45s", got)
+		}
+		if got := sessionPollRetryAfter(&upstream.RateLimitError{RetryAfter: 90 * time.Second}); got != 90*time.Second {
+			t.Errorf("RateLimitError RetryAfter = %s, want 90s", got)
+		}
+		if got := sessionPollRetryAfter(errors.New("plain")); got != 0 {
+			t.Errorf("plain error RetryAfter = %s, want 0", got)
+		}
+	})
 }

--- a/internal/pool/spend.go
+++ b/internal/pool/spend.go
@@ -1,12 +1,21 @@
 package pool
 
 // Local per-token spend ledger (issue #87): an in-memory rolling 24h token
-// spend window plus UTC day/week/month buckets with rollover, mirroring the
-// reference account quota bookkeeping (reference/freebuff-reverse
-// internal/accounts/record.go QuotaUsed/QuotaPeriodStart and
-// internal/quota/quota.go BucketStart/NeedsRollover). Updated from chat
-// usage (pool.RecordSpend, fed by the server's parsed usage blocks) and
-// surfaced next to Messages24h in the healthz token snapshot.
+// spend window plus a Pacific-midnight day bucket (issue #122) and UTC
+// week/month buckets with rollover, mirroring the reference account quota
+// bookkeeping (reference/freebuff-reverse internal/accounts/record.go
+// QuotaUsed/QuotaPeriodStart and internal/quota/quota.go
+// BucketStart/NeedsRollover). Updated from chat usage (pool.RecordSpend,
+// fed by the server's parsed usage blocks) and surfaced next to Messages24h
+// in the healthz token snapshot.
+//
+// The account's $15/$5/$0.50 daily spend ceilings (reference/freebuff
+// freebuff-spend-ceilings.ts) are SERVER-enforced at Pacific midnight, and
+// the proxy cannot know which cohort (full/limited/restricted) a token's
+// account sits in — so this ledger is a token-count heuristic, not an exact
+// USD accounting. Per-token granularity is the right level: one proxy token
+// is one upstream account, so the per-token ledger tracks the same
+// per-account spend the server counts.
 
 import (
 	"time"
@@ -23,8 +32,9 @@ type spendEntry struct {
 type spendLedger struct {
 	// rolling is the 24h window: amounts with timestamps, pruned on access.
 	rolling []spendEntry
-	// UTC day/week/month buckets with their period start (unix); roll over
-	// per BucketStart/NeedsRollover semantics.
+	// Pacific-midnight day bucket (#122) plus UTC week/month buckets, each
+	// with their period start (unix); roll over per BucketStart/NeedsRollover
+	// semantics.
 	dayUsed    int64
 	dayStart   int64
 	weekUsed   int64
@@ -65,13 +75,17 @@ func rollBucket(used, start int64, period string, now time.Time, tokens int64) (
 	return used + tokens, start
 }
 
-// bucketStart is the UTC start of the period containing now (mirrors
-// reference quota.BucketStart: day = UTC midnight, week = UTC Monday,
-// month = UTC 1st).
+// bucketStart is the start of the period containing now: the day bucket
+// rolls at Pacific midnight (America/Los_Angeles), matching the CLI's
+// per-account daily ceilings reset "since midnight Pacific"
+// (reference/freebuff freebuff-spend-ceilings.ts:5-8 and zoned-time.ts
+// getZonedDayBounds) — UTC midnight would split one Pacific day across two
+// proxy buckets and misreport the ceiling window (#122). Week stays UTC
+// Monday and month UTC 1st (the CLI only models daily ceilings).
 func bucketStart(now time.Time, period string) int64 {
-	u := now.UTC()
 	switch period {
 	case "week":
+		u := now.UTC()
 		weekday := int(u.Weekday())
 		if weekday == 0 {
 			weekday = 7
@@ -79,9 +93,10 @@ func bucketStart(now time.Time, period string) int64 {
 		return time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, time.UTC).
 			AddDate(0, 0, -(weekday - 1)).Unix()
 	case "month":
+		u := now.UTC()
 		return time.Date(u.Year(), u.Month(), 1, 0, 0, 0, 0, time.UTC).Unix()
 	default: // day
-		return time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, time.UTC).Unix()
+		return pacificDayStart(now).Unix()
 	}
 }
 
@@ -98,9 +113,84 @@ func needsRollover(start int64, period string, now time.Time) bool {
 	case "month":
 		end = end.AddDate(0, 1, 0)
 	default:
-		end = end.Add(24 * time.Hour)
+		// The day window ends at the NEXT Pacific midnight, which is
+		// 23/24/25 hours after the start on DST transition days — a fixed
+		// 24h window would roll the bucket at the wrong instant (#122).
+		end = nextPacificMidnight(end)
 	}
 	return !now.Before(end)
+}
+
+// pacificDayStart is the Pacific-midnight (America/Los_Angeles) start of the
+// day containing now. Prefers the system tz database; when unavailable it
+// derives the boundary from the US DST rule (PDT = UTC-7 from the second
+// Sunday of March 09:00Z to the first Sunday of November 08:00Z; PST = UTC-8
+// otherwise) — never a fixed UTC hour, so the 07:00Z/08:00Z midnight is
+// DST-aware (#122, reference/freebuff zoned-time.ts getZonedDayBounds).
+func pacificDayStart(now time.Time) time.Time {
+	if loc, err := time.LoadLocation("America/Los_Angeles"); err == nil {
+		y, m, d := now.In(loc).Date()
+		return time.Date(y, m, d, 0, 0, 0, 0, loc)
+	}
+	// No system tzdata: compute the Pacific calendar date of now via the
+	// offset in effect at this instant, then that date's midnight via the
+	// offset in effect at 00:00 local (the transition Sundays keep the OLD
+	// offset at their own midnight — the spring-forward day starts in PST
+	// and the fall-back day starts in PDT).
+	u := now.UTC()
+	local := u.Add(-pacificOffsetAt(u))
+	y, m, d := local.Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC).Add(pacificOffsetAtLocalMidnight(y, m, d))
+}
+
+// nextPacificMidnight returns the first Pacific midnight strictly after the
+// Pacific-midnight instant start (23/24/25 hours later — the DST day
+// length). Wall-clock calendar math, so the offset is re-resolved for the
+// new date instead of naively adding 24h.
+func nextPacificMidnight(start time.Time) time.Time {
+	if loc, err := time.LoadLocation("America/Los_Angeles"); err == nil {
+		return start.In(loc).AddDate(0, 0, 1)
+	}
+	// tzdata-less: derive start's Pacific wall-clock date, add one day, and
+	// resolve that date's midnight with the offset in effect at 00:00 local.
+	u := start.UTC()
+	local := u.Add(-pacificOffsetAt(u))
+	y, m, d := local.AddDate(0, 0, 1).Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC).Add(pacificOffsetAtLocalMidnight(y, m, d))
+}
+
+// pacificOffsetAt returns the Pacific UTC offset in effect at the instant t:
+// PDT (UTC-7) from the second Sunday of March 09:00Z (02:00 PST) to the
+// first Sunday of November 08:00Z (02:00 PDT), PST (UTC-8) otherwise.
+func pacificOffsetAt(t time.Time) time.Duration {
+	u := t.UTC()
+	spring := nthSunday(u.Year(), time.March, 2).Add(9 * time.Hour)
+	fall := nthSunday(u.Year(), time.November, 1).Add(8 * time.Hour)
+	if !u.Before(spring) && u.Before(fall) {
+		return 7 * time.Hour
+	}
+	return 8 * time.Hour
+}
+
+// pacificOffsetAtLocalMidnight returns the Pacific UTC offset in effect at
+// 00:00 local on the calendar date y-m-d. The transition Sundays keep the
+// OLD offset at their own midnight (both transitions happen at 02:00 local),
+// so the date is compared strictly inside the DST span.
+func pacificOffsetAtLocalMidnight(y int, m time.Month, d int) time.Duration {
+	spring := nthSunday(y, time.March, 2)
+	fall := nthSunday(y, time.November, 1)
+	date := time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+	if date.After(spring) && date.Before(fall.AddDate(0, 0, 1)) {
+		return 7 * time.Hour
+	}
+	return 8 * time.Hour
+}
+
+// nthSunday returns the calendar date of the nth Sunday in month m of year
+// y (US DST rule: second Sunday of March, first Sunday of November).
+func nthSunday(y int, m time.Month, n int) time.Time {
+	first := time.Date(y, m, 1, 0, 0, 0, 0, time.UTC)
+	return first.AddDate(0, 0, (7-int(first.Weekday()))%7+(n-1)*7)
 }
 
 // rolling24h prunes the window and returns the total within the last 24h.

--- a/internal/pool/wave3_test.go
+++ b/internal/pool/wave3_test.go
@@ -255,8 +255,10 @@ func TestSpendLedgerRollover(t *testing.T) {
 		t.Fatal("period starts not set")
 	}
 
-	// Day rollover: force yesterday's start, add → resets then accumulates.
-	l.dayStart = now.Add(-24 * time.Hour).Unix()
+	// Day rollover: force a start from the previous Pacific day (26h is
+	// safely past the previous midnight even on the 25h fall-back DST day),
+	// add → resets then accumulates.
+	l.dayStart = now.Add(-26 * time.Hour).Unix()
 	l.add(50, now)
 	v = ledgerView(l)
 	if v.Day != 50 {
@@ -267,6 +269,56 @@ func TestSpendLedgerRollover(t *testing.T) {
 	}
 	if v.Week != 150 {
 		t.Errorf("Week = %d, want 150 (week window still open)", v.Week)
+	}
+}
+
+// TestSpendDayBucketRollsAtPacificMidnight pins the #122 day-bucket
+// boundary: the daily bucket rolls at Pacific midnight
+// (America/Los_Angeles), NOT UTC midnight. In summer (PDT, UTC-7) the
+// boundary is 07:00Z: the UTC day turns over at 00:00Z hours earlier, so a
+// UTC-midnight bucket would reset at the wrong instant.
+func TestSpendDayBucketRollsAtPacificMidnight(t *testing.T) {
+	// Summer: Pacific midnight = 07:00Z (PDT).
+	before := time.Date(2026, 8, 17, 6, 59, 0, 0, time.UTC) // 23:59 PDT 08-16
+	after := time.Date(2026, 8, 17, 7, 0, 0, 0, time.UTC)   // 00:00 PDT 08-17
+
+	if got := bucketStart(before, "day"); got != time.Date(2026, 8, 16, 7, 0, 0, 0, time.UTC).Unix() {
+		t.Errorf("bucketStart(%v) = %v, want 08-16T07:00Z (Pacific midnight)", before, time.Unix(got, 0).UTC())
+	}
+	if got := bucketStart(after, "day"); got != time.Date(2026, 8, 17, 7, 0, 0, 0, time.UTC).Unix() {
+		t.Errorf("bucketStart(%v) = %v, want 08-17T07:00Z (Pacific midnight)", after, time.Unix(got, 0).UTC())
+	}
+	// Winter (PST, UTC-8): the boundary is 08:00Z.
+	winter := time.Date(2026, 1, 5, 8, 30, 0, 0, time.UTC) // 00:30 PST 01-05
+	if got := bucketStart(winter, "day"); got != time.Date(2026, 1, 5, 8, 0, 0, 0, time.UTC).Unix() {
+		t.Errorf("bucketStart(%v) = %v, want 01-05T08:00Z (Pacific midnight)", winter, time.Unix(got, 0).UTC())
+	}
+
+	p := newTestPool(t, testutil.NewMock())
+	p.spendMu.Lock()
+	l := p.spendPerToken[0]
+	p.spendMu.Unlock()
+
+	l.add(100, before)
+	v := ledgerView(l)
+	if v.Day != 100 {
+		t.Fatalf("Day after 100 at %v = %d, want 100", before, v.Day)
+	}
+	// 00:00Z is 00:00 PDT the same Pacific day: the UTC date rolled, the
+	// Pacific day has not — no reset.
+	l.add(50, time.Date(2026, 8, 17, 0, 0, 0, 0, time.UTC))
+	v = ledgerView(l)
+	if v.Day != 150 {
+		t.Errorf("Day after add at 00:00Z = %d, want 150 (no Pacific rollover yet)", v.Day)
+	}
+	// 07:00Z = 00:00 PDT: the Pacific day rolled — reset then accumulate.
+	l.add(75, after)
+	v = ledgerView(l)
+	if v.Day != 75 {
+		t.Errorf("Day after add at 07:00Z = %d, want 75 (rolled at Pacific midnight)", v.Day)
+	}
+	if want := time.Date(2026, 8, 17, 7, 0, 0, 0, time.UTC); !v.DayStart.Equal(want) {
+		t.Errorf("DayStart = %v, want %v (Pacific midnight)", v.DayStart, want)
 	}
 }
 

--- a/internal/pool/wave3_test.go
+++ b/internal/pool/wave3_test.go
@@ -2,7 +2,8 @@ package pool
 
 // Wave-3 pool tests: quota-aware token ordering (#85), the session-create
 // admission gate (#86), the local spend ledger (#87), run pre-create at
-// admission (#90a), abandoned-lease finish (#53), and step recording (#91).
+// admission (#90a), abandoned-lease finish (#53/#114), and step recording
+// (#114: steps ride the FINISH payload).
 
 import (
 	"context"
@@ -319,9 +320,11 @@ func TestLeaseAbandonFinishesRun(t *testing.T) {
 	runID := lease.Run.RunID
 	p.LeaseAbandon(lease) // client disconnect
 
+	// Issue #114: an abandoned run must FINISH as cancelled, not completed —
+	// a gateway with zero cancelled runs looks synthetic.
 	eventually(t, "abandoned run FINISH", func() bool {
 		for _, f := range mock.FinishedRunsSnapshot() {
-			if f.RunID == runID && f.Status == "completed" {
+			if f.RunID == runID && f.Status == "cancelled" {
 				return true
 			}
 		}
@@ -358,12 +361,23 @@ func TestRecordRunStepThroughPool(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Issue #114: steps are appended in memory and batched with FINISH —
+	// the pool path must never hit the (removed) /steps endpoint.
 	p.RecordRunStep(lease, "chatcmpl-9")
-	eventually(t, "step recorded via pool", func() bool {
-		steps := mock.StepsSnapshot()
-		return len(steps) == 1 && steps[0].StepNumber == 2 && steps[0].MessageID == "chatcmpl-9"
-	})
 	p.LeaseRelease(lease)
+	p.Shutdown(context.Background())
+
+	finished := parentFinished(mock)
+	if len(finished) != 1 {
+		t.Fatalf("finished runs = %d, want 1 (parent only)", len(finished))
+	}
+	f := finished[0]
+	if f.Status != "completed" || f.TotalSteps != 1 {
+		t.Errorf("FINISH = %+v, want completed with 1 total step", f)
+	}
+	if len(f.Steps) != 1 || f.Steps[0].StepNumber != 1 || f.Steps[0].MessageID == nil || *f.Steps[0].MessageID != "chatcmpl-9" {
+		t.Errorf("FINISH steps = %+v, want step 1 with message chatcmpl-9", f.Steps)
+	}
 }
 
 // parentFinished filters the mock's FINISH records to parent (non

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -73,10 +73,14 @@ var LimitedTierModels = map[string]bool{
 }
 
 // fallbackAgents is the hardcoded model→agent fallback used when the sources
-// are unreachable. Ported verbatim from registry.js (lines 14-41), entry
-// order preserved: first-seen assignment decides which agent owns models that
-// appear in several entries (e.g. the gemini helpers all list the same two
-// models; file-picker-max comes first).
+// are unreachable. It mirrors the vendored FREE_MODE_AGENT_MODELS allowlist
+// (reference/freebuff common/src/constants/free-agents.ts) for the root and
+// dedicated free agents. The laguna/ling/greg rows were REMOVED from the
+// allowlist upstream on 2026-08-04/08-07 and must not be served offline
+// (#121) — the stale JS port (reference/proxy-freebuff/lib/registry.js) is
+// NOT the source of truth. Entry order preserved: first-seen assignment
+// decides which agent owns models that appear in several entries (e.g. the
+// gemini helpers all list the same two models; file-picker-max comes first).
 var fallbackAgents = []agentModels{
 	{agent: "base2-free", models: []string{
 		"deepseek/deepseek-v4-pro",
@@ -91,11 +95,6 @@ var fallbackAgents = []agentModels{
 	{agent: "base2-free-deepseek-flash", models: []string{"deepseek/deepseek-v4-flash"}},
 	{agent: "base2-free-mimo", models: []string{"mimo/mimo-v2.5"}},
 	{agent: "base2-free-glm", models: []string{"z-ai/glm-5.2"}},
-	{agent: "base2-free-laguna-s-2-1", models: []string{"poolside/laguna-s-2.1"}},
-	{agent: "base2-free-laguna-s-2-1-openrouter", models: []string{"openrouter/poolside/laguna-s-2.1"}},
-	{agent: "base2-free-ling-3-flash", models: []string{"inclusionai/ling-3.0-flash:free"}},
-	{agent: "base2-free-greg-2-ultra", models: []string{"crof/greg-2-ultra"}},
-	{agent: "base2-free-greg-2-super", models: []string{"crof/greg-2-super"}},
 	{agent: "base2-free-fable", models: []string{"anthropic/claude-fable-5"}},
 	{agent: "file-picker", models: []string{"google/gemini-2.5-flash-lite"}},
 	{agent: "file-picker-max", models: []string{"google/gemini-3.1-flash-lite", "google/gemini-3.5-flash-lite"}},

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -28,27 +28,25 @@ func fileSource(t *testing.T, path string) string {
 	return "file:///" + filepath.ToSlash(abs)
 }
 
-// expectedFallback is the model→agent map the JS fallback table (lines
-// 14-41) must produce: first-seen assignment in entry order, so the five
-// base2-free models belong to base2-free (not their dedicated one-model
-// agents), and the gemini helper models belong to file-picker / file-picker-max
-// (which precede file-lister / researcher-* / basher).
+// expectedFallback is the model→agent map the fallback table must produce:
+// first-seen assignment in entry order, so the five base2-free models belong
+// to base2-free (not their dedicated one-model agents), and the gemini
+// helper models belong to file-picker / file-picker-max (which precede
+// file-lister / researcher-* / basher). Mirrors the vendored
+// FREE_MODE_AGENT_MODELS allowlist (reference/freebuff
+// common/src/constants/free-agents.ts); the laguna/ling/greg rows were
+// removed upstream on 2026-08-04/08-07 (#121) and are absent here.
 var expectedFallback = map[string]string{
-	"deepseek/deepseek-v4-pro":         "base2-free",
-	"deepseek/deepseek-v4-flash":       "base2-free",
-	"minimax/minimax-m3":               "base2-free",
-	"openai/gpt-5.6-luna":              "base2-free",
-	"mimo/mimo-v2.5":                   "base2-free",
-	"z-ai/glm-5.2":                     "base2-free-glm",
-	"poolside/laguna-s-2.1":            "base2-free-laguna-s-2-1",
-	"openrouter/poolside/laguna-s-2.1": "base2-free-laguna-s-2-1-openrouter",
-	"inclusionai/ling-3.0-flash:free":  "base2-free-ling-3-flash",
-	"crof/greg-2-ultra":                "base2-free-greg-2-ultra",
-	"crof/greg-2-super":                "base2-free-greg-2-super",
-	"anthropic/claude-fable-5":         "base2-free-fable",
-	"google/gemini-2.5-flash-lite":     "file-picker",
-	"google/gemini-3.1-flash-lite":     "file-picker-max",
-	"google/gemini-3.5-flash-lite":     "file-picker-max",
+	"deepseek/deepseek-v4-pro":     "base2-free",
+	"deepseek/deepseek-v4-flash":   "base2-free",
+	"minimax/minimax-m3":           "base2-free",
+	"openai/gpt-5.6-luna":          "base2-free",
+	"mimo/mimo-v2.5":               "base2-free",
+	"z-ai/glm-5.2":                 "base2-free-glm",
+	"anthropic/claude-fable-5":     "base2-free-fable",
+	"google/gemini-2.5-flash-lite": "file-picker",
+	"google/gemini-3.1-flash-lite": "file-picker-max",
+	"google/gemini-3.5-flash-lite": "file-picker-max",
 }
 
 func TestFallbackMap(t *testing.T) {

--- a/internal/runs/runs.go
+++ b/internal/runs/runs.go
@@ -16,6 +16,7 @@ package runs
 import (
 	"context"
 	cryptoRand "crypto/rand"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -37,6 +38,31 @@ const DefaultCooldown = 30 * time.Minute
 // from re-hitting the blocked admission, short enough to re-probe after the
 // client switches egress/VPN.
 const countryBlockCooldown = 15 * time.Minute
+
+// ip_capped bounded re-admission (#118, gap item 16). The CLI treats
+// ip_capped as TERMINAL for its poll loop (nextDelayMs returns null —
+// reference/freebuff use-freebuff-session.ts) and relies on a human to pace
+// the retry. The proxy is a server (no interactive user), so full terminal
+// breaks service: instead, re-admission is bounded — each hit backs off the
+// FULL server retryAfterMs + ±20% jitter, and after ipCappedMaxDailyAttempts
+// hits within a rolling ipCappedDailyWindow the token stops re-admitting
+// until the Pacific-midnight reset (treated like rate_limited's reset) and
+// surfaces 429 ip_capped to clients. This is a documented proxy deviation
+// from the CLI's fully-terminal behavior.
+const (
+	// ipCappedMaxDailyAttempts is the per-token daily re-admission budget:
+	// the Nth ip_capped hit in one window locks the token until the
+	// Pacific-midnight reset.
+	ipCappedMaxDailyAttempts = 3
+	// ipCappedJitterSpan is the symmetric jitter fraction (1/5 = ±20%,
+	// mirroring the CLI's jitterPollIntervalMs / pool sessionPollJittered).
+	ipCappedJitterSpan = 5
+)
+
+// ipCappedDailyWindow is the rolling window over which ip_capped
+// re-admission attempts are counted (a test-shrinkable var so tests can
+// exercise window rollover without sleeping 24h).
+var ipCappedDailyWindow = 24 * time.Hour
 
 // shutdownTimeout bounds Shutdown when the caller passes a context without a
 // deadline (PRD §5: "10s force deadline").
@@ -205,6 +231,15 @@ type RunManager struct {
 	// ip_capped + Retry-After instead of a generic cooldown 502.
 	ipCapped      *upstream.IpCappedError
 	ipCappedUntil time.Time
+	// ip_capped bounded re-admission (#118): ipCappedCount counts
+	// re-admission attempts within the rolling ipCappedDailyWindow starting
+	// at ipCappedWindowStart; when it reaches ipCappedMaxDailyAttempts the
+	// token is locked until ipCappedTerminalUntil (the Pacific-midnight
+	// reset, treated like rate_limited) instead of re-admitting on the
+	// short retryAfter window.
+	ipCappedCount         int
+	ipCappedWindowStart   time.Time
+	ipCappedTerminalUntil time.Time
 	// totalRequests is the cumulative count of Acquire leases handed out.
 	// It is kept separate from the per-run counters because rotated runs
 	// that get FINISHed leave the active+draining sets and would otherwise
@@ -636,6 +671,10 @@ func (m *RunManager) ClearCooldowns() {
 	m.countryUntil = time.Time{}
 	m.ipCapped = nil
 	m.ipCappedUntil = time.Time{}
+	// Unlock also resets the ip_capped daily re-admission budget (#118).
+	m.ipCappedCount = 0
+	m.ipCappedWindowStart = time.Time{}
+	m.ipCappedTerminalUntil = time.Time{}
 	m.mu.Unlock()
 }
 
@@ -668,12 +707,16 @@ func (m *RunManager) CooldownRateLimit(rle *upstream.RateLimitError) {
 	m.ipCapped = nil
 }
 
-// CooldownIpCapped applies an ip_capped cooldown bounded to the body's
-// retryAfterMs ONLY — never the Pacific-midnight quota lock (ip_capped is
-// admission-only, not tied to a quota reset). Remembered so Acquires keep
-// surfacing 429 ip_capped + Retry-After during the short window instead of
-// re-hitting upstream (mirrors CooldownRateLimit). Errors with
-// RetryAfter <= 0 are ignored.
+// CooldownIpCapped applies an ip_capped cooldown with bounded re-admission
+// (#118): each hit backs off the FULL server retryAfterMs + ±20% jitter,
+// and once the token hits ipCappedMaxDailyAttempts within a rolling
+// ipCappedDailyWindow it stops re-admitting until the Pacific-midnight
+// reset (treated like rate_limited's reset) — the proxy's server-model
+// deviation from the CLI's fully-terminal ip_capped (use-freebuff-session.ts
+// nextDelayMs returns null). Remembered so Acquires keep surfacing
+// 429 ip_capped + Retry-After during the window instead of re-hitting
+// upstream (mirrors CooldownRateLimit). Errors with RetryAfter <= 0 are
+// ignored.
 func (m *RunManager) CooldownIpCapped(ice *upstream.IpCappedError) {
 	if ice == nil {
 		return
@@ -683,8 +726,30 @@ func (m *RunManager) CooldownIpCapped(ice *upstream.IpCappedError) {
 	if ice.RetryAfter <= 0 {
 		return
 	}
+	now := time.Now()
+	// Rolling window: slide to a fresh window when 24h have elapsed since
+	// the first hit, or when a previous terminal lock (Pacific-midnight
+	// reset) has already expired — so a token capped out yesterday re-admits
+	// today instead of inheriting yesterday's count.
+	if m.ipCappedWindowStart.IsZero() ||
+		now.Sub(m.ipCappedWindowStart) >= ipCappedDailyWindow ||
+		(!m.ipCappedTerminalUntil.IsZero() && now.After(m.ipCappedTerminalUntil)) {
+		m.ipCappedWindowStart = now
+		m.ipCappedCount = 0
+		m.ipCappedTerminalUntil = time.Time{}
+	}
+	m.ipCappedCount++
 	m.ipCapped = ice
-	m.ipCappedUntil = time.Now().Add(ice.RetryAfter)
+	if m.ipCappedCount >= ipCappedMaxDailyAttempts {
+		// Daily budget exhausted: no more re-admission until the
+		// Pacific-midnight reset (rate_limited-style lock); the remembered
+		// error keeps surfacing 429 ip_capped meanwhile.
+		m.ipCappedTerminalUntil = upstream.NextPacificMidnight()
+		m.ipCappedUntil = m.ipCappedTerminalUntil
+	} else {
+		m.ipCappedTerminalUntil = time.Time{}
+		m.ipCappedUntil = now.Add(ipCappedJitter(ice.RetryAfter))
+	}
 	m.cooldownUntil = m.ipCappedUntil
 	m.rateLimit = nil
 	m.ban = nil
@@ -700,6 +765,25 @@ func (m *RunManager) IpCappedError() *upstream.IpCappedError {
 		return m.ipCapped
 	}
 	return nil
+}
+
+// ipCappedJitter applies the CLI's symmetric ±20% jitter around d for the
+// ip_capped re-admission backoff (the CLI jitters its poll intervals the
+// same way — jitterPollIntervalMs; reference/freebuff sdk
+// polling-backoff.ts).
+func ipCappedJitter(d time.Duration) time.Duration {
+	span := d / ipCappedJitterSpan
+	return d - span + time.Duration(ipCappedRand()%uint64(2*span+1))
+}
+
+// ipCappedRand mints a jitter draw from crypto/rand, falling back to a
+// time-seeded value on failure (mirrors pool.sessionRand).
+func ipCappedRand() uint64 {
+	var b [8]byte
+	if _, err := cryptoRand.Read(b[:]); err != nil {
+		return uint64(time.Now().UnixNano())
+	}
+	return binary.BigEndian.Uint64(b[:])
 }
 
 // RateLimitError returns the remembered rate-limit error while its

--- a/internal/runs/runs.go
+++ b/internal/runs/runs.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"freebuff-proxy/internal/session"
@@ -66,13 +67,14 @@ type Options struct {
 }
 
 // asyncJobKind discriminates the deferred-side-effect jobs carried by the
-// bounded finish queue (issue #90/#91): FINISH a rotated/drained run,
-// record a completed chat step, or create the context-pruner child run.
+// bounded finish queue (issue #90/#91): FINISH a rotated/drained run, or
+// create the context-pruner child run. Chat-step recording used to be a
+// third kind (#91) but is now a synchronous in-memory append (issue #114:
+// steps are batched and sent WITH FINISH — the CLI has no /steps endpoint).
 type asyncJobKind uint8
 
 const (
 	jobFinish asyncJobKind = iota
-	jobStep
 	jobChildRun
 )
 
@@ -80,10 +82,8 @@ const (
 // single background worker per RunManager; when the bounded queue is full
 // the caller runs the job inline bounded by the inline timeout.
 type asyncJob struct {
-	kind      asyncJobKind
-	run       *Run
-	messageID string
-	startTime time.Time
+	kind asyncJobKind
+	run  *Run
 }
 
 // newTraceSessionID mints a UUIDv4 trace session id from crypto/rand,
@@ -101,7 +101,9 @@ func newTraceSessionID() string {
 }
 
 // Run is one agent run leased to a caller. Requests counts acquires served
-// by this run; it is sent as totalSteps when the run is FINISHed.
+// by this run; it is used as the totalSteps fallback when no steps were
+// recorded (issue #114 — a step is one chat call, recorded in memory and
+// batched with FINISH).
 type Run struct {
 	AgentID   string
 	RunID     string
@@ -112,6 +114,25 @@ type Run struct {
 	// exactly like the CLI (run.ts: previousRun?.traceSessionId ??
 	// randomUUID; reference/proxy-freebuff lib/runs.js:43-46).
 	TraceSessionID string
+
+	// StepCount is the run's 1-based per-chat-call step counter, stamped
+	// as codebuff_metadata["llm_step_number"] (issue #113, CLI parity:
+	// run-agent-step.ts increments per step). Atomic: chatAttempt
+	// increments it while the manager goroutines may rotate/finish the
+	// run, so the server reaches it without the manager mutex.
+	StepCount atomic.Int64
+
+	// Steps accumulates the run's completed chat steps in memory (issue
+	// #114): they are batched and sent WITH FINISH — the CLI has no /steps
+	// endpoint, so step recording is local-only. Guarded by the manager
+	// mutex; snapshot under the lock at FINISH time.
+	Steps []upstream.RunStep
+
+	// Status is the run's terminal disposition reported in FINISH
+	// (completed/cancelled/failed, CLI parity run-agent-step.ts
+	// 1237-1341). Empty means completed. Set by ReleaseAbandoned
+	// (cancelled) and MarkFailed (failed); guarded by the manager mutex.
+	Status string
 
 	inflight  int  // leases outstanding; guarded by the manager mutex
 	finishing bool // FINISH in flight; guarded by the manager mutex
@@ -124,6 +145,13 @@ type Run struct {
 	// #55): the TTL eviction drops entries stuck draining past DrainTTL.
 	// Guarded by the manager mutex.
 	drainedAt time.Time
+}
+
+// NextStepNumber increments the run's 1-based per-chat step counter and
+// returns the new value. The server calls it once per chat call to stamp
+// codebuff_metadata["llm_step_number"] (issue #113).
+func (r *Run) NextStepNumber() int64 {
+	return r.StepCount.Add(1)
 }
 
 // runFlight coordinates single-flight coalescing for concurrent StartRun calls.
@@ -372,16 +400,18 @@ func (m *RunManager) InflightCount() int {
 	return n
 }
 
-// FinishRun FINISHes the run upstream with the given step accounting and
-// drops it from the active set. On upstream failure the run is put back on
-// the draining list so Maintain retries it. It does not touch inflight —
-// callers should have already Released the lease.
-func (m *RunManager) FinishRun(ctx context.Context, run *Run, totalSteps int) {
+// FinishRun FINISHes the run upstream with its recorded terminal status,
+// completed steps, and totalSteps (issue #114), then drops it from the
+// active set. On upstream failure the run is put back on the draining list
+// so Maintain retries it. It does not touch inflight — callers should have
+// already Released the lease.
+func (m *RunManager) FinishRun(ctx context.Context, run *Run) {
 	if run == nil {
 		return
 	}
 	m.drop(run)
-	if err := m.client.FinishRun(ctx, run.RunID, totalSteps); err != nil {
+	status, steps, totalSteps := m.finishPayload(run)
+	if err := m.client.FinishRun(ctx, run.RunID, status, totalSteps, steps, ""); err != nil {
 		// Keep the run around for a Maintain retry; the id is not
 		// necessarily dead upstream (network errors, 5xx).
 		m.mu.Lock()
@@ -478,13 +508,15 @@ func (m *RunManager) Shutdown(ctx context.Context) {
 	// counter survives.
 	if m.store != nil && m.key != "" {
 		m.mu.Lock()
-		snapshot := make([]Run, 0, len(m.runs))
+		snapshot := make([]*Run, 0, len(m.runs))
 		for _, run := range m.runs {
-			snapshot = append(snapshot, *run)
+			// cloneRun, never *run: the Run carries an atomic.Int64 step
+			// counter that must not be copied after first use.
+			snapshot = append(snapshot, m.cloneRun(run))
 		}
 		m.mu.Unlock()
-		for i := range snapshot {
-			m.persistRun(&snapshot[i])
+		for _, run := range snapshot {
+			m.persistRun(run)
 		}
 		m.keptForPersistence = true
 		if err := m.session.Shutdown(ctx); err != nil {
@@ -520,7 +552,8 @@ func (m *RunManager) Shutdown(ctx context.Context) {
 
 	var errs []string
 	for _, run := range all {
-		if err := m.client.FinishRun(ctx, run.RunID, run.Requests); err != nil {
+		status, steps, totalSteps := m.finishPayload(run)
+		if err := m.client.FinishRun(ctx, run.RunID, status, totalSteps, steps, ""); err != nil {
 			errs = append(errs, fmt.Sprintf("finish run %s: %v", run.RunID, err))
 		}
 	}
@@ -548,7 +581,8 @@ func (m *RunManager) FinishAllRuns(ctx context.Context) {
 
 	var errs []string
 	for _, run := range all {
-		if err := m.client.FinishRun(ctx, run.RunID, run.Requests); err != nil {
+		status, steps, totalSteps := m.finishPayload(run)
+		if err := m.client.FinishRun(ctx, run.RunID, status, totalSteps, steps, ""); err != nil {
 			errs = append(errs, fmt.Sprintf("finish run %s: %v", run.RunID, err))
 		} else {
 			m.removeRun(run)
@@ -947,8 +981,8 @@ func (m *RunManager) startFinishWorker() {
 	})
 }
 
-// finishLoop is the deferred-job worker: FINISH rotated/drained runs,
-// record chat steps, and create context-pruner child runs, all best-effort.
+// finishLoop is the deferred-job worker: FINISH rotated/drained runs and
+// create context-pruner child runs, all best-effort.
 func (m *RunManager) finishLoop() {
 	defer m.finishWg.Done()
 	defer close(m.finishExited)
@@ -975,19 +1009,12 @@ func (m *RunManager) finishLoop() {
 	}
 }
 
-// runJob executes one deferred job (FINISH / step / child run). Best-effort:
+// runJob executes one deferred job (FINISH or child run). Best-effort:
 // failures are logged, never surfaced to a caller.
 func (m *RunManager) runJob(ctx context.Context, job asyncJob) {
 	switch job.kind {
 	case jobFinish:
 		m.finishIfReadyCtx(ctx, job.run)
-	case jobStep:
-		if job.run == nil || job.run.RunID == "" || m.client == nil {
-			return
-		}
-		if err := m.client.RecordRunStep(ctx, job.run.RunID, job.messageID, job.startTime); err != nil {
-			slog.Debug("runs: record step failed", "run_id", job.run.RunID, "err", err)
-		}
 	case jobChildRun:
 		m.createChildRun(ctx, job.run)
 	}
@@ -1005,19 +1032,86 @@ func (m *RunManager) createChildRun(ctx context.Context, parent *Run) {
 		slog.Debug("runs: context-pruner child start failed", "parent_run_id", parent.RunID, "err", err)
 		return
 	}
-	if err := m.client.FinishRun(ctx, childID, 1); err != nil {
+	if err := m.client.FinishRun(ctx, childID, "completed", 1, nil, ""); err != nil {
 		slog.Debug("runs: context-pruner child finish failed", "child_run_id", childID, "err", err)
 	}
 }
 
-// RecordStep queues a completed-chat step recording for run (issue #91):
-// the server fires it after a successful chat with the response message id.
-// Best-effort through the bounded queue; failures are logged only.
+// RecordStep appends a completed-chat step to run's in-memory step list
+// (issue #114): steps are batched and sent WITH FINISH — the CLI has no
+// /steps endpoint, so recording is local-only and never touches the
+// network. The server fires it after a successful chat; messageID is the
+// completed chat response id ("" → null on the wire, allowed by the CLI
+// step schema). Step numbers are sequential 1,2,3… in completion order.
 func (m *RunManager) RecordStep(run *Run, messageID string) {
 	if run == nil || run.RunID == "" {
 		return
 	}
-	m.enqueue(asyncJob{kind: jobStep, run: run, messageID: messageID, startTime: time.Now()})
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var msgID *string
+	if messageID != "" {
+		msgID = &messageID
+	}
+	run.Steps = append(run.Steps, upstream.RunStep{
+		ID:         newTraceSessionID(),
+		StepNumber: len(run.Steps) + 1,
+		MessageID:  msgID,
+		Status:     "completed",
+		StartTime:  time.Now().UTC().Format(time.RFC3339Nano),
+	})
+}
+
+// MarkFailed records that run's chat died on a terminal upstream error so
+// its eventual FINISH reports status "failed" instead of "completed"
+// (issue #114: a gateway with zero failed runs looks synthetic). The server
+// calls it from the chat error path; the run stays active — only its
+// terminal status is recorded.
+func (m *RunManager) MarkFailed(run *Run) {
+	if run == nil {
+		return
+	}
+	m.mu.Lock()
+	run.Status = "failed"
+	m.mu.Unlock()
+}
+
+// finishPayload snapshots the run's recorded terminal status, steps, and
+// totalSteps for its FINISH (issue #114): status is honest
+// (completed/cancelled/failed), steps are batched and sent WITH FINISH, and
+// totalSteps prefers the recorded step count, falling back to the request
+// count when no steps were recorded (a prewarmed run that served no
+// successful chats still reports its activity). Caller does not hold m.mu.
+func (m *RunManager) finishPayload(run *Run) (status string, steps []upstream.RunStep, totalSteps int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	status = run.Status
+	if status == "" {
+		status = "completed"
+	}
+	steps = append([]upstream.RunStep(nil), run.Steps...)
+	totalSteps = len(steps)
+	if totalSteps == 0 {
+		totalSteps = run.Requests
+	}
+	return status, steps, totalSteps
+}
+
+// cloneRun copies run's snapshot-able fields without copying the atomic
+// step counter by value (atomic.Int64 must never be copied after first
+// use). Used by Shutdown's persistence snapshot.
+func (m *RunManager) cloneRun(run *Run) *Run {
+	c := &Run{
+		AgentID:        run.AgentID,
+		RunID:          run.RunID,
+		StartedAt:      run.StartedAt,
+		Requests:       run.Requests,
+		TraceSessionID: run.TraceSessionID,
+		Status:         run.Status,
+		Steps:          append([]upstream.RunStep(nil), run.Steps...),
+	}
+	c.StepCount.Store(run.StepCount.Load())
+	return c
 }
 
 // Precreate starts the run for agentID if none is fresh, without leasing it
@@ -1114,7 +1208,8 @@ func (m *RunManager) finishIfReadyCtx(ctx context.Context, run *Run) {
 	run.finishing = true
 	m.mu.Unlock()
 
-	if err := m.client.FinishRun(ctx, run.RunID, run.Requests); err != nil {
+	status, steps, totalSteps := m.finishPayload(run)
+	if err := m.client.FinishRun(ctx, run.RunID, status, totalSteps, steps, ""); err != nil {
 		m.mu.Lock()
 		run.finishing = false
 		m.mu.Unlock()
@@ -1142,7 +1237,9 @@ func (m *RunManager) finishIfReadyCtx(ctx context.Context, run *Run) {
 // abandoned agent run alive until rotation. Concurrent requests on the same
 // run keep it alive (inflight stays > 0). The decrement and the finish
 // decision happen under the manager mutex, so a racing Acquire can never
-// lease a run that is about to be finished.
+// lease a run that is about to be finished. The abandoned run FINISHes as
+// "cancelled" (issue #114): a run killed by a client disconnect must not
+// report completed — a gateway with zero cancelled runs looks synthetic.
 func (m *RunManager) ReleaseAbandoned(run *Run) {
 	if run == nil {
 		return
@@ -1156,9 +1253,12 @@ func (m *RunManager) ReleaseAbandoned(run *Run) {
 		m.mu.Unlock()
 		return
 	}
-	// Last lease on the run. If it is still the current run, drop it from
-	// the active set so no new acquire reuses it, then FINISH it. A run
-	// that already rotated away is owned by the draining queue.
+	// Last lease abandoned: the run must FINISH as cancelled, whichever
+	// finish path owns it (active drop or the draining queue).
+	run.Status = "cancelled"
+	// If it is still the current run, drop it from the active set so no
+	// new acquire reuses it, then FINISH it. A run that already rotated
+	// away is owned by the draining queue.
 	if current, ok := m.runs[run.AgentID]; ok && current == run {
 		delete(m.runs, run.AgentID)
 		m.mu.Unlock()

--- a/internal/runs/runs_edge_test.go
+++ b/internal/runs/runs_edge_test.go
@@ -47,7 +47,7 @@ func TestFinishRunFailureRetriesOnMaintain(t *testing.T) {
 	// The first FINISH fails upstream; the run must stay around for a
 	// Maintain retry, not be dropped.
 	mock.FinishFailures = 1
-	mgr.FinishRun(context.Background(), run, 3)
+	mgr.FinishRun(context.Background(), run)
 
 	if got := mock.FinishesStartedSnapshot(); got != 2 {
 		t.Fatalf("FINISH attempts = %d, want 2 (child + failed run)", got)

--- a/internal/runs/runs_test.go
+++ b/internal/runs/runs_test.go
@@ -110,11 +110,18 @@ func TestFinishRunDropsFromActive(t *testing.T) {
 	}
 	mgr.Release(run)
 
-	mgr.FinishRun(context.Background(), run, 3)
+	// Issue #114: record 3 completed steps — totalSteps must come from the
+	// recorded steps (preferred over the request-count fallback) and the
+	// steps must ride IN the FINISH payload.
+	for i := 0; i < 3; i++ {
+		mgr.RecordStep(run, "")
+	}
+	mgr.FinishRun(context.Background(), run)
 
 	eventually(t, "FINISH payload", func() bool {
 		f, ok := finishedRun(mock, "run-0001")
-		return ok && f.Status == "completed" && f.TotalSteps == 3
+		return ok && f.Status == "completed" && f.TotalSteps == 3 && len(f.Steps) == 3 &&
+			f.Steps[0].StepNumber == 1 && f.Steps[2].StepNumber == 3
 	})
 
 	// Dropped from active: the next acquire must START afresh.

--- a/internal/runs/runs_test.go
+++ b/internal/runs/runs_test.go
@@ -686,6 +686,66 @@ func TestClearCooldowns(t *testing.T) {
 	}
 }
 
+// TestCooldownIpCappedDailyCap verifies #118: after ipCappedMaxDailyAttempts
+// hits within one window the token stops re-admitting until the
+// Pacific-midnight reset (rate_limited-style lock) while still surfacing the
+// remembered 429 ip_capped error; ClearCooldowns resets the budget.
+func TestCooldownIpCappedDailyCap(t *testing.T) {
+	m := NewRunManager(nil, nil, time.Hour)
+	for i := 0; i < ipCappedMaxDailyAttempts; i++ {
+		m.CooldownIpCapped(&upstream.IpCappedError{RetryAfter: time.Second})
+	}
+	midnight := upstream.NextPacificMidnight()
+	until := m.CooldownUntil()
+	if until.Sub(midnight) > time.Second || until.Before(midnight) {
+		t.Errorf("CooldownUntil after %d hits = %v, want ≈ Pacific midnight %v (daily cap)", ipCappedMaxDailyAttempts, until, midnight)
+	}
+	if m.IpCappedError() == nil {
+		t.Error("remembered ip_capped error not surfaced during terminal window")
+	}
+
+	// Dashboard unlock resets the budget: the next hit gets a short jittered
+	// window again, not an immediate midnight lock.
+	m.ClearCooldowns()
+	if !m.CooldownUntil().IsZero() {
+		t.Fatal("ClearCooldowns did not clear the terminal window")
+	}
+	m.CooldownIpCapped(&upstream.IpCappedError{RetryAfter: time.Second})
+	if until := m.CooldownUntil(); until.After(time.Now().Add(2*time.Second)) || until.Before(time.Now()) {
+		t.Errorf("CooldownUntil after ClearCooldowns + hit = %v, want short jittered window", until)
+	}
+}
+
+// TestCooldownIpCappedJitterBounds verifies #118: the re-admission backoff
+// is the FULL server retryAfterMs + symmetric ±20% jitter, never shortened.
+func TestCooldownIpCappedJitterBounds(t *testing.T) {
+	m := NewRunManager(nil, nil, time.Hour)
+	m.CooldownIpCapped(&upstream.IpCappedError{RetryAfter: 60 * time.Second})
+	rem := time.Until(m.CooldownUntil())
+	if rem < 47*time.Second || rem > 72*time.Second {
+		t.Errorf("re-admission backoff = %s, want 60s ±20%% jitter in [48s,72s]", rem)
+	}
+}
+
+// TestCooldownIpCappedWindowSlides verifies #118: the attempt counter lives
+// in a rolling window — once the window slides (or a previous terminal lock
+// expires), the next hit starts fresh instead of inheriting yesterday's
+// count.
+func TestCooldownIpCappedWindowSlides(t *testing.T) {
+	orig := ipCappedDailyWindow
+	ipCappedDailyWindow = 5 * time.Millisecond
+	t.Cleanup(func() { ipCappedDailyWindow = orig })
+
+	m := NewRunManager(nil, nil, time.Hour)
+	m.CooldownIpCapped(&upstream.IpCappedError{RetryAfter: 100 * time.Millisecond})
+	time.Sleep(20 * time.Millisecond) // slide past the tiny window
+	m.CooldownIpCapped(&upstream.IpCappedError{RetryAfter: 100 * time.Millisecond})
+	until := m.CooldownUntil()
+	if until.Before(time.Now()) || until.After(time.Now().Add(time.Second)) {
+		t.Errorf("CooldownUntil after window slide = %v, want short ~100ms window (counter reset), not midnight", until)
+	}
+}
+
 func TestSingleFlightRunAcquisition(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()

--- a/internal/runs/wave3_test.go
+++ b/internal/runs/wave3_test.go
@@ -1,9 +1,10 @@
 package runs
 
 // Wave-3 tests: the bounded deferred-FINISH queue (#90), the draining-list
-// cap/TTL eviction (#55), abandoned-lease finish on client disconnect (#53),
-// context-pruner child runs + step recording (#91), and run persistence
-// across restarts (#40).
+// cap/TTL eviction (#55), abandoned-lease finish on client disconnect
+// (#53/#114), context-pruner child runs (#91) + step recording (#114: steps
+// are batched and sent WITH FINISH), and run persistence across restarts
+// (#40).
 
 import (
 	"context"
@@ -244,9 +245,11 @@ func TestReleaseAbandonedFinishesLastLease(t *testing.T) {
 	// FINISHed (upstream must not keep an abandoned run alive).
 	mgr.ReleaseAbandoned(run)
 
+	// Issue #114: an abandoned run must FINISH as cancelled, not completed —
+	// a gateway with zero cancelled runs looks synthetic.
 	eventually(t, "abandoned run FINISH", func() bool {
 		f, ok := finishedRun(mock, run.RunID)
-		return ok && f.Status == "completed"
+		return ok && f.Status == "cancelled"
 	})
 	mgr.mu.Lock()
 	_, active := mgr.runs[agentA]
@@ -308,7 +311,7 @@ func TestReleaseAbandonedKeepsConcurrentRequests(t *testing.T) {
 	mgr.Shutdown(context.Background())
 }
 
-func TestRecordStepQueued(t *testing.T) {
+func TestRecordStepBatchesWithFinish(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	mgr, _ := newTestManager(t, mock, time.Hour)
@@ -317,13 +320,21 @@ func TestRecordStepQueued(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Issue #114: steps are recorded in memory and batched with FINISH —
+	// recording must never hit the network (the CLI has no /steps
+	// endpoint), so the mock sees them only inside the FINISH payload.
 	mgr.RecordStep(run, "chatcmpl-123")
+	mgr.RecordStep(run, "chatcmpl-124")
+	mgr.FinishRun(context.Background(), run)
 
-	eventually(t, "step recorded", func() bool {
-		steps := mock.StepsSnapshot()
-		return len(steps) == 1 && steps[0].RunID == run.RunID &&
-			steps[0].StepNumber == 2 && steps[0].MessageID == "chatcmpl-123" &&
-			steps[0].Status == "completed"
+	eventually(t, "steps ride in FINISH", func() bool {
+		f, ok := finishedRun(mock, run.RunID)
+		if !ok || f.Status != "completed" || f.TotalSteps != 2 || len(f.Steps) != 2 {
+			return false
+		}
+		return f.Steps[0].StepNumber == 1 && f.Steps[0].MessageID != nil && *f.Steps[0].MessageID == "chatcmpl-123" &&
+			f.Steps[1].StepNumber == 2 && f.Steps[1].MessageID != nil && *f.Steps[1].MessageID == "chatcmpl-124" &&
+			f.Steps[1].Status == "completed" && f.Steps[0].StartTime != ""
 	})
 	mgr.Shutdown(context.Background())
 }
@@ -405,7 +416,7 @@ func TestRunPersistenceAdoptAndFinish(t *testing.T) {
 
 	// FINISHing the run must remove it from the store so a third restart
 	// does not resurrect it.
-	mgr2.FinishRun(context.Background(), adopted, 1)
+	mgr2.FinishRun(context.Background(), adopted)
 	eventually(t, "FINISH lands", func() bool {
 		_, ok := finishedRun(mock, adopted.RunID)
 		return ok

--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -785,6 +785,7 @@ func (s *Server) relayAnthropicStream(ctx context.Context, w http.ResponseWriter
 			if usage, ok := chunk["usage"]; ok && usage != nil {
 				if um, ok := usage.(map[string]any); ok {
 					st.usage = openAIUsageToAnthropic(um)
+					stats.usageTokens = usageTotalTokens(um) // #122 spend ledger
 				}
 			}
 			s.accumulateAnthropicChunk(send, st, chunk)
@@ -1135,6 +1136,9 @@ func (s *Server) relayAnthropicJSON(ctx context.Context, w http.ResponseWriter, 
 		s.writeJSONError(w, http.StatusBadGateway,
 			"failed to build response: "+err.Error(), "upstream_error", "upstream_unavailable", 0)
 		return
+	}
+	if usage, ok := completion["usage"].(map[string]any); ok {
+		stats.usageTokens = usageTotalTokens(usage) // #122 spend ledger
 	}
 	stats.bytes = len(out)
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/server/auth_internal_test.go
+++ b/internal/server/auth_internal_test.go
@@ -156,7 +156,7 @@ func assertNoTmpFiles(t *testing.T, dir, base string) {
 }
 
 // errorResponse decodes the OpenAI error shape writeError produces.
-func errorResponse(t *testing.T, err error) (status int, body struct {
+func errorResponse(t *testing.T, err error) (status int, hdr http.Header, body struct {
 	Error struct {
 		Message string `json:"message"`
 		Type    string `json:"type"`
@@ -172,7 +172,7 @@ func errorResponse(t *testing.T, err error) (status int, body struct {
 	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
 		t.Fatalf("writeError response is not JSON: %v: %s", err, w.Body.Bytes())
 	}
-	return w.Code, body
+	return w.Code, w.Header(), body
 }
 
 // TestWriteErrorNewMappings pins the self-healing error matrix additions:
@@ -181,7 +181,7 @@ func errorResponse(t *testing.T, err error) (status int, body struct {
 func TestWriteErrorNewMappings(t *testing.T) {
 	t.Run("country blocked 403", func(t *testing.T) {
 		err := &upstream.CountryBlockedError{CountryCode: "CN", CountryBlockReason: "region_restricted", IpPrivacySignals: []string{"vpn"}}
-		status, body := errorResponse(t, err)
+		status, _, body := errorResponse(t, err)
 		if status != http.StatusForbidden {
 			t.Errorf("status = %d, want 403", status)
 		}
@@ -195,7 +195,7 @@ func TestWriteErrorNewMappings(t *testing.T) {
 
 	t.Run("free mode cli required 403", func(t *testing.T) {
 		err := fmt.Errorf("free tier gate: %w", upstream.ErrFreeModeCLIRequired)
-		status, body := errorResponse(t, err)
+		status, _, body := errorResponse(t, err)
 		if status != http.StatusForbidden {
 			t.Errorf("status = %d, want 403", status)
 		}
@@ -210,7 +210,7 @@ func TestWriteErrorNewMappings(t *testing.T) {
 	t.Run("credits 402 with body passthrough", func(t *testing.T) {
 		const upstreamBody = `{"error":"out of credits","model":"deepseek/deepseek-v4-flash"}`
 		err := &upstream.CreditsError{Status: http.StatusPaymentRequired, Body: upstreamBody}
-		status, body := errorResponse(t, err)
+		status, _, body := errorResponse(t, err)
 		if status != http.StatusPaymentRequired {
 			t.Errorf("status = %d, want 402", status)
 		}
@@ -225,9 +225,41 @@ func TestWriteErrorNewMappings(t *testing.T) {
 		}
 	})
 
+	t.Run("waiting room required 503 with retry-after", func(t *testing.T) {
+		// #116: 428 waiting_room_required surfaces as 503 waiting_room_required
+		// + Retry-After — NEVER a bare 502.
+		err := &upstream.WaitingRoomRequiredError{RetryAfter: 45 * time.Second, Detail: `{"error":"waiting_room_required"}`}
+		status, hdr, body := errorResponse(t, err)
+		if status != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want 503", status)
+		}
+		if body.Error.Code != "waiting_room_required" {
+			t.Errorf("code = %q, want waiting_room_required", body.Error.Code)
+		}
+		if got := hdr.Get("Retry-After"); got != "45" {
+			t.Errorf("Retry-After = %q, want 45 (the refusal's retryAfter, ceil seconds)", got)
+		}
+	})
+
+	t.Run("session superseded 409", func(t *testing.T) {
+		// #119: 409 session_superseded — terminal, no auto-rejoin.
+		const upstreamBody = `{"error":"session_superseded","message":"another CLI took over"}`
+		err := &upstream.SessionSupersededError{Status: http.StatusConflict, Body: upstreamBody}
+		status, _, body := errorResponse(t, err)
+		if status != http.StatusConflict {
+			t.Errorf("status = %d, want 409", status)
+		}
+		if body.Error.Code != "session_superseded" {
+			t.Errorf("code = %q, want session_superseded", body.Error.Code)
+		}
+		if body.Error.Message != upstreamBody {
+			t.Errorf("message = %q, want upstream body verbatim", body.Error.Message)
+		}
+	})
+
 	t.Run("upstream deadline 504", func(t *testing.T) {
 		err := fmt.Errorf("chat: %w", context.DeadlineExceeded)
-		status, body := errorResponse(t, err)
+		status, _, body := errorResponse(t, err)
 		if status != http.StatusGatewayTimeout {
 			t.Errorf("status = %d, want 504", status)
 		}
@@ -244,17 +276,17 @@ func TestWriteErrorNewMappings(t *testing.T) {
 // 403 account_banned, rate limit 429, waiting room 503 — the new mappings
 // must not shadow them.
 func TestWriteErrorExistingMappingsUnchanged(t *testing.T) {
-	status, body := errorResponse(t, &upstream.BanError{ResumesAt: time.Now().Add(time.Hour), Body: `{"status":"banned"}`})
+	status, _, body := errorResponse(t, &upstream.BanError{ResumesAt: time.Now().Add(time.Hour), Body: `{"status":"banned"}`})
 	if status != http.StatusForbidden || body.Error.Code != "account_banned" {
 		t.Errorf("ban: status=%d code=%q, want 403 account_banned", status, body.Error.Code)
 	}
 
-	status, body = errorResponse(t, &upstream.RateLimitError{RetryAfter: time.Minute})
+	status, _, body = errorResponse(t, &upstream.RateLimitError{RetryAfter: time.Minute})
 	if status != http.StatusTooManyRequests || body.Error.Code != "rate_limited" {
 		t.Errorf("rate limit: status=%d code=%q, want 429 rate_limited", status, body.Error.Code)
 	}
 
-	status, body = errorResponse(t, &upstream.WaitingRoomError{RetryAfter: time.Minute})
+	status, _, body = errorResponse(t, &upstream.WaitingRoomError{RetryAfter: time.Minute})
 	if status != http.StatusServiceUnavailable || body.Error.Code != "waiting_room_queued" {
 		t.Errorf("waiting room: status=%d code=%q, want 503 waiting_room_queued", status, body.Error.Code)
 	}
@@ -386,7 +418,7 @@ func TestWriteFileAtomicFailurePreservesTarget(t *testing.T) {
 func TestWriteErrorIpCappedAndSessionLimit(t *testing.T) {
 	t.Run("ip capped 429", func(t *testing.T) {
 		err := &upstream.IpCappedError{ActiveUsersForIP: 5, Limit: 4, RetryAfter: 45 * time.Second, Body: `{"status":"ip_capped"}`}
-		status, body := errorResponse(t, err)
+		status, _, body := errorResponse(t, err)
 		if status != http.StatusTooManyRequests {
 			t.Errorf("status = %d, want 429", status)
 		}
@@ -399,7 +431,7 @@ func TestWriteErrorIpCappedAndSessionLimit(t *testing.T) {
 	})
 	t.Run("session limit reached 409", func(t *testing.T) {
 		err := &upstream.SessionLimitError{Status: http.StatusConflict, Body: `{"error":{"code":"session_limit_reached"}}`}
-		status, body := errorResponse(t, err)
+		status, _, body := errorResponse(t, err)
 		if status != http.StatusConflict {
 			t.Errorf("status = %d, want 409", status)
 		}

--- a/internal/server/responses.go
+++ b/internal/server/responses.go
@@ -481,6 +481,7 @@ func (s *Server) relayResponsesStream(ctx context.Context, w http.ResponseWriter
 			}
 			if usage, ok := chunk["usage"]; ok && usage != nil {
 				st.usage = usage
+				stats.usageTokens = usageTotalTokens(usage) // #122 spend ledger
 			}
 			s.accumulateResponsesChunk(st, chunk, send)
 		}
@@ -694,6 +695,7 @@ func (s *Server) relayResponsesJSON(ctx context.Context, w http.ResponseWriter, 
 	resp["output"] = out
 	if usage, ok := completion["usage"]; ok && usage != nil {
 		resp["usage"] = responsesUsage(usage)
+		stats.usageTokens = usageTotalTokens(usage) // #122 spend ledger
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2802,6 +2802,7 @@ func (s *Server) writeError(w http.ResponseWriter, r *http.Request, err error) {
 	var be *upstream.BanError
 	var cbe *upstream.CountryBlockedError
 	var ce *upstream.CreditsError
+	var cde *upstream.CapacityDeferredError
 	switch {
 	case errors.As(err, &be):
 		status, code = http.StatusForbidden, "account_banned"
@@ -2840,6 +2841,23 @@ func (s *Server) writeError(w http.ResponseWriter, r *http.Request, err error) {
 	case errors.As(err, &uwr):
 		status, code = http.StatusServiceUnavailable, "waiting_room_queued"
 		message, retryAfter = uwr.Error(), uwr.RetryAfter
+	case errors.As(err, &cde):
+		// #105 (server half): the client's capacity-deferred retry budget
+		// (TRANSIENT_RETRIES) is exhausted, so the free tier's transient
+		// capacity queue is surfaced to downstream clients as 429 +
+		// Retry-After — they must honor the window, not hammer a 502/503.
+		// MUST precede the generic errors.As(err, &ue) branch: the error
+		// unwraps to a Retryable UpstreamError, which would otherwise be
+		// swallowed as 503 upstream_retryable.
+		status, code = http.StatusTooManyRequests, "free_mode_capacity_deferred"
+		message = cde.Body
+		if message == "" {
+			message = cde.Error()
+		}
+		retryAfter = cde.RetryAfter
+		if retryAfter <= 0 {
+			retryAfter = 10 * time.Second
+		}
 	case errors.As(err, &ue):
 		if ue.Retryable {
 			// deployment_outside_hours etc.: temporarily unavailable, worth

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1961,6 +1961,10 @@ func (s *Server) chatCore(w http.ResponseWriter, r *http.Request, model string, 
 	if err != nil {
 		phases.Since(phasetiming.TotalMS, start)
 		s.traceChat(lease, model, time.Since(start).Milliseconds(), "error", chatErrClass(err), phases.All())
+		// Issue #114: a chat that died on a terminal upstream error must
+		// not leave its run FINISHing as completed — report it honestly
+		// (nil-safe: an acquire failure leaves no lease).
+		s.pool.MarkRunFailed(lease)
 		s.writeError(w, r, err)
 		return
 	}
@@ -2007,6 +2011,11 @@ func (s *Server) chatCore(w http.ResponseWriter, r *http.Request, model string, 
 	chatStart := time.Now()
 	stats := &relayStats{}
 	relay(ctx, w, up, stats, chatStart)
+	// Issue #114: record the completed chat as a run step — steps are
+	// batched in memory and sent WITH FINISH (the CLI has no /steps
+	// endpoint). The response message id is not extracted from the stream;
+	// the CLI step schema allows a null messageId.
+	s.pool.RecordRunStep(lease, "")
 	phases.Since(phasetiming.TotalMS, start)
 	ms := time.Since(start).Milliseconds()
 	s.logger.Info(kind+" done", chatDoneAttrs(model, lease.AgentID, stream, ms, stats.chunks, stats.bytes, reasoningEffort)...)
@@ -2128,6 +2137,12 @@ func (s *Server) chatAttempt(
 		RunID:             lease.Run.RunID,
 		SessionInstanceID: lease.SessionInstanceID,
 		TraceSessionID:    lease.Run.TraceSessionID,
+		// Issue #113: stamp the run's 1-based per-chat step counter so
+		// codebuff_metadata["llm_step_number"] matches the CLI (each chat
+		// call is one agent step; run-agent-step.ts increments per step).
+		// Incremented once per chatAttempt — the retry-once loop below
+		// retries the SAME step.
+		StepNumber: int(lease.Run.NextStepNumber()),
 	}
 
 	released := false
@@ -2233,6 +2248,12 @@ func (s *Server) chatAttempt(
 			}
 		}
 		opts.Model = effectiveModel
+		if lease.Run.RunID != opts.RunID {
+			// The retry landed on a FRESH run (run-invalid path): the new
+			// run's step counter starts at 1 — stamp its number so
+			// llm_step_number stays per-run like the CLI.
+			opts.StepNumber = int(lease.Run.NextStepNumber())
+		}
 		opts.RunID = lease.Run.RunID
 		opts.SessionInstanceID = lease.SessionInstanceID
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2016,6 +2016,10 @@ func (s *Server) chatCore(w http.ResponseWriter, r *http.Request, model string, 
 	// endpoint). The response message id is not extracted from the stream;
 	// the CLI step schema allows a null messageId.
 	s.pool.RecordRunStep(lease, "")
+	// Issue #122: feed the per-token spend ledger once per successful chat
+	// completion with the usage total observed by the relay (0 when the
+	// upstream stream carried none — RecordSpend ignores non-positive).
+	s.pool.RecordSpend(lease, stats.usageTokens)
 	phases.Since(phasetiming.TotalMS, start)
 	ms := time.Since(start).Milliseconds()
 	s.logger.Info(kind+" done", chatDoneAttrs(model, lease.AgentID, stream, ms, stats.chunks, stats.bytes, reasoningEffort)...)
@@ -2059,8 +2063,10 @@ func chatErrClass(err error) string {
 		return "ip_capped"
 	case *upstream.SessionLimitError:
 		return "session_limit_reached"
-	case *upstream.WaitingRoomError, *session.WaitingRoomError:
+	case *upstream.WaitingRoomError, *session.WaitingRoomError, *upstream.WaitingRoomRequiredError:
 		return "waiting_room"
+	case *upstream.SessionSupersededError:
+		return "session_superseded"
 	case *upstream.UpstreamError:
 		return "upstream"
 	default:
@@ -2170,6 +2176,30 @@ func (s *Server) chatAttempt(
 			if attempts > 1 {
 				return nil, nil, err
 			}
+		case errors.Is(err, upstream.ErrWaitingRoomRequired):
+			// #116: 428 waiting_room_required is session-ENDING
+			// (endsTheSession:true — the seat is gone mid-chat;
+			// reference/freebuff freebuff-session.ts FREEBUFF_GATE_CODES).
+			// Drop the cached session and re-admit ONCE for this request
+			// (mirror the ErrSessionInvalid budget: attempts > 1 surfaces
+			// the error; the WAITING_ROOM_CHAIN fires before the next
+			// create). Never loops — a single reacquire, then surface.
+			release()
+			invalidateSession(lease)
+			if attempts > 1 {
+				return nil, nil, err
+			}
+		case errors.Is(err, upstream.ErrSessionSuperseded):
+			// #119: 409 session_superseded is TERMINAL — another instance
+			// took over the account. Drop the cached row so the NEXT
+			// request (operator/next-call) re-joins fresh, but NEVER
+			// auto-reacquire within this request: auto-takeover risks
+			// ping-pong with the other instance (reference/freebuff
+			// send-message.ts handleFreebuffGateError, use-freebuff-session.ts
+			// nextDelayMs returns null for superseded).
+			release()
+			invalidateSession(lease)
+			return nil, nil, err
 		case errors.Is(err, upstream.ErrRunInvalid):
 			release()
 			invalidateRun(lease, lease.AgentID)
@@ -2196,9 +2226,11 @@ func (s *Server) chatAttempt(
 			return nil, nil, err
 		case errors.Is(err, upstream.ErrIpCapped):
 			// ip_capped is admission-only (too many distinct users on the
-			// egress IP), NOT a quota reset: cool the token only until the
-			// body's retryAfterMs — never the Pacific-midnight lock — and
-			// never invalidate the session (existing sessions keep running).
+			// egress IP), NOT a quota reset: cool the token via
+			// cooldownIpCapped's bounded re-admission (#118) — full
+			// retryAfterMs + jitter, capped per token per day (the 3rd hit
+			// in a rolling window locks until Pacific midnight) — and never
+			// invalidate the session (existing sessions keep running).
 			var ice *upstream.IpCappedError
 			if errors.As(err, &ice) {
 				cooldownIpCapped(lease, ice)
@@ -2213,6 +2245,15 @@ func (s *Server) chatAttempt(
 			if errors.As(err, &cbe) {
 				cooldownCountry(lease, cbe)
 			}
+			release()
+			return nil, nil, err
+		case errors.Is(err, upstream.ErrCredits):
+			// #117: 402 is NEVER retried — the CLI throws immediately and
+			// 402 is NOT in RETRYABLE_STATUS_CODES (reference/freebuff sdk
+			// error-utils.ts line 16; run-agent-step.ts throws on 402). A
+			// blind retry would burn a fresh lease against the same quota
+			// wall (2 upstream chat POSTs). Surface for writeError, which
+			// maps it to 402 out_of_credits.
 			release()
 			return nil, nil, err
 		default:
@@ -2272,6 +2313,23 @@ func tokenLabel(lease *pool.Lease) string {
 type relayStats struct {
 	chunks int
 	bytes  int
+	// usageTokens is the upstream usage total of the completed chat (the
+	// final usage block), fed to the pool spend ledger once per successful
+	// completion (#122). 0 when the stream carried no usage.
+	usageTokens int64
+}
+
+// usageTotalTokens extracts the token total from a chat usage object
+// (total_tokens, falling back to prompt+completion). Returns 0 when absent.
+// Feeds the per-token spend ledger (#122).
+func usageTotalTokens(usage any) int64 {
+	u, _ := usage.(map[string]any)
+	if total, ok := intOf(u["total_tokens"]); ok && total > 0 {
+		return total
+	}
+	prompt, _ := intOf(u["prompt_tokens"])
+	completion, _ := intOf(u["completion_tokens"])
+	return prompt + completion
 }
 
 // keepaliveInterval is how long the relay may sit without relaying a data
@@ -2384,6 +2442,19 @@ func (s *Server) relayStream(ctx context.Context, w http.ResponseWriter, r io.Re
 				relayed = time.Now()
 				continue
 			}
+			// The final chunk carries the usage block (or a usage-only
+			// chunk when stream_options.include_usage is set); capture its
+			// total for the spend ledger (#122). Cheap substring probe, so
+			// the per-chunk path only pays for an unmarshal on the usage
+			// chunk itself.
+			if bytes.Contains(clean, []byte(`"usage"`)) {
+				var u struct {
+					Usage any `json:"usage"`
+				}
+				if json.Unmarshal(clean, &u) == nil {
+					stats.usageTokens = usageTotalTokens(u.Usage)
+				}
+			}
 			if first {
 				first = false
 				phasetiming.FromContext(ctx).Since(phasetiming.UpstreamTTFBMS, chatStart)
@@ -2434,6 +2505,13 @@ func (s *Server) relayJSON(ctx context.Context, w http.ResponseWriter, r io.Read
 	}
 	out := acc.Finish()
 	stats.bytes = len(out)
+	// Capture the accumulated usage total for the spend ledger (#122).
+	var usageObj struct {
+		Usage any `json:"usage"`
+	}
+	if json.Unmarshal(out, &usageObj) == nil {
+		stats.usageTokens = usageTotalTokens(usageObj.Usage)
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(out)
@@ -2795,6 +2873,8 @@ func (s *Server) writeError(w http.ResponseWriter, r *http.Request, err error) {
 
 	var wr *session.WaitingRoomError
 	var uwr *upstream.WaitingRoomError
+	var wrr *upstream.WaitingRoomRequiredError
+	var sse *upstream.SessionSupersededError
 	var ue *upstream.UpstreamError
 	var rle *upstream.RateLimitError
 	var ice *upstream.IpCappedError
@@ -2841,6 +2921,26 @@ func (s *Server) writeError(w http.ResponseWriter, r *http.Request, err error) {
 	case errors.As(err, &uwr):
 		status, code = http.StatusServiceUnavailable, "waiting_room_queued"
 		message, retryAfter = uwr.Error(), uwr.RetryAfter
+	case errors.As(err, &wrr):
+		// #116: 428 waiting_room_required (endsTheSession:true — the seat
+		// is gone; chatAttempt already dropped the cached session and
+		// re-admitted once). 503 + the refusal's Retry-After — NEVER a bare
+		// 502. MUST precede the generic UpstreamError branch.
+		status, code = http.StatusServiceUnavailable, "waiting_room_required"
+		message, retryAfter = wrr.Error(), wrr.RetryAfter
+		if retryAfter < 0 {
+			retryAfter = 0
+		}
+	case errors.As(err, &sse):
+		// #119: 409 session_superseded — another instance took over the
+		// account. Terminal for this request: 409 + the upstream body, no
+		// auto-rejoin (the cached row was dropped in chatAttempt so the
+		// next request re-joins fresh).
+		status, code = http.StatusConflict, "session_superseded"
+		message = sse.Body
+		if message == "" {
+			message = "session superseded"
+		}
 	case errors.As(err, &cde):
 		// #105 (server half): the client's capacity-deferred retry budget
 		// (TRANSIENT_RETRIES) is exhausted, so the free tier's transient

--- a/internal/server/server_edge_test.go
+++ b/internal/server/server_edge_test.go
@@ -540,13 +540,16 @@ func TestChatCountryBlockCooldown(t *testing.T) {
 }
 
 // TestBridgeChatSessionInvalidBoundedRetry pins the bridge-path recovery
-// budget: a session_superseded chat error recreates the session once and
+// budget: a session-invalid chat error recreates the session once and
 // retries, then fails with 502 — never an unbounded recreate loop.
+// session_superseded is its OWN terminal sentinel (see
+// TestBridgeChatSessionSupersededTerminal) — this test uses session_expired
+// to pin the invalidate+reacquire-once budget for ErrSessionInvalid.
 func TestBridgeChatSessionInvalidBoundedRetry(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	mock.ChatStatus = http.StatusBadRequest
-	mock.ChatErrorBody = `{"error":{"message":"session_superseded"}}`
+	mock.ChatErrorBody = `{"error":{"message":"session_expired"}}`
 	ts, _ := newBridgeTestServer(t, mock)
 
 	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA),
@@ -562,6 +565,32 @@ func TestBridgeChatSessionInvalidBoundedRetry(t *testing.T) {
 	}
 	if got := mock.SessionCreates; got != 2 {
 		t.Errorf("upstream session creates = %d, want exactly 2 (session recreated once)", got)
+	}
+}
+
+// TestBridgeChatSessionSupersededTerminal pins #119 on the bridge path: 409
+// session_superseded surfaces immediately (409 session_superseded) with NO
+// in-request reacquire — one chat attempt, one session create.
+func TestBridgeChatSessionSupersededTerminal(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.ChatStatus = http.StatusBadRequest
+	mock.ChatErrorBody = `{"error":{"message":"session_superseded"}}`
+	ts, _ := newBridgeTestServer(t, mock)
+
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA),
+		map[string]string{"Authorization": "Bearer client-tok-ss"})
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, data)
+	}
+	if !strings.Contains(string(data), "session_superseded") {
+		t.Errorf("body missing session_superseded: %s", data)
+	}
+	if got := len(mock.RecordedChatHeaders); got != 1 {
+		t.Errorf("upstream chat attempts = %d, want exactly 1 (no auto-reacquire on superseded)", got)
+	}
+	if got := mock.SessionCreates; got != 1 {
+		t.Errorf("upstream session creates = %d, want exactly 1 (no in-request rejoin)", got)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -164,11 +165,13 @@ func TestChatStream(t *testing.T) {
 		t.Fatalf("upstream chat calls = %d, want 1", len(mock.RecordedChatHeaders))
 	}
 	h := mock.RecordedChatHeaders[0]
-	if got := h.Get("x-freebuff-model"); got != modelA {
-		t.Errorf("x-freebuff-model = %q, want %q", got, modelA)
+	// #106: the chat POST carries no model/instance headers — they ride in
+	// the body metadata only.
+	if got := h.Get("x-freebuff-model"); got != "" {
+		t.Errorf("x-freebuff-model = %q on the chat POST, want absent (#106)", got)
 	}
-	if got := h.Get("x-freebuff-instance-id"); got != "inst-abc-123" {
-		t.Errorf("x-freebuff-instance-id = %q, want inst-abc-123", got)
+	if got := h.Get("x-freebuff-instance-id"); got != "" {
+		t.Errorf("x-freebuff-instance-id = %q on the chat POST, want absent (#106)", got)
 	}
 	recorded := mock.RecordedChatBodies[0]
 	for _, want := range []string{`"codebuff_metadata"`, `"data_collection":"deny"`, `"stream":true`, `"stop":["cb_easp"]`, `"run_id":"run-0001"`} {
@@ -176,14 +179,18 @@ func TestChatStream(t *testing.T) {
 			t.Errorf("upstream body missing %s: %s", want, recorded)
 		}
 	}
-	// #80+#52: trace_session_id is minted once per run and threaded through
-	// the envelope; client_id is stable per SESSION INSTANCE (derived from
-	// the instance id, #52), not a fresh per-request draw.
+	// #80+#103: trace_session_id is minted once per run and threaded through
+	// the envelope; client_id is a FRESH random 13-char base36 draw per chat
+	// call — never the sess:/run:-prefixed shapes the server fingerprints as
+	// a proxy.
 	if !strings.Contains(recorded, `"trace_session_id":"`) {
 		t.Errorf("upstream body missing trace_session_id: %s", recorded)
 	}
-	if !strings.Contains(recorded, `"client_id":"sess:inst-abc-123"`) {
-		t.Errorf("upstream body missing session-stable client_id sess:inst-abc-123: %s", recorded)
+	if strings.Contains(recorded, `"client_id":"sess:`) || strings.Contains(recorded, `"client_id":"run:`) {
+		t.Errorf("upstream body carries a prefixed client_id: %s", recorded)
+	}
+	if !regexp.MustCompile(`"client_id":"[a-z0-9]{13}"`).MatchString(recorded) {
+		t.Errorf("upstream body missing a 13-char base36 client_id: %s", recorded)
 	}
 }
 
@@ -919,8 +926,16 @@ func TestSmokeDefaultsToFallbackModel(t *testing.T) {
 	if len(mock.RecordedChatHeaders) == 0 {
 		t.Fatal("no upstream chat recorded")
 	}
-	if got := mock.RecordedChatHeaders[0].Get("x-freebuff-model"); got != "deepseek/deepseek-v4-flash" {
-		t.Errorf("smoke probe model = %q, want deepseek/deepseek-v4-flash", got)
+	// #106: the smoke probe is a chat POST — the model rides in the body,
+	// not an x-freebuff-model header.
+	if got := mock.RecordedChatHeaders[0].Get("x-freebuff-model"); got != "" {
+		t.Errorf("smoke probe chat POST carries x-freebuff-model %q, want absent (#106)", got)
+	}
+	if len(mock.RecordedChatBodies) == 0 {
+		t.Fatal("no upstream chat body recorded")
+	}
+	if !strings.Contains(mock.RecordedChatBodies[0], `"model":"deepseek/deepseek-v4-flash"`) {
+		t.Errorf("smoke probe body missing model deepseek/deepseek-v4-flash: %s", mock.RecordedChatBodies[0])
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1593,6 +1593,70 @@ func TestUpstreamRetryableNotBlindRetried(t *testing.T) {
 	}
 }
 
+// TestChatCapacityDeferredSurfaced429 verifies #105 (server half): once the
+// client-side capacity-deferred budget is exhausted, the gateway surfaces the
+// free tier's transient capacity queue as 429 free_mode_capacity_deferred +
+// Retry-After (the upstream window) — never the old bare 502 upstream_
+// unavailable or a generic 503 upstream_retryable — so downstream clients
+// honor the window instead of re-POSTing immediately. The mock sees exactly
+// one chat call: the typed error unwraps to a Retryable UpstreamError, so
+// chatAttempt must not blind-retry it a second time.
+func TestChatCapacityDeferredSurfaced429(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	var chatCalls atomic.Int32
+	mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
+		chatCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "7")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"code":"free_mode_capacity_deferred","message":"Free mode is at capacity; your request will be retried automatically","retryAfterMs":7000}}`)
+	}
+	// TRANSIENT_RETRIES=0 = exhausted budget: the client surfaces the typed
+	// CapacityDeferredError immediately (no in-place retry, no retry-after
+	// sleep), so the server mapping is exercised on the first call.
+	ts, _ := newTestServerCfg(t, nil, func(cfg *config.Config) { cfg.TransientRetries = 0 }, mock)
+
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429: %s", resp.StatusCode, data)
+	}
+	if ra := resp.Header.Get("Retry-After"); ra != "7" {
+		t.Errorf("Retry-After = %q, want 7 (the upstream window, ceil seconds)", ra)
+	}
+	if !strings.Contains(string(data), `"code":"free_mode_capacity_deferred"`) {
+		t.Errorf("body missing free_mode_capacity_deferred code: %s", data)
+	}
+	if got := chatCalls.Load(); got != 1 {
+		t.Errorf("upstream chat calls = %d, want 1 (no blind retry after budget exhaustion)", got)
+	}
+}
+
+// TestChatCapacityDeferredDefaultRetryAfter verifies the 10s Retry-After
+// fallback when the upstream free_mode_capacity_deferred response carries no
+// retry-after window (the AI SDK's default honor window).
+func TestChatCapacityDeferredDefaultRetryAfter(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"code":"free_mode_capacity_deferred","message":"Free mode is at capacity; your request will be retried automatically"}}`)
+	}
+	ts, _ := newTestServerCfg(t, nil, func(cfg *config.Config) { cfg.TransientRetries = 0 }, mock)
+
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429: %s", resp.StatusCode, data)
+	}
+	if ra := resp.Header.Get("Retry-After"); ra != "10" {
+		t.Errorf("Retry-After = %q, want 10 (default window)", ra)
+	}
+	if !strings.Contains(string(data), `"code":"free_mode_capacity_deferred"`) {
+		t.Errorf("body missing free_mode_capacity_deferred code: %s", data)
+	}
+}
+
 // TestBridgeModeHealthzReportsMode pins the healthz "mode" field in pure
 // bridge mode.
 func TestBridgeModeHealthzReportsMode(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -275,6 +275,46 @@ func TestChatNonStream(t *testing.T) {
 	}
 }
 
+// TestChatFeedsSpendLedger pins the #122 spend feeder: every successful chat
+// completion records the upstream usage total into the token's spend ledger
+// (streaming and non-stream paths), so SpendDay/Spend24h reflect real usage
+// instead of the pre-wiring zeros.
+func TestChatFeedsSpendLedger(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.ChatBody = testutil.SSEEvent(chunk("chatcmpl-s1", 1, `"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]`)) +
+		testutil.SSEEvent(chunk("chatcmpl-s1", 1, `"choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":11,"completion_tokens":2,"total_tokens":13}`))
+	ts, pool := newTestServer(t, nil, mock)
+
+	req := `{"model":"` + modelA + `","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", []byte(req), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stream status = %d, want 200: %s", resp.StatusCode, data)
+	}
+
+	snaps := pool.Snapshot()
+	if len(snaps) != 1 {
+		t.Fatalf("pool tokens = %d, want 1", len(snaps))
+	}
+	if snaps[0].SpendDay != 13 || snaps[0].Spend24h != 13 {
+		t.Errorf("spend after stream chat = %d/%d, want 13/13 (usage 11+2)", snaps[0].SpendDay, snaps[0].Spend24h)
+	}
+
+	// The non-stream path feeds the same ledger: a second completion
+	// accumulates on top.
+	mock.ChatBody = testutil.SSEEvent(chunk("chatcmpl-s2", 2, `"choices":[{"index":0,"delta":{"content":"yo"},"finish_reason":null}]`)) +
+		testutil.SSEEvent(chunk("chatcmpl-s2", 2, `"choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":7,"total_tokens":12}`))
+	req2 := `{"model":"` + modelA + `","messages":[{"role":"user","content":"hi"}],"stream":false}`
+	resp2, _ := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", []byte(req2), nil)
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("non-stream status = %d, want 200", resp2.StatusCode)
+	}
+	snaps = pool.Snapshot()
+	if snaps[0].SpendDay != 25 || snaps[0].Spend24h != 25 {
+		t.Errorf("spend after two chats = %d/%d, want 25/25 (13+12)", snaps[0].SpendDay, snaps[0].Spend24h)
+	}
+}
+
 func TestWaitingRoom503ThenRetry(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
@@ -424,8 +464,11 @@ func TestChatSessionInvalidBoundedRetry(t *testing.T) {
 	// Every chat returns a session-invalid error. Without a retry budget the
 	// recovery loop re-creates the session and re-chats forever, hanging the
 	// client; the budget must cap it at one retry (2 chat attempts total).
+	// session_superseded is its OWN terminal sentinel (see
+	// TestChatSessionSupersededTerminal) — this test uses session_expired to
+	// pin the invalidate+reacquire-once budget for ErrSessionInvalid.
 	mock.ChatStatus = http.StatusBadRequest
-	mock.ChatErrorBody = `{"error":{"message":"session_superseded"}}`
+	mock.ChatErrorBody = `{"error":{"message":"session_expired"}}`
 	ts, _ := newTestServer(t, nil, mock)
 
 	// A client timeout makes a regression (unbounded loop) fail fast instead
@@ -449,6 +492,48 @@ func TestChatSessionInvalidBoundedRetry(t *testing.T) {
 	}
 	if got := mock.SessionCreates; got != 2 {
 		t.Errorf("upstream session creates = %d, want exactly 2 (bounded retry)", got)
+	}
+}
+
+// TestChatSessionSupersededTerminal pins #119: 409 session_superseded (another
+// instance took over the account, endsTheSession:true) is TERMINAL — the
+// cached session is dropped so the NEXT request re-joins fresh, but the
+// request NEVER auto-reacquires (auto-takeover risks ping-pong). One chat
+// attempt, one session create, 409 session_superseded surfaced.
+func TestChatSessionSupersededTerminal(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.ChatStatus = http.StatusBadRequest
+	mock.ChatErrorBody = `{"error":{"message":"session_superseded"}}`
+	ts, _ := newTestServer(t, nil, mock)
+
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, data)
+	}
+	if !strings.Contains(string(data), "session_superseded") {
+		t.Errorf("body missing session_superseded: %s", data)
+	}
+	if got := len(mock.RecordedChatHeaders); got != 1 {
+		t.Errorf("upstream chat attempts = %d, want exactly 1 (no auto-reacquire on superseded)", got)
+	}
+	if got := mock.SessionCreates; got != 1 {
+		t.Errorf("upstream session creates = %d, want exactly 1 (no in-request rejoin)", got)
+	}
+
+	// The cached session was dropped: the NEXT request re-joins fresh (the
+	// CLI's "stop and rejoin later" semantic) — a second session create +
+	// chat happen, and the mock's persistent superseded chat surfaces again
+	// as 409.
+	resp2, data2 := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	if resp2.StatusCode != http.StatusConflict {
+		t.Fatalf("second request status = %d, want 409 (superseded again): %s", resp2.StatusCode, data2)
+	}
+	if got := mock.SessionCreates; got != 2 {
+		t.Errorf("session creates after next request = %d, want 2 (fresh re-join)", got)
+	}
+	if got := len(mock.RecordedChatHeaders); got != 2 {
+		t.Errorf("upstream chat attempts after next request = %d, want 2", got)
 	}
 }
 
@@ -610,8 +695,10 @@ func TestModelsEndpoint(t *testing.T) {
 	if out.Object != "list" {
 		t.Errorf("object = %q, want list", out.Object)
 	}
-	if len(out.Data) < 15 {
-		t.Errorf("models = %d, want >= 15", len(out.Data))
+	// #121: the offline fallback pruned 5 dead model ids (laguna/ling/greg),
+	// 15 -> 10 rows (registry fallbackAgents, free-agents.ts-verified).
+	if len(out.Data) < 10 {
+		t.Errorf("models = %d, want >= 10", len(out.Data))
 	}
 	for i, m := range out.Data {
 		if m.ID == "" || m.Object != "model" || m.OwnedBy == "" {
@@ -656,8 +743,9 @@ func TestHealthz(t *testing.T) {
 	if out.UptimeSeconds < 0 {
 		t.Errorf("uptime_seconds = %v, want >= 0", out.UptimeSeconds)
 	}
-	if out.Models < 15 {
-		t.Errorf("models = %d, want >= 15", out.Models)
+	// #121: fallback registry 15 -> 10 rows after pruning dead model ids.
+	if out.Models < 10 {
+		t.Errorf("models = %d, want >= 10", out.Models)
 	}
 	if len(out.Tokens) != 2 {
 		t.Errorf("tokens = %d, want 2", len(out.Tokens))

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -88,7 +88,7 @@ type Manager struct {
 	reAdmitLead time.Duration
 	// probeTTL (issue #60, SESSION_PROBE_CACHE_TTL default 15s) + lastAdmitted:
 	// the last successful upstream session response is reused to skip a
-	// redundant GET (heartbeat) within the TTL.
+	// redundant poll GET within the TTL.
 	probeTTL     time.Duration
 	lastAdmitted time.Time
 
@@ -153,7 +153,7 @@ func (m *Manager) SetReAdmitLead(d time.Duration) {
 }
 
 // SetAdmissionProbeTTL configures the admission probe cache TTL (issue #60):
-// heartbeat GETs within d of the last successful session response are
+// session poll GETs within d of the last successful session response are
 // skipped. d <= 0 disables. Wired by the pool from SESSION_PROBE_CACHE_TTL;
 // safe to call at runtime.
 func (m *Manager) SetAdmissionProbeTTL(d time.Duration) {
@@ -298,6 +298,28 @@ func shortInstance(id string) string {
 	return id
 }
 
+// sessionUsable reports whether the cached state can serve a chat right now:
+// an active session until expiresAt-5s (the reference safety margin), or any
+// state that still holds a live instance id within the 30-minute grace drain
+// after expiry (gap #13, FREEBUFF_SESSION_GRACE_MS: within grace the row
+// stays alive and chat passes — reference/freebuff freebuff-session.ts). The
+// instance-id test guards the grace extension: an ended row whose instance id
+// is gone cannot be ridden, and an expired active cache is only reusable
+// while its slot survives upstream.
+func sessionUsable(s *cachedState) bool {
+	if s == nil || s.instanceID == "" {
+		return false
+	}
+	if s.status == "active" && time.Now().Before(s.expiresAt.Add(-expiryMargin)) {
+		return true
+	}
+	graceEnd := s.gracePeriodEndsAt
+	if graceEnd.IsZero() && !s.expiresAt.IsZero() {
+		graceEnd = s.expiresAt.Add(graceWindow)
+	}
+	return !graceEnd.IsZero() && time.Now().Before(graceEnd)
+}
+
 // commit replaces the cached state and mirrors it into the store (when
 // configured). Caller must hold m.mu.
 //
@@ -339,17 +361,24 @@ func (m *Manager) EnsureSessionForModel(ctx context.Context, model string) (stri
 		s := m.state
 		if s != nil && !m.refreshing {
 			switch s.status {
-			case "active":
-				if (model == "" || s.model == "" || s.model == model) && time.Now().Before(s.expiresAt.Add(-expiryMargin)) {
+			case "active", "ended":
+				// Fast path: reuse the cached instance while it is usable —
+				// an active session until expiresAt-5s, or (gap #13) a
+				// session whose instance id survives the 30-minute grace
+				// drain (FREEBUFF_SESSION_GRACE_MS: within grace the row
+				// stays alive and chat passes).
+				if (model == "" || s.model == "" || s.model == model) && sessionUsable(s) {
 					instance := s.instanceID
-					// Issue #99: pre-emptive re-admit. When the session has
-					// less than the re-admit lead left, kick off an async
-					// re-admit (single-flight through the refreshing
-					// machinery) and ride the old session this request; the
-					// next request gets the new instance. The refresh runs on
-					// a background context so the caller's cancellation never
-					// strands a half-started admission.
-					if m.reAdmitLead > 0 && time.Until(s.expiresAt.Add(-expiryMargin)) <= m.reAdmitLead {
+					// Issue #99: pre-emptive re-admit. Only while the
+					// session is still pre-expiry (within reAdmitLead of
+					// expiresAt-5s): inside the grace drain the CLI rides
+					// the old row until grace ends, and a fresh admission
+					// would supersede it. The refresh runs on a background
+					// context so the caller's cancellation never strands a
+					// half-started admission.
+					if s.status == "active" && m.reAdmitLead > 0 &&
+						time.Now().Before(s.expiresAt.Add(-expiryMargin)) &&
+						time.Until(s.expiresAt.Add(-expiryMargin)) <= m.reAdmitLead {
 						m.refreshing = true
 						m.refreshErr = nil
 						refreshCh := make(chan struct{})
@@ -363,7 +392,8 @@ func (m *Manager) EnsureSessionForModel(ctx context.Context, model string) (stri
 					slog.Debug("session reused", "instance_id", instance, "model", s.model, "expires_at", s.expiresAt.Format(time.RFC3339))
 					return instance, nil
 				}
-				// Freshness exceeded or model mismatch — fall through to refresh.
+				// Usability exhausted (past grace) or model mismatch — fall
+				// through to refresh.
 			case "disabled":
 				m.mu.Unlock()
 				return "", nil
@@ -414,10 +444,10 @@ func (m *Manager) EnsureSessionForModel(ctx context.Context, model string) (stri
 						}
 					}
 					// Issue #99: a failed pre-emptive re-admit leaves the old
-					// active session authoritative — ride it rather than
-					// erroring a request that could still be served.
-					if s != nil && s.status == "active" &&
-						time.Now().Before(s.expiresAt.Add(-expiryMargin)) {
+					// session authoritative — ride it rather than erroring a
+					// request that could still be served (through the grace
+					// drain, gap #13).
+					if s != nil && sessionUsable(s) {
 						return s.instanceID, nil
 					}
 					return "", err
@@ -502,7 +532,7 @@ func (m *Manager) asyncReAdmit(model string) {
 // statusError maps an upstream session status to the typed error callers
 // use for recovery (token cooldown, region surfacing). st supplies the
 // fields carried by the error; non-error statuses return nil. Shared by
-// refresh and Heartbeat so both map the same way.
+// refresh and Poll so both map the same way.
 func statusError(status string, st *upstream.SessionState) error {
 	switch status {
 	case "banned":
@@ -608,7 +638,8 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string) error {
 				standing:           st.Standing,
 			})
 			// Issue #60: the successful admission refreshes the probe cache
-			// window — subsequent heartbeat GETs within the TTL are skipped.
+			// window — subsequent session poll GETs within the TTL are
+			// skipped.
 			m.lastAdmitted = time.Now()
 			m.mu.Unlock()
 			slog.Debug("session created", "status", "active", "instance_id", st.InstanceID,
@@ -819,40 +850,50 @@ func (m *Manager) EndSession(ctx context.Context) error {
 	return nil
 }
 
-// Shutdown handles session teardown at process shutdown. When persistence is
-// disabled it behaves exactly like EndSession (DELETE upstream). When
-// persistence is enabled, only a genuinely active + unexpired session is kept
-// alive — so a later restart can resume it — and its state is flushed to the
-// store. Every other state (nil, queued, disabled, expired-active, ended)
-// falls through to the normal EndSession path, which releases the upstream
-// slot and removes the store entry via the CAS commit. Runs are FINISHed
-// separately by the run manager.
+// Shutdown handles session teardown at process shutdown. Per the CLI
+// (gap #13), exit ALWAYS releases the upstream session slot (DELETE),
+// whether or not persistence is enabled — the CLI DELETEs on exit and a
+// later restart re-admits fresh. When persistence is enabled the cached
+// state is flushed to the store FIRST (so a crash mid-shutdown does not
+// lose the entry) and the entry survives the DELETE: a restart resumes via
+// pollPersisted, which re-adopts the slot when the DELETE did not take
+// effect upstream, or drops the dead entry and re-POSTs fresh when it did.
+// Runs are FINISHed separately by the run manager.
 func (m *Manager) Shutdown(ctx context.Context) error {
 	if m.store == nil {
+		// No persistence: exactly the normal EndSession path (DELETE
+		// upstream + drop the cache).
 		return m.EndSession(ctx)
 	}
 	m.mu.Lock()
-	keepAlive := false
 	instanceID := ""
-	if s := m.state; s != nil && s.status == "active" && s.instanceID != "" &&
-		time.Now().Before(s.expiresAt.Add(-expiryMargin)) {
-		keepAlive = true
-		instanceID = s.instanceID
-		m.store.Save(m.key, s)
+	if m.state != nil && m.state.instanceID != "" {
+		instanceID = m.state.instanceID
+		m.store.Save(m.key, m.state)
 		// Surface a failed flush: without the persisted entry a restart
 		// cannot resume the slot, so a write/rename failure must not be
 		// silent. Re-read the FILE through a fresh Store — the in-memory
 		// map is updated before the flush attempt and cannot verify disk.
 		if persisted := NewStore(m.store.path).Load(m.key); persisted == nil || persisted.instanceID != instanceID {
-			slog.Warn("session: keep-alive persist failed", "instance_id", instanceID)
+			slog.Warn("session: shutdown persist failed", "instance_id", shortInstance(instanceID))
 		}
 	}
 	m.mu.Unlock()
-	if keepAlive {
-		slog.Debug("session kept for restart", "instance_id", instanceID)
+
+	if instanceID == "" {
 		return nil
 	}
-	return m.EndSession(ctx)
+	// Release the upstream slot directly (not EndSession): EndSession's CAS
+	// commit(nil) would remove the store entry we just flushed, and the
+	// DELETE is keyed on the user, not the instance (reference/freebuff
+	// session wire: DELETE = Bearer only; the client still sends the
+	// instance header today — P2 #18 backlog). The cached state is kept
+	// in-memory so the store entry stays; the process is exiting.
+	slog.Debug("session ended on shutdown", "instance_id", shortInstance(instanceID))
+	if err := m.client.EndSession(ctx, instanceID); err != nil && !errors.Is(err, upstream.ErrSessionInvalid) {
+		return err
+	}
+	return nil
 }
 
 // pollPersisted attempts to resume a persisted session before a fresh create
@@ -924,18 +965,24 @@ func (m *Manager) pollPersisted(ctx context.Context, requestedModel string) (*up
 	}
 }
 
-// Heartbeat sends a periodic compact GET with x-freebuff-heartbeat: 1 for active sessions,
-// keeping last_seen_at fresh on the server so the session concurrency slot is maintained.
-func (m *Manager) Heartbeat(ctx context.Context) error {
+// Poll runs the periodic session-liveness poll: a compact GET with NO
+// heartbeat header — the CLI never beats (x-freebuff-heartbeat is
+// Desktop-only, reference/freebuff freebuff-models.ts:1212-1215); liveness
+// comes from the recurring compact GET itself (gap #2). It refreshes the
+// cached state the way the CLI's 30s compact poll does: statusError
+// mappings, drop-on-ban, invalidate on superseded/none, and — within the
+// 30-minute grace drain — an ended response that still carries the instance
+// id is kept as a usable "ended" row instead of being invalidated (gap #13).
+func (m *Manager) Poll(ctx context.Context) error {
 	m.mu.Lock()
-	if m.state == nil || m.state.status != "active" || m.state.instanceID == "" {
+	if m.state == nil || (m.state.status != "active" && m.state.status != "ended") || m.state.instanceID == "" {
 		m.mu.Unlock()
 		return nil
 	}
 	// Issue #60: admission probe caching — within the probe TTL of the last
 	// successful session response the cached state is authoritative, so the
-	// heartbeat GET is redundant; skip it (less upstream traffic, fewer
-	// chances to trip the one-client-at-a-time gate).
+	// poll GET is redundant; skip it (less upstream traffic, fewer chances
+	// to trip the one-client-at-a-time gate).
 	if m.probeTTL > 0 && !m.lastAdmitted.IsZero() && time.Since(m.lastAdmitted) < m.probeTTL {
 		m.mu.Unlock()
 		return nil
@@ -943,7 +990,7 @@ func (m *Manager) Heartbeat(ctx context.Context) error {
 	instanceID := m.state.instanceID
 	m.mu.Unlock()
 
-	st, err := m.client.GetSessionWithOpts(ctx, instanceID, true, true)
+	st, err := m.client.GetSessionWithOpts(ctx, instanceID, true)
 	if err != nil {
 		return err
 	}
@@ -954,24 +1001,60 @@ func (m *Manager) Heartbeat(ctx context.Context) error {
 	if serr := statusError(st.Status, st); serr != nil {
 		// A banned session is dead until the account unban: drop the cached
 		// admission (cooldown) so the token re-admits only after the pool's
-		// ban window, instead of heartbeat-ing a stale slot.
+		// ban window, instead of polling a stale slot.
 		if st.Status == "banned" {
 			m.mu.Lock()
 			if m.state != nil && m.state.instanceID == instanceID {
 				m.commit(nil)
-				slog.Debug("session dropped during heartbeat", "reason", st.Status, "instance_id", instanceID)
+				slog.Debug("session dropped during poll", "reason", st.Status, "instance_id", instanceID)
 			}
 			m.mu.Unlock()
 		}
 		return serr
 	}
-	if st.Status == "ended" || st.Status == "superseded" || st.Status == "none" {
+	if st.Status == "superseded" || st.Status == "none" {
 		m.mu.Lock()
 		if m.state != nil && m.state.instanceID == instanceID {
 			m.commit(nil)
-			slog.Debug("session ended during heartbeat", "reason", st.Status, "instance_id", instanceID)
+			slog.Debug("session ended during poll", "reason", st.Status, "instance_id", instanceID)
 		}
 		m.mu.Unlock()
+		return nil
+	}
+	if st.Status == "ended" {
+		// Ended WITH the instance id still present: the row is in the 30-min
+		// grace drain and stays usable (gap #13). Refresh the cached state
+		// as ended-with-instance so the fast path keeps serving it until
+		// grace closes; the pool keeps polling. The grace end comes from the
+		// response when present, else expiresAt + graceWindow.
+		graceEnd := st.GracePeriodEndsAt
+		if (graceEnd == time.Time{}) && !st.ExpiresAt.IsZero() {
+			graceEnd = st.ExpiresAt.Add(graceWindow)
+		}
+		if st.InstanceID != "" && !graceEnd.IsZero() && time.Now().Before(graceEnd) {
+			m.mu.Lock()
+			if m.state != nil && m.state.instanceID == instanceID {
+				m.commit(&cachedState{
+					status:            "ended",
+					instanceID:        st.InstanceID,
+					model:             m.state.model,
+					expiresAt:         st.ExpiresAt,
+					gracePeriodEndsAt: graceEnd,
+				})
+				slog.Debug("session in grace drain during poll", "instance_id", instanceID, "grace_ends_at", graceEnd.Format(time.RFC3339))
+			}
+			m.mu.Unlock()
+			return nil
+		}
+		// The row is gone (no instance id) or past grace: drop it so the
+		// next EnsureSession re-creates a fresh session.
+		m.mu.Lock()
+		if m.state != nil && m.state.instanceID == instanceID {
+			m.commit(nil)
+			slog.Debug("session ended during poll", "reason", st.Status, "instance_id", instanceID)
+		}
+		m.mu.Unlock()
+		return nil
 	}
 	return nil
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -844,7 +844,10 @@ func (m *Manager) EndSession(ctx context.Context) error {
 		return nil
 	}
 	slog.Debug("session ended", "instance_id", instanceID)
-	if err := m.client.EndSession(ctx, instanceID); err != nil && !errors.Is(err, upstream.ErrSessionInvalid) {
+	// A superseded DELETE is the same "slot already gone" case as
+	// session-invalid (#119): swallow both so teardown never errors on a
+	// slot another instance took over.
+	if err := m.client.EndSession(ctx, instanceID); err != nil && !errors.Is(err, upstream.ErrSessionInvalid) && !errors.Is(err, upstream.ErrSessionSuperseded) {
 		return err
 	}
 	return nil
@@ -886,11 +889,11 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 	// Release the upstream slot directly (not EndSession): EndSession's CAS
 	// commit(nil) would remove the store entry we just flushed, and the
 	// DELETE is keyed on the user, not the instance (reference/freebuff
-	// session wire: DELETE = Bearer only; the client still sends the
-	// instance header today — P2 #18 backlog). The cached state is kept
-	// in-memory so the store entry stays; the process is exiting.
+	// session wire: DELETE = Bearer only, #120 — EndSession never sends the
+	// instance header). The cached state is kept in-memory so the store
+	// entry stays; the process is exiting.
 	slog.Debug("session ended on shutdown", "instance_id", shortInstance(instanceID))
-	if err := m.client.EndSession(ctx, instanceID); err != nil && !errors.Is(err, upstream.ErrSessionInvalid) {
+	if err := m.client.EndSession(ctx, instanceID); err != nil && !errors.Is(err, upstream.ErrSessionInvalid) && !errors.Is(err, upstream.ErrSessionSuperseded) {
 		return err
 	}
 	return nil
@@ -992,6 +995,20 @@ func (m *Manager) Poll(ctx context.Context) error {
 
 	st, err := m.client.GetSessionWithOpts(ctx, instanceID, true)
 	if err != nil {
+		// #116: 428 waiting_room_required is session-ENDING
+		// (endsTheSession:true per FREEBUFF_GATE_CODES — the seat is gone;
+		// reference/freebuff freebuff-session.ts). Drop the cached admission
+		// so the next EnsureSession re-admits fresh (the pool's
+		// WAITING_ROOM_CHAIN fires before the create). Any other poll error
+		// is left for the pool's failure backoff.
+		if errors.Is(err, upstream.ErrWaitingRoomRequired) {
+			m.mu.Lock()
+			if m.state != nil && m.state.instanceID == instanceID {
+				m.commit(nil)
+				slog.Debug("session dropped during poll", "reason", "waiting_room_required", "instance_id", instanceID)
+			}
+			m.mu.Unlock()
+		}
 		return err
 	}
 	m.mu.Lock()

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1028,7 +1028,7 @@ func (m *Manager) Poll(ctx context.Context) error {
 		// grace closes; the pool keeps polling. The grace end comes from the
 		// response when present, else expiresAt + graceWindow.
 		graceEnd := st.GracePeriodEndsAt
-		if (graceEnd == time.Time{}) && !st.ExpiresAt.IsZero() {
+		if graceEnd.IsZero() && !st.ExpiresAt.IsZero() {
 			graceEnd = st.ExpiresAt.Add(graceWindow)
 		}
 		if st.InstanceID != "" && !graceEnd.IsZero() && time.Now().Before(graceEnd) {

--- a/internal/session/session_persist_test.go
+++ b/internal/session/session_persist_test.go
@@ -282,12 +282,14 @@ func TestPersistModelMatchAdopted(t *testing.T) {
 	})
 }
 
-// TestShutdownKeepAliveOnlyWhenResumable verifies Shutdown keeps the upstream
-// session alive only for genuinely active + unexpired sessions. Every other
-// state falls through to the normal EndSession path (upstream DELETE + store
-// removal via the CAS commit).
-func TestShutdownKeepAliveOnlyWhenResumable(t *testing.T) {
-	t.Run("active unexpired kept", func(t *testing.T) {
+// TestShutdownAlwaysDeletesEvenWhenPersisting verifies gap #13: shutdown
+// ALWAYS releases the upstream session slot (DELETE) whether or not
+// persistence is enabled — the CLI DELETEs on exit. The store entry is
+// still written (and survives the DELETE) so a restart can resume via
+// pollPersisted, which drops the dead entry and re-POSTs fresh when the
+// DELETE took effect upstream.
+func TestShutdownAlwaysDeletesEvenWhenPersisting(t *testing.T) {
+	t.Run("active unexpired deleted but entry kept", func(t *testing.T) {
 		mock := testutil.NewMock()
 		defer mock.Close()
 		store := NewStore(filepath.Join(t.TempDir(), "state.json"))
@@ -299,15 +301,15 @@ func TestShutdownKeepAliveOnlyWhenResumable(t *testing.T) {
 		if err := mgr.Shutdown(context.Background()); err != nil {
 			t.Fatal(err)
 		}
-		if mock.SessionEnds != 0 {
-			t.Errorf("SessionEnds = %d, want 0 (active+unexpired kept for restart)", mock.SessionEnds)
+		if mock.SessionEnds != 1 {
+			t.Errorf("SessionEnds = %d, want 1 (DELETE on exit even when persisting)", mock.SessionEnds)
 		}
 		if got := store.Load(key); got == nil || got.instanceID != "inst-abc-123" {
-			t.Errorf("store after Shutdown = %+v, want active inst-abc-123", got)
+			t.Errorf("store after Shutdown = %+v, want active inst-abc-123 (entry survives the DELETE)", got)
 		}
 	})
 
-	t.Run("queued ends upstream and drops entry", func(t *testing.T) {
+	t.Run("queued ends upstream and entry kept", func(t *testing.T) {
 		mock := testutil.NewMock()
 		defer mock.Close()
 		mock.SessionSequence = []string{"queued"}
@@ -333,12 +335,14 @@ func TestShutdownKeepAliveOnlyWhenResumable(t *testing.T) {
 		if mock.SessionEnds != 1 {
 			t.Errorf("SessionEnds = %d, want 1 (queued releases the upstream slot)", mock.SessionEnds)
 		}
-		if got := store.Load(key); got != nil {
-			t.Errorf("store after Shutdown = %+v, want nil (entry removed)", got)
+		// The queued entry survives the DELETE; a restart ignores it
+		// (pollPersisted only resumes active slots) and re-POSTs fresh.
+		if got := store.Load(key); got == nil || got.status != "queued" {
+			t.Errorf("store after Shutdown = %+v, want queued entry kept", got)
 		}
 	})
 
-	t.Run("expired active ends upstream", func(t *testing.T) {
+	t.Run("expired active deleted but entry kept", func(t *testing.T) {
 		mock := testutil.NewMock()
 		defer mock.Close()
 		store := NewStore(filepath.Join(t.TempDir(), "state.json"))
@@ -359,10 +363,10 @@ func TestShutdownKeepAliveOnlyWhenResumable(t *testing.T) {
 			t.Fatal(err)
 		}
 		if mock.SessionEnds != 1 {
-			t.Errorf("SessionEnds = %d, want 1 (expired-active is not resumable)", mock.SessionEnds)
+			t.Errorf("SessionEnds = %d, want 1 (DELETE on exit)", mock.SessionEnds)
 		}
-		if got := store.Load(key); got != nil {
-			t.Errorf("store after Shutdown = %+v, want nil", got)
+		if got := store.Load(key); got == nil || got.instanceID != "inst-expired" {
+			t.Errorf("store after Shutdown = %+v, want inst-expired entry kept", got)
 		}
 	})
 }

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -809,6 +809,52 @@ func TestPollInvalidatesRecreateStatuses(t *testing.T) {
 	}
 }
 
+// TestPollDropsRowOnWaitingRoomRequired verifies #116: a 428
+// waiting_room_required poll response is session-ENDING
+// (endsTheSession:true) — Poll drops the cached admission so the next
+// EnsureSession re-admits fresh, and surfaces the typed error for the
+// pool's failure backoff.
+func TestPollDropsRowOnWaitingRoomRequired(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mgr := newTestManager(t, mock)
+
+	if _, err := mgr.EnsureSession(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	var reAdmits atomic.Int32
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			// 428 on the poll GET (the compact session poll).
+			w.WriteHeader(http.StatusTooEarly) // 428
+			_, _ = io.WriteString(w, `{"error":"waiting_room_required"}`)
+			return
+		}
+		// POST (re-admit after the 428 drop): a fresh active slot.
+		reAdmits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-abc-123","expiresAt":"2030-01-01T00:00:00Z"}`)
+	}
+
+	err := mgr.Poll(context.Background())
+	if !errors.Is(err, upstream.ErrWaitingRoomRequired) {
+		t.Fatalf("Poll error = %v, want ErrWaitingRoomRequired", err)
+	}
+	if snap := mgr.Snapshot(); snap.Status != "" {
+		t.Errorf("status = %q, want empty (cached row dropped on 428)", snap.Status)
+	}
+
+	// The next EnsureSession re-admits fresh (the pool fires the
+	// WAITING_ROOM_CHAIN before the create).
+	if _, err := mgr.EnsureSession(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := reAdmits.Load(); got != 1 {
+		t.Errorf("re-admit session creates = %d, want 1 (fresh admission after 428 drop)", got)
+	}
+}
+
 // TestModelLockedReleasesOldSlot verifies the model_locked branch releases
 // the OLD upstream slot (SessionEnds == 1) before retrying with the desired
 // model: the model-switch invariant that a locked slot is not leaked.
@@ -988,28 +1034,39 @@ func TestPollTransportErrorKeepsCachedState(t *testing.T) {
 }
 
 // TestEndSessionSwallowsSessionInvalid verifies EndSession returns nil when
-// the upstream DELETE fails with a 400 session_superseded (ErrSessionInvalid
-// — the slot is already gone, nothing to do).
+// the upstream DELETE fails with a "slot already gone" rejection — 400
+// session_expired (ErrSessionInvalid) and 400 session_superseded
+// (ErrSessionSuperseded, #119) — nothing to do either way.
 func TestEndSessionSwallowsSessionInvalid(t *testing.T) {
-	mock := testutil.NewMock()
-	defer mock.Close()
-	mgr := newTestManager(t, mock)
+	for _, tc := range []struct {
+		body string
+		want error
+	}{
+		{`{"error":"session_expired"}`, upstream.ErrSessionInvalid},
+		{`{"error":"session_superseded"}`, upstream.ErrSessionSuperseded},
+	} {
+		t.Run(tc.body, func(t *testing.T) {
+			mock := testutil.NewMock()
+			defer mock.Close()
+			mgr := newTestManager(t, mock)
 
-	if _, err := mgr.EnsureSession(context.Background()); err != nil {
-		t.Fatal(err)
-	}
+			if _, err := mgr.EnsureSession(context.Background()); err != nil {
+				t.Fatal(err)
+			}
 
-	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodDelete {
-			w.WriteHeader(http.StatusBadRequest)
-			_, _ = io.WriteString(w, `{"error":"session_superseded"}`)
-			return
-		}
-		http.NotFound(w, r)
-	}
+			mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodDelete {
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = io.WriteString(w, tc.body)
+					return
+				}
+				http.NotFound(w, r)
+			}
 
-	if err := mgr.EndSession(context.Background()); err != nil {
-		t.Fatalf("EndSession with 400 session_superseded = %v, want nil (ErrSessionInvalid swallowed)", err)
+			if err := mgr.EndSession(context.Background()); err != nil {
+				t.Fatalf("EndSession with 400 %s = %v, want nil (%v swallowed)", tc.body, err, tc.want)
+			}
+		})
 	}
 }
 
@@ -1305,6 +1362,8 @@ func TestModelLockedFallbackInstance(t *testing.T) {
 			_, _ = io.WriteString(w, `{"status":"active","instanceId":"active-inst-456","model":"model/new"}`)
 		case http.MethodDelete:
 			mu.Lock()
+			// #120: the CLI DELETEs with Bearer only — no instance header
+			// (reference/freebuff freebuff-session-api.ts releaseFreebuffSlot).
 			deleteInstanceIDs = append(deleteInstanceIDs, r.Header.Get("x-freebuff-instance-id"))
 			mu.Unlock()
 			w.WriteHeader(http.StatusOK)
@@ -1328,8 +1387,8 @@ func TestModelLockedFallbackInstance(t *testing.T) {
 	if len(deleteInstanceIDs) != 1 {
 		t.Fatalf("EndSession calls = %d, want 1", len(deleteInstanceIDs))
 	}
-	if deleteInstanceIDs[0] != "locked-inst-123" {
-		t.Errorf("EndSession instanceID = %q, want locked-inst-123", deleteInstanceIDs[0])
+	if deleteInstanceIDs[0] != "" {
+		t.Errorf("DELETE x-freebuff-instance-id = %q, want absent (#120: session DELETE is Bearer-only)", deleteInstanceIDs[0])
 	}
 }
 

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -131,7 +131,10 @@ func TestEndedRecreates(t *testing.T) {
 func TestExpiredCacheRefreshes(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
-	mock.ExpiresIn = -1 * time.Minute // already past expiry margin
+	// Expiry beyond the 30-min grace window (issue #115): a session that
+	// expired more than graceWindow ago must refresh. Expiries inside the
+	// window are reusable (TestEnsureSessionRidesGraceFastPath).
+	mock.ExpiresIn = -31 * time.Minute
 	mgr := newTestManager(t, mock)
 
 	// First call: no cache → one create, state trusted on return.
@@ -146,7 +149,7 @@ func TestExpiredCacheRefreshes(t *testing.T) {
 		t.Errorf("creates = %d, want 1", mock.SessionCreates)
 	}
 
-	// Second call: stale cache → refresh (create #2).
+	// Second call: stale cache past grace → refresh (create #2).
 	instance, err = mgr.EnsureSession(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -155,7 +158,7 @@ func TestExpiredCacheRefreshes(t *testing.T) {
 		t.Errorf("instance = %q", instance)
 	}
 	if mock.SessionCreates != 2 {
-		t.Errorf("creates = %d, want 2 (stale cache → refresh)", mock.SessionCreates)
+		t.Errorf("creates = %d, want 2 (stale cache past grace → refresh)", mock.SessionCreates)
 	}
 }
 
@@ -557,18 +560,18 @@ func TestSnapshotQuotaByModel(t *testing.T) {
 	}
 }
 
-func TestHeartbeat(t *testing.T) {
+func TestPoll(t *testing.T) {
 	t.Run("inactive session returns nil", func(t *testing.T) {
 		mock := testutil.NewMock()
 		defer mock.Close()
 		mgr := newTestManager(t, mock)
 
-		if err := mgr.Heartbeat(context.Background()); err != nil {
-			t.Fatalf("Heartbeat inactive: %v", err)
+		if err := mgr.Poll(context.Background()); err != nil {
+			t.Fatalf("Poll inactive: %v", err)
 		}
 	})
 
-	t.Run("active session sends heartbeat header", func(t *testing.T) {
+	t.Run("active session polls compact without heartbeat header", func(t *testing.T) {
 		mock := testutil.NewMock()
 		defer mock.Close()
 		mgr := newTestManager(t, mock)
@@ -578,20 +581,25 @@ func TestHeartbeat(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		heartbeatSeen := false
+		var gotCompact, gotHeartbeat string
 		mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
-			if r.Header.Get("x-freebuff-heartbeat") == "1" {
-				heartbeatSeen = true
-			}
+			gotCompact = r.Header.Get("x-freebuff-compact-session")
+			gotHeartbeat = r.Header.Get("x-freebuff-heartbeat")
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-abc-123"}`)
 		}
 
-		if err := mgr.Heartbeat(context.Background()); err != nil {
-			t.Fatalf("Heartbeat: %v", err)
+		if err := mgr.Poll(context.Background()); err != nil {
+			t.Fatalf("Poll: %v", err)
 		}
-		if !heartbeatSeen {
-			t.Error("x-freebuff-heartbeat header not sent upstream")
+		// Gap #2: the CLI never beats — x-freebuff-heartbeat is
+		// Desktop-only (reference/freebuff freebuff-models.ts:1212-1215);
+		// liveness comes from the recurring compact GET.
+		if gotCompact != "1" {
+			t.Errorf("x-freebuff-compact-session = %q, want 1", gotCompact)
+		}
+		if gotHeartbeat != "" {
+			t.Errorf("x-freebuff-heartbeat = %q, want absent on polls", gotHeartbeat)
 		}
 		if snap := mgr.Snapshot(); snap.Status != "active" {
 			t.Errorf("status = %q, want active", snap.Status)
@@ -613,13 +621,137 @@ func TestHeartbeat(t *testing.T) {
 			_, _ = io.WriteString(w, `{"status":"ended","instanceId":"inst-abc-123"}`)
 		}
 
-		if err := mgr.Heartbeat(context.Background()); err != nil {
-			t.Fatalf("Heartbeat: %v", err)
+		if err := mgr.Poll(context.Background()); err != nil {
+			t.Fatalf("Poll: %v", err)
 		}
 		if snap := mgr.Snapshot(); snap.Status != "" {
 			t.Errorf("status = %q, want empty after invalidation", snap.Status)
 		}
 	})
+}
+
+// TestPollRidesGraceEndedWithInstance verifies gap #13 on the poll path: an
+// "ended" response that still carries the instance id (with a future grace
+// end) is kept as a usable ended-with-instance row — the fast path keeps
+// serving it until grace closes, with no fresh admission.
+func TestPollRidesGraceEndedWithInstance(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mgr := newTestManager(t, mock)
+
+	if _, err := mgr.EnsureSession(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	graceEnd := time.Now().Add(20 * time.Minute).UTC().Format(time.RFC3339)
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":"ended","instanceId":"inst-abc-123","gracePeriodEndsAt":"`+graceEnd+`"}`)
+	}
+
+	if err := mgr.Poll(context.Background()); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	snap := mgr.Snapshot()
+	if snap.Status != "ended" || snap.InstanceID != "inst-abc-123" {
+		t.Fatalf("snapshot = %+v, want ended inst-abc-123 (in-grace row kept)", snap)
+	}
+
+	// The fast path reuses the in-grace slot: no upstream create.
+	creates := mock.SessionCreates
+	instance, err := mgr.EnsureSession(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if instance != "inst-abc-123" {
+		t.Errorf("instance = %q, want inst-abc-123 (ride through grace)", instance)
+	}
+	if mock.SessionCreates != creates {
+		t.Errorf("session creates = %d, want %d (no fresh admission inside grace)", mock.SessionCreates, creates)
+	}
+}
+
+// TestEnsureSessionRidesGraceFastPath verifies gap #13 on the fast path: an
+// active cache entry whose expiry margin has passed is still reusable while
+// its instance id survives the 30-minute grace drain, and once grace closes
+// the next EnsureSession re-admits.
+func TestEnsureSessionRidesGraceFastPath(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mgr := newTestManager(t, mock)
+
+	// Active-but-expired cache, still within the grace drain.
+	mgr.mu.Lock()
+	mgr.commit(&cachedState{
+		status:            "active",
+		instanceID:        "inst-grace",
+		model:             "deepseek/deepseek-v4-pro",
+		expiresAt:         time.Now().Add(-10 * time.Minute),
+		gracePeriodEndsAt: time.Now().Add(20 * time.Minute),
+	})
+	mgr.mu.Unlock()
+
+	creates := mock.SessionCreates
+	instance, err := mgr.EnsureSessionForModel(context.Background(), "deepseek/deepseek-v4-pro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if instance != "inst-grace" {
+		t.Errorf("instance = %q, want inst-grace (ride through grace)", instance)
+	}
+	if mock.SessionCreates != creates {
+		t.Errorf("session creates = %d, want %d (no fresh admission inside grace)", mock.SessionCreates, creates)
+	}
+
+	// Past the grace window: the fast path falls through and re-admits.
+	mgr.mu.Lock()
+	mgr.commit(&cachedState{
+		status:            "active",
+		instanceID:        "inst-grace",
+		model:             "deepseek/deepseek-v4-pro",
+		expiresAt:         time.Now().Add(-45 * time.Minute),
+		gracePeriodEndsAt: time.Now().Add(-10 * time.Minute),
+	})
+	mgr.mu.Unlock()
+
+	if _, err := mgr.EnsureSessionForModel(context.Background(), "deepseek/deepseek-v4-pro"); err != nil {
+		t.Fatal(err)
+	}
+	if mock.SessionCreates != creates+1 {
+		t.Errorf("session creates = %d, want %d (re-admit after grace closes)", mock.SessionCreates, creates+1)
+	}
+}
+
+// TestPollEndedPastGraceInvalidates verifies an "ended" poll response whose
+// grace window has already closed (or that carries no instance id) drops the
+// cached slot so the next EnsureSession re-creates fresh.
+func TestPollEndedPastGraceInvalidates(t *testing.T) {
+	for name, body := range map[string]string{
+		"past grace":  `{"status":"ended","instanceId":"inst-abc-123","gracePeriodEndsAt":"2020-01-01T00:00:00Z"}`,
+		"no instance": `{"status":"ended"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			mock := testutil.NewMock()
+			defer mock.Close()
+			mgr := newTestManager(t, mock)
+
+			if _, err := mgr.EnsureSession(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+
+			mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, body)
+			}
+
+			if err := mgr.Poll(context.Background()); err != nil {
+				t.Fatalf("Poll: %v", err)
+			}
+			if snap := mgr.Snapshot(); snap.Status != "" {
+				t.Errorf("status = %q, want empty after %s ended poll", snap.Status, name)
+			}
+		})
+	}
 }
 
 // TestRecreateStatusesRecreates pins status-matrix parity for the
@@ -648,10 +780,10 @@ func TestRecreateStatusesRecreates(t *testing.T) {
 	}
 }
 
-// TestHeartbeatInvalidatesRecreateStatuses verifies Heartbeat invalidates
-// the cached admission for "superseded"/"none" polls exactly like "ended"
-// (status parity for the heartbeat path).
-func TestHeartbeatInvalidatesRecreateStatuses(t *testing.T) {
+// TestPollInvalidatesRecreateStatuses verifies Poll invalidates the cached
+// admission for "superseded"/"none" polls exactly like "ended" (status
+// parity for the poll path).
+func TestPollInvalidatesRecreateStatuses(t *testing.T) {
 	for _, status := range []string{"superseded", "none"} {
 		t.Run(status, func(t *testing.T) {
 			mock := testutil.NewMock()
@@ -667,8 +799,8 @@ func TestHeartbeatInvalidatesRecreateStatuses(t *testing.T) {
 				_, _ = io.WriteString(w, `{"status":"`+status+`","instanceId":"inst-abc-123"}`)
 			}
 
-			if err := mgr.Heartbeat(context.Background()); err != nil {
-				t.Fatalf("Heartbeat: %v", err)
+			if err := mgr.Poll(context.Background()); err != nil {
+				t.Fatalf("Poll: %v", err)
 			}
 			if snap := mgr.Snapshot(); snap.Status != "" {
 				t.Errorf("status = %q, want empty after %s invalidation", snap.Status, status)
@@ -815,11 +947,11 @@ func TestQueuedZeroPollAtClamp(t *testing.T) {
 	}
 }
 
-// TestHeartbeatTransportErrorKeepsCachedState verifies a transport error on
-// the heartbeat poll surfaces as an error (pool cooldown path) while the
-// cached active admission stays intact — the transport failure did not prove
-// the session dead.
-func TestHeartbeatTransportErrorKeepsCachedState(t *testing.T) {
+// TestPollTransportErrorKeepsCachedState verifies a transport error on the
+// session poll surfaces as an error (pool backoff path) while the cached
+// active admission stays intact — the transport failure did not prove the
+// session dead.
+func TestPollTransportErrorKeepsCachedState(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	mgr := newTestManager(t, mock)
@@ -828,7 +960,7 @@ func TestHeartbeatTransportErrorKeepsCachedState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Subsequent heartbeat GET hangs up the connection (transport error).
+	// Subsequent poll GET hangs up the connection (transport error).
 	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
 		hj, ok := w.(http.Hijacker)
 		if !ok {
@@ -843,8 +975,8 @@ func TestHeartbeatTransportErrorKeepsCachedState(t *testing.T) {
 		_ = conn.Close()
 	}
 
-	if err := mgr.Heartbeat(context.Background()); err == nil {
-		t.Fatal("heartbeat transport error must surface, got nil")
+	if err := mgr.Poll(context.Background()); err == nil {
+		t.Fatal("poll transport error must surface, got nil")
 	}
 	snap := mgr.Snapshot()
 	if snap.Status != "active" {
@@ -989,7 +1121,7 @@ func TestActiveSessionWithoutModelServesAnyModel(t *testing.T) {
 		t.Errorf("creates = %d, want 1 (model-less session reused for any model)", mock.SessionCreates)
 	}
 }
-func TestHeartbeatStatusErrors(t *testing.T) {
+func TestPollStatusErrors(t *testing.T) {
 	t.Run("banned returns BanError and clears cached admission", func(t *testing.T) {
 		mock := testutil.NewMock()
 		defer mock.Close()
@@ -1004,7 +1136,7 @@ func TestHeartbeatStatusErrors(t *testing.T) {
 			_, _ = io.WriteString(w, `{"status":"banned","resumes_at":"2026-08-16T12:00:00Z"}`)
 		}
 
-		err := mgr.Heartbeat(context.Background())
+		err := mgr.Poll(context.Background())
 		var be *upstream.BanError
 		if !errors.As(err, &be) {
 			t.Fatalf("want *upstream.BanError, got %v", err)
@@ -1034,7 +1166,7 @@ func TestHeartbeatStatusErrors(t *testing.T) {
 			_, _ = io.WriteString(w, `{"status":"country_blocked","countryCode":"US","countryBlockReason":"region restricted","ipPrivacySignals":["proxy"]}`)
 		}
 
-		err := mgr.Heartbeat(context.Background())
+		err := mgr.Poll(context.Background())
 		var cbe *upstream.CountryBlockedError
 		if !errors.As(err, &cbe) {
 			t.Fatalf("want *upstream.CountryBlockedError, got %v", err)
@@ -1061,7 +1193,7 @@ func TestHeartbeatStatusErrors(t *testing.T) {
 			_, _ = io.WriteString(w, `{"status":"rate_limited","retryAfterMs":45000,"limit":5,"recentCount":5}`)
 		}
 
-		err := mgr.Heartbeat(context.Background())
+		err := mgr.Poll(context.Background())
 		var rle *upstream.RateLimitError
 		if !errors.As(err, &rle) {
 			t.Fatalf("want *upstream.RateLimitError, got %v", err)
@@ -1203,11 +1335,11 @@ func TestModelLockedFallbackInstance(t *testing.T) {
 
 // ── Wave 1 issue tests (#81) ─────────────────────────────────────────────
 
-// TestHeartbeatIpCapped verifies #81: an ip_capped session status maps to
+// TestPollIpCapped verifies #81: an ip_capped session status maps to
 // the distinct upstream.IpCappedError (admission-only, bounded to
 // retryAfterMs — never the Pacific-midnight quota lock), NOT a
 // RateLimitError.
-func TestHeartbeatIpCapped(t *testing.T) {
+func TestPollIpCapped(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	mgr := newTestManager(t, mock)
@@ -1221,7 +1353,7 @@ func TestHeartbeatIpCapped(t *testing.T) {
 		_, _ = io.WriteString(w, `{"status":"ip_capped","activeUsersForIp":5,"limit":4,"retryAfterMs":30000}`)
 	}
 
-	err := mgr.Heartbeat(context.Background())
+	err := mgr.Poll(context.Background())
 	if errors.Is(err, upstream.ErrRateLimited) {
 		t.Fatal("ip_capped mapped to ErrRateLimited, want distinct ErrIpCapped")
 	}

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -84,7 +84,11 @@ func TestStoreDropsExpiredGrace(t *testing.T) {
 	}
 }
 
-func TestShutdownKeepsSessionWhenPersist(t *testing.T) {
+// TestShutdownDeletesEvenWhenPersist verifies gap #13: shutdown DELETEs the
+// upstream slot even with persistence enabled, while the store entry
+// survives the DELETE for restart-resume (pollPersisted re-adopts when the
+// DELETE did not take effect, or drops the dead entry and re-POSTs fresh).
+func TestShutdownDeletesEvenWhenPersist(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	store := NewStore(filepath.Join(t.TempDir(), "state.json"))
@@ -100,8 +104,8 @@ func TestShutdownKeepsSessionWhenPersist(t *testing.T) {
 	if err := mgr.Shutdown(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if mock.SessionEnds != 0 {
-		t.Errorf("SessionEnds = %d, want 0 (session kept alive for restart)", mock.SessionEnds)
+	if mock.SessionEnds != 1 {
+		t.Errorf("SessionEnds = %d, want 1 (DELETE on exit even when persisting)", mock.SessionEnds)
 	}
 	if got := store.Load(mgr.key); got == nil || got.instanceID != "inst-abc-123" {
 		t.Errorf("store after Shutdown = %+v, want active inst-abc-123", got)
@@ -129,7 +133,9 @@ func TestResumePersistedOnRestart(t *testing.T) {
 	defer mock.Close()
 	path := filepath.Join(t.TempDir(), "state.json")
 
-	// First process: create a session and shut down (keeps it alive).
+	// First process: create a session and shut down. Shutdown DELETEs the
+	// upstream slot (gap #13) but keeps the store entry, so a restart can
+	// still probe it via pollPersisted.
 	mgr1 := newTestManagerWithStore(t, mock, NewStore(path))
 	if _, err := mgr1.EnsureSession(context.Background()); err != nil {
 		t.Fatal(err)
@@ -141,7 +147,10 @@ func TestResumePersistedOnRestart(t *testing.T) {
 		t.Fatalf("SessionCreates after first process = %d, want 1", mock.SessionCreates)
 	}
 
-	// Second process (same token → same store key): must resume, not create.
+	// Second process (same token → same store key): pollPersisted probes the
+	// persisted slot. This mock's DELETE is stateless (the instance still
+	// answers active), so the slot is resumed and no new quota is burned —
+	// the same path that re-POSTs fresh when the DELETE took effect upstream.
 	mgr2 := newTestManagerWithStore(t, mock, NewStore(path))
 	instance, err := mgr2.EnsureSession(context.Background())
 	if err != nil {

--- a/internal/session/wave3_test.go
+++ b/internal/session/wave3_test.go
@@ -149,10 +149,10 @@ func TestReAdmitDisabledByDefault(t *testing.T) {
 	}
 }
 
-// TestHeartbeatSkipsWithinProbeTTL pins issue #60(a): heartbeat GETs within
+// TestPollSkipsWithinProbeTTL pins issue #60(a): session poll GETs within
 // the admission probe cache TTL of a successful session response are
 // skipped; after the TTL the GET happens.
-func TestHeartbeatSkipsWithinProbeTTL(t *testing.T) {
+func TestPollSkipsWithinProbeTTL(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	m := newTestSession(t, mock)
@@ -162,17 +162,17 @@ func TestHeartbeatSkipsWithinProbeTTL(t *testing.T) {
 		t.Fatal(err)
 	}
 	pollsAfterAdmit := mock.SessionPolls
-	if err := m.Heartbeat(context.Background()); err != nil {
+	if err := m.Poll(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if mock.SessionPolls != pollsAfterAdmit {
-		t.Errorf("heartbeat within probe TTL issued a GET (polls %d → %d)", pollsAfterAdmit, mock.SessionPolls)
+		t.Errorf("poll within probe TTL issued a GET (polls %d → %d)", pollsAfterAdmit, mock.SessionPolls)
 	}
 }
 
-// TestHeartbeatAfterProbeTTLPolls pins the other side: once the TTL
-// elapses, the heartbeat GET fires.
-func TestHeartbeatAfterProbeTTLPolls(t *testing.T) {
+// TestPollAfterProbeTTLPolls pins the other side: once the TTL elapses, the
+// session poll GET fires.
+func TestPollAfterProbeTTLPolls(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	m := newTestSession(t, mock)
@@ -183,11 +183,11 @@ func TestHeartbeatAfterProbeTTLPolls(t *testing.T) {
 	}
 	time.Sleep(80 * time.Millisecond) // age past the TTL
 	polls := mock.SessionPolls
-	if err := m.Heartbeat(context.Background()); err != nil {
+	if err := m.Poll(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if mock.SessionPolls != polls+1 {
-		t.Errorf("heartbeat after TTL = %d polls, want %d+1", mock.SessionPolls, polls)
+		t.Errorf("poll after TTL = %d polls, want %d+1", mock.SessionPolls, polls)
 	}
 }
 

--- a/internal/testutil/env.go
+++ b/internal/testutil/env.go
@@ -18,7 +18,8 @@ var configEnvKeys = []string{
 	"CLI_VERSION", "MODEL_ALIASES", "TRANSIENT_RETRIES", "SESSION_PERSIST",
 	"SESSION_STATE_FILE", "AUTO_DISCOVER_TOKEN",
 	"HTTP2_UPSTREAM",
-	"USER_ID",
+	"ACTING_USER_ID",
+	"USER_ID", // legacy alias (pre-rename knob, #126)
 }
 
 // UnsetConfigEnv removes every ambient freebuff-proxy config env var for the

--- a/internal/testutil/mockupstream.go
+++ b/internal/testutil/mockupstream.go
@@ -19,10 +19,10 @@ import (
 
 // FinishedRun records an agent-run FINISH payload received by the mock.
 type FinishedRun struct {
-	RunID        string         `json:"runId"`
-	Status       string         `json:"status"`
-	TotalSteps   int            `json:"totalSteps"`
-	ErrorMessage string         `json:"errorMessage,omitempty"`
+	RunID        string `json:"runId"`
+	Status       string `json:"status"`
+	TotalSteps   int    `json:"totalSteps"`
+	ErrorMessage string `json:"errorMessage,omitempty"`
 	// Steps mirrors the CLI step wire shape, captured from the FINISH
 	// payload (issue #114): steps are batched and sent WITH FINISH.
 	Steps []RecordedStep `json:"steps,omitempty"`

--- a/internal/testutil/mockupstream.go
+++ b/internal/testutil/mockupstream.go
@@ -19,9 +19,13 @@ import (
 
 // FinishedRun records an agent-run FINISH payload received by the mock.
 type FinishedRun struct {
-	RunID      string `json:"runId"`
-	Status     string `json:"status"`
-	TotalSteps int    `json:"totalSteps"`
+	RunID        string         `json:"runId"`
+	Status       string         `json:"status"`
+	TotalSteps   int            `json:"totalSteps"`
+	ErrorMessage string         `json:"errorMessage,omitempty"`
+	// Steps mirrors the CLI step wire shape, captured from the FINISH
+	// payload (issue #114): steps are batched and sent WITH FINISH.
+	Steps []RecordedStep `json:"steps,omitempty"`
 }
 
 // StartRequest records one agent-runs START payload (issue #91).
@@ -30,13 +34,17 @@ type StartRequest struct {
 	AncestorRunIDs []string `json:"ancestorRunIds"`
 }
 
-// RecordedStep records one /api/v1/agent-runs/{runID}/steps payload
-// (issue #91).
+// RecordedStep mirrors one agent-run step as received in a FINISH payload
+// (issue #114): steps are batched and sent WITH FINISH — the CLI has no
+// /steps endpoint.
 type RecordedStep struct {
-	RunID      string `json:"-"`
-	StepNumber int    `json:"stepNumber"`
-	MessageID  string `json:"messageId"`
-	Status     string `json:"status"`
+	ID          string   `json:"id"`
+	StepNumber  int      `json:"stepNumber"`
+	Credits     int      `json:"credits,omitempty"`
+	ChildRunIDs []string `json:"childRunIds,omitempty"`
+	MessageID   *string  `json:"messageId"`
+	Status      string   `json:"status,omitempty"`
+	StartTime   string   `json:"startTime"`
 }
 
 // MockUpstream is a scriptable codebuff.com stand-in.
@@ -89,9 +97,6 @@ type MockUpstream struct {
 	// StartRequests records every agent-runs START payload (agentId +
 	// ancestorRunIds) so tests can assert the run-tree wiring.
 	StartRequests []StartRequest
-
-	// RecordedSteps records /steps POST payloads (issue #91).
-	RecordedSteps []RecordedStep
 
 	ChatStatus    int    // 200 by default
 	ChatBody      string // SSE body served on 200
@@ -247,8 +252,6 @@ func (m *MockUpstream) handle(w http.ResponseWriter, r *http.Request) {
 		}
 	case r.URL.Path == "/api/v1/agent-runs" && r.Method == http.MethodPost:
 		m.handleAgentRuns(w, r)
-	case strings.HasPrefix(r.URL.Path, "/api/v1/agent-runs/") && strings.HasSuffix(r.URL.Path, "/steps") && r.Method == http.MethodPost:
-		m.handleSteps(w, r)
 	case r.URL.Path == "/api/v1/chat/completions" && r.Method == http.MethodPost:
 		m.handleChat(w, r)
 	case r.URL.Path == "/api/auth/cli/code" && r.Method == http.MethodPost:
@@ -427,12 +430,14 @@ func (m *MockUpstream) handleProbe(w http.ResponseWriter) {
 func (m *MockUpstream) handleAgentRuns(w http.ResponseWriter, r *http.Request) {
 	body, _ := io.ReadAll(r.Body)
 	var payload struct {
-		Action         string   `json:"action"`
-		AgentID        string   `json:"agentId"`
-		RunID          string   `json:"runId"`
-		Status         string   `json:"status"`
-		Steps          int      `json:"totalSteps"`
-		AncestorRunIDs []string `json:"ancestorRunIds"`
+		Action         string         `json:"action"`
+		AgentID        string         `json:"agentId"`
+		RunID          string         `json:"runId"`
+		Status         string         `json:"status"`
+		TotalSteps     int            `json:"totalSteps"`
+		ErrorMessage   string         `json:"errorMessage"`
+		StepList       []RecordedStep `json:"steps"`
+		AncestorRunIDs []string       `json:"ancestorRunIds"`
 	}
 	_ = json.Unmarshal(body, &payload)
 
@@ -491,9 +496,11 @@ func (m *MockUpstream) handleAgentRuns(w http.ResponseWriter, r *http.Request) {
 		}
 		m.mu.Lock()
 		m.FinishedRuns = append(m.FinishedRuns, FinishedRun{
-			RunID:      payload.RunID,
-			Status:     payload.Status,
-			TotalSteps: payload.Steps,
+			RunID:        payload.RunID,
+			Status:       payload.Status,
+			TotalSteps:   payload.TotalSteps,
+			ErrorMessage: payload.ErrorMessage,
+			Steps:        append([]RecordedStep(nil), payload.StepList...),
 		})
 		m.mu.Unlock()
 		writeJSON(w, 200, map[string]any{"ok": true})
@@ -502,47 +509,12 @@ func (m *MockUpstream) handleAgentRuns(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// handleSteps records a /api/v1/agent-runs/{runID}/steps POST (issue #91).
-func (m *MockUpstream) handleSteps(w http.ResponseWriter, r *http.Request) {
-	body, _ := io.ReadAll(r.Body)
-	var payload struct {
-		StepNumber int    `json:"stepNumber"`
-		MessageID  string `json:"messageId"`
-		Status     string `json:"status"`
-	}
-	_ = json.Unmarshal(body, &payload)
-	runID := stepsRunID(r.URL.Path)
-	m.mu.Lock()
-	m.RecordedSteps = append(m.RecordedSteps, RecordedStep{
-		RunID:      runID,
-		StepNumber: payload.StepNumber,
-		MessageID:  payload.MessageID,
-		Status:     payload.Status,
-	})
-	m.mu.Unlock()
-	writeJSON(w, 200, map[string]any{"ok": true})
-}
-
-// stepsRunID extracts the run id from /api/v1/agent-runs/{id}/steps.
-func stepsRunID(path string) string {
-	trimmed := strings.TrimPrefix(path, "/api/v1/agent-runs/")
-	trimmed = strings.TrimSuffix(trimmed, "/steps")
-	return trimmed
-}
-
 // firstOf returns the first element, or "" for an empty slice.
 func firstOf(s []string) string {
 	if len(s) == 0 {
 		return ""
 	}
 	return s[0]
-}
-
-// StepsSnapshot returns a locked copy of the recorded /steps payloads.
-func (m *MockUpstream) StepsSnapshot() []RecordedStep {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return append([]RecordedStep(nil), m.RecordedSteps...)
 }
 
 // StartRequestsSnapshot returns a locked copy of the START payloads.

--- a/internal/upstream/auth_login.go
+++ b/internal/upstream/auth_login.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -38,18 +39,14 @@ import (
 	"freebuff-proxy/internal/config"
 )
 
-// freebuffLoginUserAgent is the official CLI login user agent (reference
-// account_login.go freebuffLoginUserAgent).
-const freebuffLoginUserAgent = "ai-sdk/openai-compatible/2.0.42/codebuff"
-
 // loginCallTimeout bounds each login HTTP call (code request, status poll,
 // protocol page walk).
 const loginCallTimeout = 30 * time.Second
 
 // loginPollInterval is how long between status polls (the upstream device
-// code takes a human to complete; 3s matches the reference
-// freebuffLoginPollSeconds).
-const loginPollInterval = 3 * time.Second
+// code takes a human to complete; 5s matches the reference CLI default
+// login-flow.ts pollLoginStatus intervalMs=5000, not the old 3s).
+const loginPollInterval = 5 * time.Second
 
 // NewForAuth builds a token-less client for the headless OAuth login flow
 // (#62/#66). The transport/stealth/proxy wiring is identical to a pooled
@@ -77,9 +74,11 @@ func newFingerprintID() (string, error) {
 	return "enhanced-" + hex.EncodeToString(b[:]), nil
 }
 
-// authLoginRequest builds an /api/auth/cli/* request with the official
-// login User-Agent, no credentials, and (for POST) the JSON content type
-// (reference freebuffLoginHeaders).
+// authLoginRequest builds an /api/auth/cli/* request with the chat ai-sdk
+// User-Agent (cliUserAgent — the fabricated 2.0.42 login UA is gone; the
+// real llm-providers version is 1.0.0), no credentials, and (for POST) the
+// JSON content type (reference freebuffLoginHeaders + login-flow.ts, whose
+// request() sets no UA at all).
 func (c *Client) authLoginRequest(ctx context.Context, method, path string, body []byte) (*http.Request, error) {
 	var reader io.Reader
 	if body != nil {
@@ -89,7 +88,7 @@ func (c *Client) authLoginRequest(ctx context.Context, method, path string, body
 	if err != nil {
 		return nil, fmt.Errorf("upstream: build %s %s: %w", method, path, err)
 	}
-	req.Header.Set("User-Agent", freebuffLoginUserAgent)
+	req.Header.Set("User-Agent", cliUserAgent)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -196,10 +195,12 @@ func loginExpiresAt(raw int64) time.Time {
 }
 
 // PollCLILogin polls GET /api/auth/cli/status for a started login.
-// Pending (401/2xx without a token — the backend answers 401 while the code
-// is pending) returns Done=false without error; a completed login returns
-// the token and user metadata (reference pollGitHubLogin +
-// login.ts pollLoginStatus).
+// Pending — 401 while the device code is unclaimed, a transient 5xx, or a
+// transport failure — returns Done=false WITHOUT error so callers keep
+// polling until the 5-minute deadline, mirroring login-flow.ts
+// pollLoginStatus (5xx + network errors are logged and retried; only the
+// deadline / shouldContinue abort). A completed login returns the token
+// and user metadata (reference pollGitHubLogin + login.ts pollLoginStatus).
 func (c *Client) PollCLILogin(ctx context.Context, code *CLILoginCode) (*CLILoginStatus, error) {
 	u, err := url.Parse(c.baseURL + "/api/auth/cli/status")
 	if err != nil {
@@ -219,16 +220,23 @@ func (c *Client) PollCLILogin(ctx context.Context, code *CLILoginCode) (*CLILogi
 	if err != nil {
 		return nil, fmt.Errorf("upstream: build login status request: %w", err)
 	}
-	req.Header.Set("User-Agent", freebuffLoginUserAgent)
+	req.Header.Set("User-Agent", cliUserAgent)
 	resp, cancel, err := c.do(req, loginCallTimeout)
 	if err != nil {
-		return nil, fmt.Errorf("upstream: poll login: %w", err)
+		// Transient transport failure: login-flow.ts logs and keeps polling
+		// through network errors — return pending so the caller retries
+		// until its 5-minute deadline (#125).
+		slog.Warn("login status poll: transient transport error, will retry", "err", err)
+		return &CLILoginStatus{}, nil
 	}
 	defer cancel()
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 500 {
+		// Transient upstream error: login-flow.ts keeps polling on any
+		// non-401 status — return pending (#125).
 		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
-		return nil, fmt.Errorf("upstream: poll login failed: status %d: %s", resp.StatusCode, truncate(string(raw), 200))
+		slog.Warn("login status poll: transient upstream status, will retry", "status", resp.StatusCode, "body", truncate(string(raw), 200))
+		return &CLILoginStatus{}, nil
 	}
 	if resp.StatusCode != http.StatusOK {
 		// Pending: 401 while the device code is unclaimed (login.ts keeps
@@ -305,14 +313,14 @@ func (c *Client) ProtocolGitHubLogin(ctx context.Context, username, password, to
 	}
 
 	// 1. Load the login page so the jar picks up session cookies.
-	if _, err := getWithUA(ctx, client, code.LoginURL, freebuffLoginUserAgent); err != nil {
+	if _, err := getWithUA(ctx, client, code.LoginURL, cliUserAgent); err != nil {
 		return nil, fmt.Errorf("freebuff github protocol login: login page: %w", err)
 	}
 
 	// 2. Walk the OAuth authorize page: GET the sign-in URL (the login page
 	// redirects there), find the login form, submit username+password.
 	if authorizeURL := githubProtocolAuthorizeURL(code.LoginURL); authorizeURL != "" {
-		if _, err := getWithUA(ctx, client, authorizeURL, freebuffLoginUserAgent); err != nil {
+		if _, err := getWithUA(ctx, client, authorizeURL, cliUserAgent); err != nil {
 			return nil, fmt.Errorf("freebuff github protocol login: authorize page: %w", err)
 		}
 	}
@@ -320,7 +328,7 @@ func (c *Client) ProtocolGitHubLogin(ctx context.Context, username, password, to
 	// 3. The login page may live at the login URL itself (github.com/login)
 	// or on the authorize flow; submit the password form wherever it is.
 	// We track the most recent page body through the login form.
-	loginResp, err := getWithUA(ctx, client, code.LoginURL, freebuffLoginUserAgent)
+	loginResp, err := getWithUA(ctx, client, code.LoginURL, cliUserAgent)
 	if err != nil {
 		return nil, fmt.Errorf("freebuff github protocol login: login form: %w", err)
 	}
@@ -330,7 +338,7 @@ func (c *Client) ProtocolGitHubLogin(ctx context.Context, username, password, to
 	}
 	form.Fields.Set("login", username)
 	form.Fields.Set("password", password)
-	postResp, err := submitForm(ctx, client, form, loginResp.finalURL, freebuffLoginUserAgent)
+	postResp, err := submitForm(ctx, client, form, loginResp.finalURL, cliUserAgent)
 	if err != nil {
 		return nil, fmt.Errorf("freebuff github protocol login: password submit: %w", err)
 	}
@@ -348,7 +356,7 @@ func (c *Client) ProtocolGitHubLogin(ctx context.Context, username, password, to
 		if totpForm.Fields.Get("otp") != "" {
 			totpForm.Fields.Set("otp", code6)
 		}
-		postResp, err = submitForm(ctx, client, totpForm, postResp.finalURL, freebuffLoginUserAgent)
+		postResp, err = submitForm(ctx, client, totpForm, postResp.finalURL, cliUserAgent)
 		if err != nil {
 			return nil, fmt.Errorf("freebuff github protocol login: totp submit: %w", err)
 		}
@@ -360,7 +368,7 @@ func (c *Client) ProtocolGitHubLogin(ctx context.Context, username, password, to
 		if strings.HasPrefix(target, "/") {
 			target = "https://github.com" + target
 		}
-		if _, err := getWithUA(ctx, client, target, freebuffLoginUserAgent); err != nil {
+		if _, err := getWithUA(ctx, client, target, cliUserAgent); err != nil {
 			return nil, fmt.Errorf("freebuff github protocol login: oauth callback: %w", err)
 		}
 	}
@@ -369,7 +377,11 @@ func (c *Client) ProtocolGitHubLogin(ctx context.Context, username, password, to
 	return c.pollForCompletion(ctx, code, 0)
 }
 
-// pollForCompletion polls PollCLILogin until Done, up to pollTimeout.
+// pollForCompletion polls PollCLILogin until Done, up to the 5-minute
+// deadline. 5xx and transport failures are already transient inside
+// PollCLILogin (pending, no error), so the only errors landing here are
+// locally-built-request failures; the loop otherwise mirrors login-flow.ts
+// (keep polling, abort only on deadline / ctx cancel).
 func (c *Client) pollForCompletion(ctx context.Context, code *CLILoginCode, _ time.Duration) (*CLILoginStatus, error) {
 	deadline := time.Now().Add(5 * time.Minute)
 	for {

--- a/internal/upstream/auth_wave6_test.go
+++ b/internal/upstream/auth_wave6_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -12,13 +13,14 @@ import (
 	"freebuff-proxy/internal/testutil"
 )
 
-// --- #52: session-stable client_id ------------------------------------------
+// --- #103: fresh random client_id per chat call -----------------------------
 
-// TestInjectEnvelopeSessionStableClientID verifies #52: client_id derives
-// from the SESSION INSTANCE id (stable across all runs of a session), falls
-// back to the run id when no instance is set, and stays stable across
-// requests.
-func TestInjectEnvelopeSessionStableClientID(t *testing.T) {
+// TestInjectEnvelopeFreshRandomClientID verifies #103: client_id is a FRESH
+// random SDK-faithful base36 draw per chat call — never the sess:/run:-
+// prefixed shapes the server fingerprints as a proxy, never wf- prefixed,
+// and never stable across calls. trace_session_id stays per run and
+// freebuff_instance_id stays per session.
+func TestInjectEnvelopeFreshRandomClientID(t *testing.T) {
 	out, err := injectEnvelope([]byte(`{"model":"m"}`), "free", ChatOptions{RunID: "run-1", SessionInstanceID: "inst-9", TraceSessionID: "trace-abc"})
 	if err != nil {
 		t.Fatal(err)
@@ -28,15 +30,24 @@ func TestInjectEnvelopeSessionStableClientID(t *testing.T) {
 		t.Fatal(err)
 	}
 	md := sent["codebuff_metadata"].(map[string]any)
-	if md["client_id"] != "sess:inst-9" {
-		t.Errorf("client_id = %v, want sess:inst-9 (stable per session instance)", md["client_id"])
+	clientID, _ := md["client_id"].(string)
+	if !regexp.MustCompile(`^[a-z0-9]{13}$`).MatchString(clientID) {
+		t.Errorf("client_id = %q, want a 13-char base36 draw", clientID)
+	}
+	for _, prefix := range []string{"sess:", "run:", "wf-"} {
+		if strings.HasPrefix(clientID, prefix) {
+			t.Errorf("client_id = %q, must not carry the %q prefix (proxy fingerprint)", clientID, prefix)
+		}
 	}
 	if md["trace_session_id"] != "trace-abc" {
 		t.Errorf("trace_session_id = %v, want trace-abc (per run)", md["trace_session_id"])
 	}
+	if md["freebuff_instance_id"] != "inst-9" {
+		t.Errorf("freebuff_instance_id = %v, want inst-9 (per session)", md["freebuff_instance_id"])
+	}
 
-	// Same session, a DIFFERENT run (rotation): client_id must NOT change.
-	out2, err := injectEnvelope([]byte(`{"model":"m"}`), "free", ChatOptions{RunID: "run-2", SessionInstanceID: "inst-9"})
+	// A second call with the SAME run AND session must draw a DIFFERENT id.
+	out2, err := injectEnvelope([]byte(`{"model":"m"}`), "free", ChatOptions{RunID: "run-1", SessionInstanceID: "inst-9"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,11 +55,11 @@ func TestInjectEnvelopeSessionStableClientID(t *testing.T) {
 		t.Fatal(err)
 	}
 	md2 := sent["codebuff_metadata"].(map[string]any)
-	if md2["client_id"] != "sess:inst-9" {
-		t.Errorf("client_id = %v after run rotation, want sess:inst-9 (session-stable)", md2["client_id"])
+	if id2, _ := md2["client_id"].(string); id2 == clientID {
+		t.Errorf("client_id = %q on a second call, want a fresh draw per call", id2)
 	}
 
-	// No instance id (disabled session): falls back to the run-derived id.
+	// No instance id (disabled session): still a fresh unprefixed draw.
 	out3, err := injectEnvelope([]byte(`{"model":"m"}`), "free", ChatOptions{RunID: "run-3"})
 	if err != nil {
 		t.Fatal(err)
@@ -56,8 +67,37 @@ func TestInjectEnvelopeSessionStableClientID(t *testing.T) {
 	if err := json.Unmarshal(out3, &sent); err != nil {
 		t.Fatal(err)
 	}
-	if md3 := sent["codebuff_metadata"].(map[string]any); md3["client_id"] != "run:run-3" {
-		t.Errorf("client_id = %v without instance, want run:run-3", md3["client_id"])
+	md3 := sent["codebuff_metadata"].(map[string]any)
+	if id3, _ := md3["client_id"].(string); !regexp.MustCompile(`^[a-z0-9]{13}$`).MatchString(id3) || strings.HasPrefix(id3, "run:") {
+		t.Errorf("client_id without instance = %q, want fresh unprefixed 13-char base36", id3)
+	}
+}
+
+// TestInjectEnvelopeStepNumber verifies #113: llm_step_number is injected as
+// a STRING when ChatOptions.StepNumber > 0 and absent when zero.
+func TestInjectEnvelopeStepNumber(t *testing.T) {
+	out, err := injectEnvelope([]byte(`{"model":"m"}`), "free", ChatOptions{RunID: "r", StepNumber: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sent map[string]any
+	if err := json.Unmarshal(out, &sent); err != nil {
+		t.Fatal(err)
+	}
+	md := sent["codebuff_metadata"].(map[string]any)
+	if md["llm_step_number"] != "3" {
+		t.Errorf("llm_step_number = %v (%T), want %q (string form)", md["llm_step_number"], md["llm_step_number"], "3")
+	}
+
+	out2, err := injectEnvelope([]byte(`{"model":"m"}`), "free", ChatOptions{RunID: "r"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(out2, &sent); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := sent["codebuff_metadata"].(map[string]any)["llm_step_number"]; present {
+		t.Error("llm_step_number present when StepNumber == 0")
 	}
 }
 

--- a/internal/upstream/auth_wave6_test.go
+++ b/internal/upstream/auth_wave6_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -237,6 +240,107 @@ func TestPollCLILoginPendingThenComplete(t *testing.T) {
 	}
 	if mock.AuthCLIStatusRequests != 2 {
 		t.Errorf("AuthCLIStatusRequests = %d, want 2", mock.AuthCLIStatusRequests)
+	}
+}
+
+// TestPollCLILoginTransient5xxKeepsPolling verifies #125: a transient 5xx
+// from /api/auth/cli/status must report pending (Done=false, no error) so
+// the caller keeps polling until the 5-minute deadline — mirroring
+// login-flow.ts pollLoginStatus, which retries every non-401 status.
+func TestPollCLILoginTransient5xxKeepsPolling(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	client, err := NewForAuth(testConfig(mock.URL(), nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := client.StartCLILogin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The upstream answers 500 (transient blip). Handler is set AFTER
+	// StartCLILogin, so only status polls hit it.
+	mock.AuthCLIHandler = func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/auth/cli/status" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"error":"boom"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}
+	status, err := client.PollCLILogin(context.Background(), code)
+	if err != nil {
+		t.Fatalf("PollCLILogin errored on transient 5xx, want pending (no error): %v", err)
+	}
+	if status.Done || status.AuthToken != "" {
+		t.Errorf("status = %+v, want Done=false on transient 5xx", status)
+	}
+}
+
+// TestPollCLILoginTransportErrorTransient verifies #125: a transport-level
+// failure (connection refused) must report pending, not abort — the CLI
+// keeps polling through network errors (login-flow.ts catch branch).
+func TestPollCLILoginTransportErrorTransient(t *testing.T) {
+	// A closed listener makes every request fail at dial time.
+	closed := httptest.NewServer(http.NotFoundHandler())
+	closed.Close()
+	client, err := NewForAuth(testConfig(closed.URL, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := &CLILoginCode{
+		FingerprintID:   "enhanced-x",
+		FingerprintHash: "h",
+		ExpiresAtRaw:    time.Now().Add(5 * time.Minute).UnixMilli(),
+	}
+	status, err := client.PollCLILogin(context.Background(), code)
+	if err != nil {
+		t.Fatalf("PollCLILogin errored on transport failure, want pending (no error): %v", err)
+	}
+	if status.Done || status.AuthToken != "" {
+		t.Errorf("status = %+v, want Done=false on transport failure", status)
+	}
+}
+
+// TestAuthLoginRequestsCarryCLIUA verifies #125: the /api/auth/cli/code and
+// /api/auth/cli/status calls send the real chat ai-sdk cliUserAgent (1.0.0),
+// never the fabricated 2.0.42 login UA (the CLI's request() sets no UA, and
+// the proxy's closest equivalent is the pinned cli UA).
+func TestAuthLoginRequestsCarryCLIUA(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	var codeUA, statusUA string
+	mock.AuthCLIHandler = func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/auth/cli/code":
+			codeUA = r.Header.Get("User-Agent")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"fingerprintId":"enhanced-x","fingerprintHash":"h","loginUrl":"https://github.com/login/oauth/authorize?auth_code=abc","expiresAt":`+strconv.FormatInt(time.Now().Add(5*time.Minute).UnixMilli(), 10)+`}`)
+		case "/api/auth/cli/status":
+			statusUA = r.Header.Get("User-Agent")
+			w.WriteHeader(http.StatusUnauthorized) // pending
+		default:
+			http.NotFound(w, r)
+		}
+	}
+	client, err := NewForAuth(testConfig(mock.URL(), nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := client.StartCLILogin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.PollCLILogin(context.Background(), code); err != nil {
+		t.Fatal(err)
+	}
+	if codeUA != cliUserAgent {
+		t.Errorf("/api/auth/cli/code User-Agent = %q, want %q", codeUA, cliUserAgent)
+	}
+	if statusUA != cliUserAgent {
+		t.Errorf("/api/auth/cli/status User-Agent = %q, want %q", statusUA, cliUserAgent)
 	}
 }
 

--- a/internal/upstream/client.go
+++ b/internal/upstream/client.go
@@ -255,8 +255,9 @@ func (e *CreditsError) Unwrap() error { return ErrCredits }
 // automatically. The client retries it in-place against the SAME lease and
 // session (up to TRANSIENT_RETRIES extra attempts) before surfacing it; it
 // is never a token cooldown and never a session invalidation. Unwrap yields
-// a Retryable UpstreamError so generic server paths surface it as a
-// retryable 503 once the client-side budget is exhausted.
+// a Retryable UpstreamError so errors.As finds it, but writeError has a
+// dedicated branch: it surfaces as 429 free_mode_capacity_deferred with
+// Retry-After once the client-side budget is exhausted (#105) — not a 503.
 type CapacityDeferredError struct {
 	Status     int
 	RetryAfter time.Duration

--- a/internal/upstream/client.go
+++ b/internal/upstream/client.go
@@ -447,6 +447,12 @@ type ChatOptions struct {
 	// CLI (run.ts: previousRun?.traceSessionId ?? randomUUID). Injected as
 	// codebuff_metadata["trace_session_id"] when set.
 	TraceSessionID string
+	// StepNumber is the 1-based per-run agent step counter (CLI parity:
+	// llm_step_number is merged on every chat call, String(n);
+	// reference/freebuff agent-runtime run-agent-step.ts:1175-1177).
+	// Injected as codebuff_metadata["llm_step_number"] when > 0; the run
+	// manager sets it per chat call at the server construction sites.
+	StepNumber int
 }
 
 // Client speaks the codebuff.com wire protocol for a single token.
@@ -459,7 +465,6 @@ type Client struct {
 	requestTimeout     time.Duration
 	sessionCallTimeout time.Duration
 	requestJitter      time.Duration
-	cliVersion         string
 	costMode           string
 	userID             string // optional x-freebuff-acting-user-id (USER_ID; CLI parity)
 	debugDump          bool
@@ -523,14 +528,16 @@ func (c *Client) TokenKey() string {
 	return hex.EncodeToString(sum[:])
 }
 
-// cliUserAgent mirrors the official CLI / SDK user agent. The upstream
-// free-tier gate (403 free_mode_cli_required) keys on the CLI request
-// envelope (x-freebuff-* headers, codebuff_metadata, forced streaming and
-// the cb_easp stop sentinel — see the package comment), NOT the User-Agent,
-// so the stealth path may carry a browser UA matched to its TLS fingerprint
-// without tripping the gate. This constant is applied on the non-stealth
-// path so the request signature stays identical on every request.
-const cliUserAgent = "ai-sdk/openai-compatible/0.10.7/codebuff"
+// cliUserAgent mirrors the official CLI chat user agent: the pinned
+// @codebuff/llm-providers version, NOT the CLI_VERSION knob
+// (reference/freebuff model-provider.ts:150; llm-providers package.json
+// 1.0.0). The upstream free-tier gate (403 free_mode_cli_required) keys on
+// the CLI request envelope (x-freebuff-* headers, codebuff_metadata, forced
+// streaming and the cb_easp stop sentinel — see the package comment), but
+// the server still fingerprints the UA, and 0.10.7 (the SDK version) is
+// never emitted by a real CLI. Every upstream API call (chat + session +
+// agent-runs) sends this UA — no browser persona (#108/#109).
+const cliUserAgent = "ai-sdk/openai-compatible/1.0.0/codebuff"
 
 // New builds the client for one token.
 func New(token string, cfg *config.Config) (*Client, error) {
@@ -550,11 +557,6 @@ func NewWithIndex(token string, tokenIndex int, cfg *config.Config) (*Client, er
 		return nil, errors.New("upstream: nil config")
 	}
 
-	cliVer := cfg.CLIVersion
-	if cliVer == "" {
-		cliVer = "0.10.7"
-	}
-
 	c := &Client{
 		token:                 token,
 		tokenIndex:            tokenIndex,
@@ -562,7 +564,6 @@ func NewWithIndex(token string, tokenIndex int, cfg *config.Config) (*Client, er
 		requestTimeout:        cfg.RequestTimeout,
 		sessionCallTimeout:    cfg.SessionCallTimeout,
 		requestJitter:         cfg.RequestJitter,
-		cliVersion:            cliVer,
 		costMode:              cfg.CostMode,
 		userID:                cfg.UserID,
 		debugDump:             cfg.DebugDump,
@@ -663,11 +664,12 @@ func NewWithIndex(token string, tokenIndex int, cfg *config.Config) (*Client, er
 				return errors.New("too many redirects")
 			}
 			// Go strips Authorization/Cookie on cross-host redirects but not
-			// x-codebuff-api-key, which carries the same raw token. Drop both
-			// when the redirect target is a different host OR downgrades the
-			// scheme https->http (same host, plaintext) so the token never
-			// leaks to a redirect target; same-scheme same-host redirects
-			// (e.g. CDN or bare-host -> www) keep their credentials.
+			// x-codebuff-api-key, which carried the same raw token (defensive —
+			// newRequest no longer sets it, #107). Drop both when the redirect
+			// target is a different host OR downgrades the scheme https->http
+			// (same host, plaintext) so the token never leaks to a redirect
+			// target; same-scheme same-host redirects (e.g. CDN or bare-host
+			// -> www) keep their credentials.
 			if !strings.EqualFold(via[0].URL.Host, req.URL.Host) ||
 				(strings.EqualFold(via[0].URL.Scheme, "https") && strings.EqualFold(req.URL.Scheme, "http")) {
 				req.Header.Del("Authorization")
@@ -730,10 +732,11 @@ func (c *Client) ChatCompletions(ctx context.Context, opts ChatOptions, body []b
 			req = req.WithContext(reqCtx)
 		}
 		req.Header.Set("Accept", "application/json, text/event-stream")
-		req.Header.Set("x-freebuff-model", opts.Model)
-		if opts.SessionInstanceID != "" {
-			req.Header.Set("x-freebuff-instance-id", opts.SessionInstanceID)
-		}
+		// The chat POST carries NO x-freebuff-model / x-freebuff-instance-id
+		// headers (#106): the official CLI sends exactly Authorization + the
+		// ai-sdk UA (+ optional acting-user-id) on chat
+		// (reference/freebuff model-provider.ts:146-152); the model and
+		// instance id ride only in the body metadata (injectEnvelope).
 		if c.userID != "" {
 			// The official CLI sends the acting user id on every chat call and
 			// the free-mode gate expects it
@@ -754,6 +757,25 @@ func (c *Client) ChatCompletions(ctx context.Context, opts ChatOptions, body []b
 			if isCapacityDeferred(cerr) && capacityDeferredAttempts < c.transientRetriesLimit {
 				capacityDeferredAttempts++
 				c.capacityDeferredRetries.Add(1) // lifetime metric
+				// #105: the free-tier capacity queue asks the client to WAIT
+				// before retrying — the AI SDK absorbs the deferral silently,
+				// honoring retry-after with a 10s default
+				// (reference/freebuff sdk model-provider.ts:41-49,62-81). Sleep
+				// the parsed retry-after (floor 10s) so the same-session retry
+				// does not re-POST immediately (amplification); ctx
+				// cancellation aborts the sleep like every other upstream wait.
+				ra := 10 * time.Second
+				var cde *CapacityDeferredError
+				if errors.As(cerr, &cde) && cde.RetryAfter > 0 {
+					ra = cde.RetryAfter
+				}
+				timer := time.NewTimer(ra)
+				select {
+				case <-timer.C:
+				case <-ctx.Done():
+					timer.Stop()
+					return nil, ctx.Err()
+				}
 				continue
 			}
 			return nil, cerr
@@ -783,11 +805,15 @@ func (c *Client) CreateSessionForModel(ctx context.Context, model string) (*Sess
 // 404 maps to Status "ended" (the session vanished upstream; the session
 // manager re-creates it). Only a CREATE 404 maps to "disabled".
 func (c *Client) GetSession(ctx context.Context, instanceID string) (*SessionState, error) {
-	return c.GetSessionWithOpts(ctx, instanceID, false, false)
+	return c.GetSessionWithOpts(ctx, instanceID, false)
 }
 
-// GetSessionWithOpts polls /api/v1/freebuff/session with optional compact or heartbeat headers.
-func (c *Client) GetSessionWithOpts(ctx context.Context, instanceID string, compact, heartbeat bool) (*SessionState, error) {
+// GetSessionWithOpts polls /api/v1/freebuff/session with an optional compact
+// response header. There is deliberately NO heartbeat option: the CLI never
+// sends x-freebuff-heartbeat (Desktop-only, reference/freebuff
+// freebuff-models.ts:1212-1215); liveness comes from the recurring compact
+// GET itself (gap #2).
+func (c *Client) GetSessionWithOpts(ctx context.Context, instanceID string, compact bool) (*SessionState, error) {
 	req, err := c.newRequest(ctx, http.MethodGet, "/api/v1/freebuff/session", nil)
 	if err != nil {
 		return nil, err
@@ -797,9 +823,6 @@ func (c *Client) GetSessionWithOpts(ctx context.Context, instanceID string, comp
 	}
 	if compact {
 		req.Header.Set("x-freebuff-compact-session", "1")
-	}
-	if heartbeat {
-		req.Header.Set("x-freebuff-heartbeat", "1")
 	}
 	return c.sessionCall(req)
 }
@@ -907,18 +930,59 @@ func (c *Client) StartRun(ctx context.Context, agentID string) (string, error) {
 	return parsed.RunID, nil
 }
 
-// FinishRun POSTs /api/v1/agent-runs with action FINISH, marking the run
-// completed with step accounting (mirrors the official CLI payload).
-func (c *Client) FinishRun(ctx context.Context, runID string, totalSteps int) error {
-	payload, _ := json.Marshal(map[string]any{
+// RunStep is one agent-run step, batched in memory and sent WITH FINISH
+// (issue #114, CLI parity: reference/freebuff/sdk/src/impl/database.ts
+// pendingAgentStepSchema — the CLI has NO /steps endpoint, so steps ride
+// the FINISH payload). The proxy records one step per completed chat call.
+type RunStep struct {
+	// ID is a per-step UUID minted at record time.
+	ID string `json:"id"`
+	// StepNumber is the 1-based per-run step index (sequential 1,2,3…).
+	StepNumber int `json:"stepNumber"`
+	// Credits is always 0 for the proxy (the upstream account owns spend).
+	Credits int `json:"credits,omitempty"`
+	// ChildRunIDs is empty for proxy-recorded steps (child runs are
+	// separate runs, not steps).
+	ChildRunIDs []string `json:"childRunIds,omitempty"`
+	// MessageID is the completed chat response id; null when the stream
+	// never carried one (the CLI schema allows a null messageId).
+	MessageID *string `json:"messageId"`
+	// Status mirrors the CLI step lifecycle; proxy-recorded steps are
+	// always "completed" (recorded only after a successful chat).
+	Status string `json:"status,omitempty"`
+	// StartTime is the step start instant, RFC3339Nano UTC.
+	StartTime string `json:"startTime"`
+}
+
+// FinishRun POSTs /api/v1/agent-runs with action FINISH, reporting the
+// run's honest terminal status and its completed steps (issue #114, CLI
+// parity: reference/freebuff/sdk/src/impl/database.ts finishAgentRun — the
+// full payload is sent in ONE request; there is no /steps endpoint).
+// totalSteps is the step count the manager reports (len(steps) preferred,
+// falling back to the request count when no steps were recorded);
+// errorMessage is omitted when empty and truncated to 5000 runes otherwise,
+// exactly like the CLI's truncateString(errorMessage, 5000).
+func (c *Client) FinishRun(ctx context.Context, runID, status string, totalSteps int, steps []RunStep, errorMessage string) error {
+	if steps == nil {
+		steps = []RunStep{}
+	}
+	payload := map[string]any{
 		"action":        "FINISH",
 		"runId":         runID,
-		"status":        "completed",
+		"status":        status,
 		"totalSteps":    totalSteps,
 		"directCredits": 0,
 		"totalCredits":  0,
-	})
-	req, err := c.newRequest(ctx, http.MethodPost, "/api/v1/agent-runs", payload)
+		"steps":         steps,
+	}
+	if errorMessage != "" {
+		payload["errorMessage"] = truncateRunes(errorMessage, 5000)
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := c.newRequest(ctx, http.MethodPost, "/api/v1/agent-runs", body)
 	if err != nil {
 		return err
 	}
@@ -929,9 +993,9 @@ func (c *Client) FinishRun(ctx context.Context, runID string, totalSteps int) er
 	}
 	defer releaseCancel(cancel)
 	defer func() { _ = resp.Body.Close() }()
-	body := drainBody(resp.Body)
+	bodyStr := drainBody(resp.Body)
 	if resp.StatusCode >= 400 {
-		return c.classify(resp.StatusCode, body, resp.Header)
+		return c.classify(resp.StatusCode, bodyStr, resp.Header)
 	}
 	return nil
 }
@@ -972,45 +1036,6 @@ func (c *Client) StartChildRun(ctx context.Context, parentRunID string) (string,
 		return "", fmt.Errorf("upstream: child START response missing runId: %q", truncate(body, 200))
 	}
 	return parsed.RunID, nil
-}
-
-// RecordRunStep POSTs /api/v1/agent-runs/{runID}/steps with stepNumber 2
-// accounting (issue #91, CLI parity:
-// reference/freebuff-reverse .../http.go recordRunStep). Best-effort: the
-// server fires it through the bounded finish queue and failures are logged,
-// never surfaced. messageID is the completed chat response id ("" when the
-// stream never carried one); startTime anchors the step.
-func (c *Client) RecordRunStep(ctx context.Context, runID, messageID string, startTime time.Time) error {
-	body := map[string]any{
-		"stepNumber":  2,
-		"credits":     0,
-		"childRunIds": []any{},
-		"messageId":   nil,
-		"status":      "completed",
-		"startTime":   startTime.UTC().Format(time.RFC3339Nano),
-	}
-	if messageID != "" {
-		body["messageId"] = messageID
-	}
-	payload, err := json.Marshal(body)
-	if err != nil {
-		return err
-	}
-	req, err := c.newRequest(ctx, http.MethodPost, "/api/v1/agent-runs/"+runID+"/steps", payload)
-	if err != nil {
-		return err
-	}
-	resp, cancel, err := c.do(req, c.sessionCallTimeout)
-	if err != nil {
-		return err
-	}
-	defer releaseCancel(cancel)
-	defer func() { _ = resp.Body.Close() }()
-	bodyStr := drainBody(resp.Body)
-	if resp.StatusCode >= 400 {
-		return c.classify(resp.StatusCode, bodyStr, resp.Header)
-	}
-	return nil
 }
 
 // --- internals ---
@@ -1206,30 +1231,30 @@ func (c *Client) newRequest(ctx context.Context, method, path string, body []byt
 		return nil, fmt.Errorf("upstream: build %s %s: %w", method, path, err)
 	}
 	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("x-codebuff-api-key", c.token)
 	if c.authOnly {
 		// Token-less login-flow client (#62/#66): never send an empty
 		// credential pair — the /api/auth/cli/* endpoints take the login
 		// User-Agent instead (see authLoginRequest).
 		req.Header.Del("Authorization")
-		req.Header.Del("x-codebuff-api-key")
 	}
 	req.Header.Set("Content-Type", "application/json")
+	// The official CLI sends the pinned llm-providers ai-sdk UA on chat and
+	// NO browser headers on any API path (bare Bun fetch) (#108/#109 fix
+	// option (a)): the utls ClientHello impersonation stays, the browser
+	// header persona does not. x-codebuff-api-key is never sent — Bearer is
+	// the only credential (#107, reference/freebuff codebuff-api.ts:337-345).
+	req.Header.Set("User-Agent", cliUserAgent)
 	ctx = req.Context()
 	if profile := c.currentStealthProfile(); profile != nil {
 		// Resolve the concrete profile ONCE per request and stash it: the
-		// dialer reads the stash for the ClientHello, so the browser headers
-		// applied here always match the TLS fingerprint. Pinned profiles
-		// resolve to themselves; auto/random get one concrete draw.
+		// dialer reads the stash for the ClientHello, so the TLS fingerprint
+		// matches the profile. Pinned profiles resolve to themselves;
+		// auto/random get one concrete draw. Only SanitizeHeaders runs here
+		// (protective strip of proxy-identifying headers) — the profile's
+		// browser headers are deliberately NOT applied to upstream API calls.
 		connProf := stealth.GetProfileForConnection(profile)
 		ctx = withStealthProfile(ctx, connProf)
-		stealth.SanitizeAndApply(req.Header, connProf)
-	} else {
-		ver := c.cliVersion
-		if ver == "" {
-			ver = "0.10.7"
-		}
-		req.Header.Set("User-Agent", fmt.Sprintf("ai-sdk/openai-compatible/%s/codebuff", ver))
+		stealth.SanitizeHeaders(req.Header)
 	}
 	if ctx != req.Context() {
 		req = req.WithContext(ctx)
@@ -1341,11 +1366,11 @@ func (c *Client) currentStealthProfile() *stealth.Profile {
 
 // dialProfileFor returns the stealth profile the transport dialer should use
 // for a connection under ctx. For ProfileAuto/ProfileRandom the concrete
-// profile stashed by newRequest wins, so the ClientHello matches the browser
-// headers applied to that request; a bare context (no stash) resolves per
+// profile stashed by newRequest wins, so the ClientHello matches the profile
+// resolved for that request; a bare context (no stash) resolves per
 // connection as before. For pinned profiles the current c.stealthProfile is
-// authoritative: the retry loop swaps it (and re-applies headers) ahead of a
-// retry, so the stash would be stale.
+// authoritative: the retry loop swaps it ahead of a retry, so the stash
+// would be stale.
 func (c *Client) dialProfileFor(ctx context.Context) *stealth.Profile {
 	profile := c.currentStealthProfile()
 	if profile != nil && (profile.ID == stealth.ProfileIDAuto || profile.ID == stealth.ProfileIDRandom) {
@@ -1537,10 +1562,12 @@ var retryProfileRotation = []struct {
 }
 
 // rotateStealthProfileForRetry swaps the pinned TLS fingerprint to a
-// different profile before a retry and re-applies its browser headers to req,
-// so the retried connection does not repeat the fingerprint that just failed.
-// random/auto already rotate per connection and are left alone. No-op when
-// retries are disabled or no fingerprint is pinned.
+// different profile before a retry so the retried connection does not repeat
+// the fingerprint that just failed. The request keeps its CLI headers —
+// only proxy-identifying headers are re-stripped; no browser persona is
+// applied on API paths (#109). random/auto already rotate per connection and
+// are left alone. No-op when retries are disabled or no fingerprint is
+// pinned.
 func (c *Client) rotateStealthProfileForRetry(req *http.Request) {
 	c.profileMu.Lock()
 	defer c.profileMu.Unlock()
@@ -1557,7 +1584,7 @@ func (c *Client) rotateStealthProfileForRetry(req *http.Request) {
 	}
 	c.stealthProfile = next
 	c.fingerprintRotations.Add(1)
-	stealth.SanitizeAndApply(req.Header, next)
+	stealth.SanitizeHeaders(req.Header)
 }
 
 // nextStealthProfile returns the profile to rotate to after cur: the next
@@ -1689,6 +1716,10 @@ const (
 	cliSystemMarkerPhrase = "You are Buffy, the strategic coding assistant"
 )
 
+// ensureCliSystemMarker guarantees the canonical "You are Buffy…" opening at
+// byte position 0 of the first system message (the free-mode gate's trimmed
+// prefix test — see the check loop below). It prepends the marker rather
+// than replacing, so custom system instructions survive.
 func ensureCliSystemMarker(payload map[string]any) {
 	rawMsgs, ok := payload["messages"].([]any)
 	if !ok || len(rawMsgs) == 0 {
@@ -1704,13 +1735,18 @@ func ensureCliSystemMarker(payload map[string]any) {
 			continue
 		}
 		if msg["role"] == "system" {
-			if content, ok := msg["content"].(string); ok && strings.Contains(content, cliSystemMarkerPhrase) {
+			// The server gate is a TRIMMED PREFIX test at position 0
+			// (hasFreebuffRootSystemPromptOpening, free-agents.ts:617-645),
+			// hardened against the prepend-and-cancel proxy trick: a message
+			// that merely mentions the phrase mid-string must NOT suppress
+			// the canonical prefix (#110).
+			if content, ok := msg["content"].(string); ok && strings.HasPrefix(strings.TrimSpace(content), cliSystemMarkerPhrase) {
 				return // already present
 			}
 			if parts, ok := msg["content"].([]any); ok {
 				for _, p := range parts {
 					if partMap, ok := p.(map[string]any); ok {
-						if txt, ok := partMap["text"].(string); ok && strings.Contains(txt, cliSystemMarkerPhrase) {
+						if txt, ok := partMap["text"].(string); ok && strings.HasPrefix(strings.TrimSpace(txt), cliSystemMarkerPhrase) {
 							return // already present
 						}
 					}
@@ -1761,30 +1797,28 @@ func injectEnvelope(body []byte, costMode string, opts ChatOptions) ([]byte, err
 
 	ensureCliSystemMarker(payload)
 
-	// client_id is stable PER SESSION INSTANCE (derived from the instance
-	// id) so upstream traces correlate the whole session lifetime — the
-	// hardest identity signal the SDK keys on (issue #52 extension of #80,
-	// which made it stable per run). With no instance id (disabled session)
-	// it falls back to the run id, then to a fresh SDK-faithful draw.
-	// trace_session_id remains per run (minted once by the run manager,
-	// reused across the run's requests; run.ts: previousRun?.traceSessionId
-	// ?? randomUUID, proxy-freebuff lib/runs.js:43-46).
-	clientID := generateClientID()
-	switch {
-	case opts.SessionInstanceID != "":
-		clientID = "sess:" + opts.SessionInstanceID
-	case opts.RunID != "":
-		clientID = "run:" + opts.RunID
-	}
+	// client_id is a FRESH random SDK-faithful draw per chat call — never
+	// the sess:/run:-prefixed shapes the server fingerprints as a proxy
+	// (#103; reference/freebuff run.ts:646
+	// Math.random().toString(36).substring(2,15), cf-worker-signals.ts
+	// ^wf-[a-z0-9]{8}$). trace_session_id remains per run (minted once by
+	// the run manager, reused across the run's requests; run.ts:
+	// previousRun?.traceSessionId ?? randomUUID, proxy-freebuff
+	// lib/runs.js:43-46) and freebuff_instance_id stays per session.
 	metadata := map[string]any{
 		"run_id":    opts.RunID,
-		"client_id": clientID,
+		"client_id": generateClientID(),
 	}
 	if opts.TraceSessionID != "" {
 		metadata["trace_session_id"] = opts.TraceSessionID
 	}
 	if opts.SessionInstanceID != "" {
 		metadata["freebuff_instance_id"] = opts.SessionInstanceID
+	}
+	// llm_step_number is the 1-based per-run agent step, String(n) on the
+	// wire (#113; reference/freebuff run-agent-step.ts:1175-1177).
+	if opts.StepNumber > 0 {
+		metadata["llm_step_number"] = strconv.Itoa(opts.StepNumber)
 	}
 	if costMode != "" {
 		metadata["cost_mode"] = costMode
@@ -2206,6 +2240,21 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return s[:n] + "..."
+}
+
+// truncateRunes truncates s to at most max runes without an ellipsis. The
+// CLI's FINISH errorMessage cap is 5000 chars (truncateString in
+// reference/freebuff/sdk/src/impl/database.ts), applied on the whole
+// payload — a full Go stack trace must not blow the cap.
+func truncateRunes(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max])
 }
 
 // dump writes a debug record to dump/ when enabled.

--- a/internal/upstream/client.go
+++ b/internal/upstream/client.go
@@ -46,8 +46,10 @@ import (
 // Typed error sentinels. Callers use errors.Is against these; the concrete
 // error values wrap an UpstreamError where applicable.
 var (
-	// ErrSessionInvalid: the free session is stale/superseded/expired or a
-	// waiting room / update is required. Refresh the session and retry once.
+	// ErrSessionInvalid: the free session is stale/expired, model-locked, or
+	// an update is required. Refresh the session and retry once. (409
+	// session_superseded is its OWN terminal sentinel, ErrSessionSuperseded
+	// — #119.)
 	ErrSessionInvalid = errors.New("upstream session invalid")
 	// ErrRunInvalid: the agent run is gone. Rotate the run and retry once.
 	ErrRunInvalid = errors.New("upstream run invalid")
@@ -87,8 +89,11 @@ var (
 	// ErrIpCapped: 429 ip_capped — too many DISTINCT users hold an active
 	// free session on the egress IP. Admission-only: existing sessions keep
 	// running and the request succeeds once one of them ends, so unlike
-	// ErrRateLimited it is NOT tied to a quota reset and must never trigger
-	// the Pacific-midnight lock (reference/freebuff freebuff-session.ts).
+	// ErrRateLimited it is NOT tied to a quota reset upstream (reference/
+	// freebuff freebuff-session.ts). The proxy's CooldownIpCapped adds a
+	// bounded re-admission policy (#118): full retryAfter + jitter per hit,
+	// with a per-token daily cap (3rd hit in a rolling window) that locks
+	// until the Pacific-midnight reset.
 	ErrIpCapped = errors.New("upstream ip capped")
 	// ErrSessionLimitReached: 409 session_limit_reached — the ACCOUNT is
 	// over its concurrent-tab budget; this session's row is fine
@@ -98,12 +103,26 @@ var (
 	ErrSessionLimitReached = errors.New("upstream session limit reached")
 	// ErrWaitingRoomRequired: 428 waiting_room_required — the account must
 	// walk the reference pre-session flow (request_ad_chain + get_streak)
-	// before the next session create (issue #94). Retryable with Retry-After
-	// honored, NO token cooldown, and deliberately DISTINCT from
-	// ErrSessionInvalid: the cached session row is not stale, so the
-	// session must NOT be invalidated/refreshed (reference
-	// freebuff2api-optimized codebuff.py:1048-1074).
+	// before the next session create (issue #94). endsTheSession:true per
+	// FREEBUFF_GATE_CODES (the seat is gone mid-chat), so the server drops
+	// the cached session and re-admits once; the WAITING_ROOM_CHAIN gate
+	// stays gated — the flag is recorded by Client.classify and the chain
+	// fires before the next create. Retryable with Retry-After honored, NO
+	// token cooldown, and deliberately DISTINCT from ErrSessionInvalid:
+	// the recovery is re-admit-once, never the invalidate+refresh loop
+	// (reference/freebuff freebuff-session.ts FREEBUFF_GATE_CODES,
+	// send-message.ts handleFreebuffGateError).
 	ErrWaitingRoomRequired = errors.New("upstream waiting room required")
+	// ErrSessionSuperseded: 409 session_superseded — another client/instance
+	// took over the account; this session's row is GONE (endsTheSession:true
+	// per FREEBUFF_GATE_CODES). TERMINAL gate rejection: the server must
+	// NOT auto-reacquire within the same request (auto-takeover risks
+	// ping-pong with the other instance) — it drops the cached row so the
+	// NEXT request re-joins fresh and surfaces 409 session_superseded
+	// (reference/freebuff freebuff-session.ts FREEBUFF_GATE_CODES,
+	// send-message.ts handleFreebuffGateError, use-freebuff-session.ts
+	// nextDelayMs returns null for superseded = stop polling).
+	ErrSessionSuperseded = errors.New("upstream session superseded")
 )
 
 // WaitingRoomError is the concrete value behind ErrWaitingRoom; callers
@@ -149,6 +168,21 @@ func (e *WaitingRoomRequiredError) Error() string {
 }
 
 func (e *WaitingRoomRequiredError) Unwrap() error { return ErrWaitingRoomRequired }
+
+// SessionSupersededError is the concrete value behind ErrSessionSuperseded
+// (#119): a 409 session_superseded gate rejection — another instance took
+// over the account (endsTheSession:true). Terminal: callers surface it as
+// 409 session_superseded and never auto-reacquire in-request.
+type SessionSupersededError struct {
+	Status int
+	Body   string // truncated upstream body
+}
+
+func (e *SessionSupersededError) Error() string {
+	return fmt.Sprintf("upstream %d: %s", e.Status, e.Body)
+}
+
+func (e *SessionSupersededError) Unwrap() error { return ErrSessionSuperseded }
 
 // UpstreamError is a non-recoverable upstream failure surfaced verbatim.
 type UpstreamError struct {
@@ -280,10 +314,12 @@ func (e *CapacityDeferredError) Unwrap() error {
 // IpCappedError is a 429 ip_capped response: too many DISTINCT users already
 // hold an active free session on this egress IP. Admission-only — existing
 // sessions on the IP keep running, and the request succeeds once one of them
-// ends — so unlike RateLimitError it is NOT tied to a quota reset and never
-// falls back to the Pacific-midnight lock. RetryAfter comes from the body's
-// retryAfterMs only (reference/freebuff freebuff-session.ts). Unwrap makes
-// errors.Is(err, ErrIpCapped) work.
+// ends — so unlike RateLimitError it is NOT tied to a quota reset upstream.
+// RetryAfter comes from the body's retryAfterMs only (reference/freebuff
+// freebuff-session.ts). The proxy's CooldownIpCapped applies the bounded
+// re-admission policy (#118): full retryAfter + jitter per hit, with a
+// per-token daily cap that locks until the Pacific-midnight reset.
+// Unwrap makes errors.Is(err, ErrIpCapped) work.
 type IpCappedError struct {
 	ActiveUsersForIP int
 	Limit            float64
@@ -467,7 +503,7 @@ type Client struct {
 	sessionCallTimeout time.Duration
 	requestJitter      time.Duration
 	costMode           string
-	userID             string // optional x-freebuff-acting-user-id (USER_ID; CLI parity)
+	userID             string // optional x-freebuff-acting-user-id (ACTING_USER_ID; see New's doc + client.go acting-user comment: only the token's OWN account id is safe)
 	debugDump          bool
 
 	// transientRetriesLimit is TRANSIENT_RETRIES: the maximum number of
@@ -540,6 +576,20 @@ func (c *Client) TokenKey() string {
 // agent-runs) sends this UA — no browser persona (#108/#109).
 const cliUserAgent = "ai-sdk/openai-compatible/1.0.0/codebuff"
 
+// freebuffCliUA is the ads-API request User-Agent, mirroring the installed
+// official CLI binary the proxy emulates (reference
+// cli/src/hooks/use-gravity-ad.ts getCliAdRequestUserAgent:
+// "Freebuff-CLI/<CODEBUFF_CLI_VERSION>"; 0.0.149 = the vendored binary).
+const freebuffCliUA = "Freebuff-CLI/0.0.149"
+
+// adBrowserUserAgent is the browser-like user agent passed to ad providers
+// for targeting/fraud screening (#124). The CLI ships one per platform and
+// warns that native runtime UAs look bot-like to ad networks
+// (reference common/src/util/ad-user-agent.ts: Chrome 124; use-gravity-ad.ts
+// sends it as the body userAgent). The proxy runs on Windows by default, so
+// the win32 entry is the faithful choice.
+const adBrowserUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+
 // New builds the client for one token.
 func New(token string, cfg *config.Config) (*Client, error) {
 	return NewWithIndex(token, 0, cfg)
@@ -566,7 +616,7 @@ func NewWithIndex(token string, tokenIndex int, cfg *config.Config) (*Client, er
 		sessionCallTimeout:    cfg.SessionCallTimeout,
 		requestJitter:         cfg.RequestJitter,
 		costMode:              cfg.CostMode,
-		userID:                cfg.UserID,
+		userID:                cfg.ActingUserID,
 		debugDump:             cfg.DebugDump,
 		transientRetriesLimit: cfg.TransientRetries,
 		http2Upstream:         cfg.HTTP2Upstream,
@@ -739,9 +789,18 @@ func (c *Client) ChatCompletions(ctx context.Context, opts ChatOptions, body []b
 		// (reference/freebuff model-provider.ts:146-152); the model and
 		// instance id ride only in the body metadata (injectEnvelope).
 		if c.userID != "" {
-			// The official CLI sends the acting user id on every chat call and
-			// the free-mode gate expects it
-			// (reference/proxy-freebuff/server.js:131-134).
+			// The official CLI sends x-freebuff-acting-user-id on every
+			// chat call with the account's OWN id, derived from
+			// GET /api/v1/me (reference/freebuff sdk/src/run.ts:649-658;
+			// sdk/src/impl/model-provider.ts:148-153 — agent-runs
+			// START/FINISH carry it too, database.ts:318-320/396-398).
+			// The server treats it as a trusted server-to-server header
+			// honored only when the request authenticates as the FreeBuff
+			// Web service account (reference/freebuff
+			// common/src/constants/freebuff-models.ts:1180-1183).
+			// ACTING_USER_ID is therefore only safe when it equals the
+			// token's own account id; any other value impersonates a
+			// foreign user (a possible flag).
 			req.Header.Set("x-freebuff-acting-user-id", c.userID)
 		}
 		resp, _, err := c.do(req, 0)
@@ -785,14 +844,19 @@ func (c *Client) ChatCompletions(ctx context.Context, opts ChatOptions, body []b
 	}
 }
 
-// CreateSession POSTs /api/v1/freebuff/session with an empty object.
+// CreateSession POSTs /api/v1/freebuff/session with no body.
 func (c *Client) CreateSession(ctx context.Context) (*SessionState, error) {
 	return c.CreateSessionForModel(ctx, "")
 }
 
-// CreateSessionForModel POSTs /api/v1/freebuff/session with the requested model header.
+// CreateSessionForModel POSTs /api/v1/freebuff/session with the requested
+// model header. The POST carries NO body and therefore no Content-Type
+// (#120): the CLI's session POST is a bare fetch with Authorization + the
+// optional x-freebuff-model header only (reference/freebuff
+// freebuff-session-api.ts callFreebuffSession, codebuff-api.ts sets
+// Content-Type only when body !== undefined).
 func (c *Client) CreateSessionForModel(ctx context.Context, model string) (*SessionState, error) {
-	req, err := c.newRequest(ctx, http.MethodPost, "/api/v1/freebuff/session", []byte("{}"))
+	req, err := c.newRequest(ctx, http.MethodPost, "/api/v1/freebuff/session", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -874,13 +938,16 @@ func (c *Client) ProbeAccount(ctx context.Context) (*SessionState, error) {
 	return state, nil
 }
 
-// EndSession DELETE /api/v1/freebuff/session; 404 is tolerated.
+// EndSession DELETE /api/v1/freebuff/session; 404 is tolerated. The DELETE
+// is keyed on the user, not the instance: the CLI releases its slot with
+// Authorization only, no x-freebuff-instance-id header (#120,
+// reference/freebuff freebuff-session-api.ts releaseFreebuffSlot → DELETE).
+// instanceID is kept for call-site logging; it is never sent.
 func (c *Client) EndSession(ctx context.Context, instanceID string) error {
 	req, err := c.newRequest(ctx, http.MethodDelete, "/api/v1/freebuff/session", nil)
 	if err != nil {
 		return err
 	}
-	req.Header.Set("x-freebuff-instance-id", instanceID)
 
 	resp, cancel, err := c.do(req, c.sessionCallTimeout)
 	if err != nil {
@@ -1231,6 +1298,18 @@ func (c *Client) newRequest(ctx context.Context, method, path string, body []byt
 	if err != nil {
 		return nil, fmt.Errorf("upstream: build %s %s: %w", method, path, err)
 	}
+	// A bodyless POST/PUT/PATCH is trivially replayable on a transient
+	// retry: give it a NoBody GetBody so do()'s TRANSIENT_RETRIES replay
+	// works (a nil GetBody silently disables retries, which after #120
+	// would break the bodyless session POST's transport-level retry). GETs
+	// and DELETEs stay nil-GetBody (never retried — idempotent reads fail
+	// fast and the poll loop's own backoff owns them).
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch:
+		if body == nil {
+			req.GetBody = func() (io.ReadCloser, error) { return http.NoBody, nil }
+		}
+	}
 	req.Header.Set("Authorization", "Bearer "+c.token)
 	if c.authOnly {
 		// Token-less login-flow client (#62/#66): never send an empty
@@ -1238,7 +1317,12 @@ func (c *Client) newRequest(ctx context.Context, method, path string, body []byt
 		// User-Agent instead (see authLoginRequest).
 		req.Header.Del("Authorization")
 	}
-	req.Header.Set("Content-Type", "application/json")
+	// Content-Type only when a body is present (#120): the CLI sets it iff
+	// body !== undefined (reference/freebuff codebuff-api.ts:344-346), so a
+	// bodyless session POST must not carry it. Chat always has a body.
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	// The official CLI sends the pinned llm-providers ai-sdk UA on chat and
 	// NO browser headers on any API path (bare Bun fetch) (#108/#109 fix
 	// option (a)): the utls ClientHello impersonation stays, the browser
@@ -1434,18 +1518,24 @@ func (c *Client) FireWaitingRoomChain(ctx context.Context) {
 // (freebuff2api-optimized config.py: ad_providers=("gravity","zeroclick")).
 var waitingRoomAdProviders = []string{"gravity", "zeroclick"}
 
-// requestAds POSTs one /api/v1/ads payload (reference codebuff.py
-// request_ads: provider + device block + userAgent).
+// requestAds POSTs one /api/v1/ads payload (reference cli/src/hooks/
+// use-gravity-ad.ts fetchAd + common/src/util/ad-user-agent.ts: provider +
+// device block + browser-like body userAgent + Freebuff-CLI header UA).
+// Faithful details kept: messages stays [] and sessionId is omitted (the
+// chain fires before a session exists — a fresh waiting-room).
 func (c *Client) requestAds(ctx context.Context, provider string) error {
 	payload := map[string]any{
 		"provider": provider,
 		"messages": []any{},
 		"device": map[string]any{
 			"os":       runtime.GOOS,
-			"timezone": "UTC",
-			"locale":   "en-US",
+			"timezone": egressDeviceTimezone(),
+			"locale":   egressDeviceLocale(),
 		},
-		"userAgent": freebuffLoginUserAgent,
+		// Body userAgent: the shared browser-like UA (NOT a runtime UA) so
+		// every ad provider sees a usable targeting signal — the CLI sends
+		// getAdUserAgent() here (#124).
+		"userAgent": adBrowserUserAgent,
 		"surface":   "waiting_room",
 	}
 	body, _ := json.Marshal(payload)
@@ -1453,7 +1543,10 @@ func (c *Client) requestAds(ctx context.Context, provider string) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("User-Agent", freebuffLoginUserAgent)
+	// Header UA: Freebuff-CLI/<version> (getCliAdRequestUserAgent), NOT the
+	// chat ai-sdk UA newRequest set — the CLI's ads POST carries exactly
+	// this product UA (#124).
+	req.Header.Set("User-Agent", freebuffCliUA)
 	resp, cancel, err := c.do(req, c.sessionCallTimeout)
 	if err != nil {
 		return err
@@ -1471,13 +1564,55 @@ func (c *Client) requestAds(ctx context.Context, provider string) error {
 	return nil
 }
 
-// getStreak GETs /api/v1/freebuff/streak (reference codebuff.py get_streak).
+// egressDeviceTimezone returns the host IANA timezone name for the ads
+// device block, mirroring the CLI's
+// Intl.DateTimeFormat().resolvedOptions().timeZone (use-gravity-ad.ts
+// getDeviceInfo). time.Local.String() is the host zone when Go resolved a
+// real IANA name; "Local" is Go's placeholder when it could not, so that
+// (and anything LoadLocation rejects) falls back to the always-valid "UTC".
+func egressDeviceTimezone() string {
+	tz := time.Local.String()
+	if tz == "" || tz == "Local" {
+		return "UTC"
+	}
+	if _, err := time.LoadLocation(tz); err != nil {
+		return "UTC"
+	}
+	return tz
+}
+
+// egressDeviceLocale returns the host locale for the ads device block,
+// derived from LC_ALL/LC_MESSAGES/LANG (POSIX "en_US.UTF-8" → "en-US",
+// charset stripped, "_" → "-"), falling back to "en-US" — the CLI's
+// Intl.DateTimeFormat().resolvedOptions().locale shape (use-gravity-ad.ts
+// getDeviceInfo). "C"/"POSIX" are not real locales and are skipped.
+func egressDeviceLocale() string {
+	for _, env := range []string{"LC_ALL", "LC_MESSAGES", "LANG"} {
+		raw := os.Getenv(env)
+		if raw == "" {
+			continue
+		}
+		lang := strings.SplitN(raw, ".", 2)[0]
+		lang = strings.ReplaceAll(lang, "_", "-")
+		if lang == "" || lang == "C" || lang == "POSIX" {
+			continue
+		}
+		return lang
+	}
+	return "en-US"
+}
+
+// getStreak GETs /api/v1/freebuff/streak (reference
+// cli/src/hooks/use-freebuff-streak-query.ts: the request() helper sets NO
+// UA override → bun's default). The proxy's equivalent of "no override" is
+// newRequest's cliUserAgent (ai-sdk 1.0.0), which is what this request
+// inherits — the old 2.0.42 login UA was never a real llm-providers
+// version (#124).
 func (c *Client) getStreak(ctx context.Context) error {
 	req, err := c.newRequest(ctx, http.MethodGet, "/api/v1/freebuff/streak", nil)
 	if err != nil {
 		return err
 	}
-	req.Header.Set("User-Agent", freebuffLoginUserAgent)
 	resp, cancel, err := c.do(req, c.sessionCallTimeout)
 	if err != nil {
 		return err
@@ -1900,9 +2035,10 @@ func classifyError(status int, body string, hdr http.Header) error {
 	case containsAny(lower, "ip_capped"):
 		// 429 ip_capped: too many DISTINCT users on the egress IP.
 		// Admission-only — existing sessions keep running, so unlike
-		// rate_limited this is NOT tied to a quota reset. Bounded cooldown
-		// to retryAfterMs only; no Pacific-midnight fallback
-		// (reference/freebuff freebuff-session.ts).
+		// rate_limited this is NOT tied to a quota reset. Cooldown is
+		// bounded by the proxy to retryAfterMs + jitter, with a per-token
+		// daily re-admission cap (3rd hit in a rolling window locks until
+		// Pacific midnight — #118) (reference/freebuff freebuff-session.ts).
 		return parseIpCapped(body, retryAfter)
 	case containsAny(lower, "waiting_room_queued"):
 		// 429 waiting_room_queued: transient admission race — the session
@@ -1923,7 +2059,18 @@ func classifyError(status int, body string, hdr http.Header) error {
 		// Client.classify wrapper records the flag so the pool can fire the
 		// gated WAITING_ROOM_CHAIN before the next create.
 		return &WaitingRoomRequiredError{RetryAfter: retryAfter, Detail: truncate(body, 200)}
-	case containsAny(lower, "freebuff_update_required", "session_superseded",
+	case containsAny(lower, "session_superseded"):
+		// #119: 409 session_superseded is a TERMINAL gate rejection
+		// (endsTheSession:true — another instance took over the account;
+		// reference/freebuff freebuff-session.ts FREEBUFF_GATE_CODES).
+		// Deliberately NOT ErrSessionInvalid: the server must never
+		// auto-reacquire in-request (auto-takeover risks ping-pong) — it
+		// surfaces 409 session_superseded and lets the NEXT request re-join
+		// fresh (send-message.ts handleFreebuffGateError marks the session
+		// superseded and stops polling; use-freebuff-session.ts
+		// nextDelayMs returns null).
+		return &SessionSupersededError{Status: status, Body: truncate(body, 200)}
+	case containsAny(lower, "freebuff_update_required",
 		"session_expired", "session_model_mismatch", "model_locked"):
 		return fmt.Errorf("%w: %s%s", ErrSessionInvalid, truncate(body, 200), retryDetail(retryAfter))
 	case status == http.StatusBadRequest && containsAny(lower, "runid not found", "runid not running"):
@@ -2029,9 +2176,11 @@ func getTime(m map[string]any, keys ...string) (time.Time, bool) {
 
 // parseIpCapped builds an IpCappedError from a 429 ip_capped body,
 // extracting retryAfterMs/activeUsersForIp/limit best-effort (absent fields
-// are tolerated). The cooldown is bounded to retryAfterMs ONLY — ip_capped
-// is admission-only and not tied to a quota reset, so the Pacific-midnight
-// fallback must never apply (reference/freebuff freebuff-session.ts).
+// are tolerated). The ERROR's retryAfter stays bounded to the body's
+// retryAfterMs (1m default) — ip_capped is admission-only and not a quota
+// reset upstream, so the parse never fabricates a Pacific-midnight window;
+// the proxy's bounded re-admission policy (full retryAfter + jitter, daily
+// cap — #118) is applied by runs.CooldownIpCapped at cooldown time.
 func parseIpCapped(body string, headerRetryAfter time.Duration) error {
 	ice := &IpCappedError{Body: truncate(body, 200), RetryAfter: headerRetryAfter}
 

--- a/internal/upstream/client_test.go
+++ b/internal/upstream/client_test.go
@@ -130,11 +130,13 @@ func TestChatCompletionsEnvelope(t *testing.T) {
 		t.Fatalf("want 1 chat request, got %d / %d", len(headers), len(bodies))
 	}
 	h := headers[0]
-	if got := h.Get("x-freebuff-model"); got != "deepseek/deepseek-v4-flash" {
-		t.Errorf("x-freebuff-model = %q", got)
+	// #106: the chat POST carries NO x-freebuff-model / x-freebuff-instance-id
+	// headers — the model and instance id ride only in the body metadata.
+	if got := h.Get("x-freebuff-model"); got != "" {
+		t.Errorf("x-freebuff-model = %q on the chat POST, want absent (#106)", got)
 	}
-	if got := h.Get("x-freebuff-instance-id"); got != "inst-1" {
-		t.Errorf("x-freebuff-instance-id = %q", got)
+	if got := h.Get("x-freebuff-instance-id"); got != "" {
+		t.Errorf("x-freebuff-instance-id = %q on the chat POST, want absent (#106)", got)
 	}
 	if got := h.Get("Authorization"); got != "Bearer tok-a" {
 		t.Errorf("Authorization = %q", got)
@@ -159,9 +161,11 @@ func TestChatCompletionsEnvelope(t *testing.T) {
 	if md["freebuff_instance_id"] != "inst-1" {
 		t.Errorf("freebuff_instance_id = %v", md["freebuff_instance_id"])
 	}
+	// #103: client_id is a FRESH random draw per chat call — never the
+	// sess:-prefixed shape the server fingerprints as a proxy.
 	clientID, _ := md["client_id"].(string)
-	if clientID != "sess:inst-1" {
-		t.Errorf("client_id = %q, want %q (stable per session instance, derived from instance id — #52)", clientID, "sess:inst-1")
+	if !regexp.MustCompile(`^[a-z0-9]{13}$`).MatchString(clientID) || strings.HasPrefix(clientID, "sess:") {
+		t.Errorf("client_id = %q, want a fresh 13-char base36 draw per chat call (#103)", clientID)
 	}
 	provider, ok := sent["provider"].(map[string]any)
 	if !ok || provider["data_collection"] != "deny" {
@@ -675,15 +679,49 @@ func TestStartAndFinishRun(t *testing.T) {
 		t.Errorf("START not recorded: %v", mock.StartedRuns)
 	}
 
-	if err := client.FinishRun(context.Background(), runID, 4); err != nil {
+	msg1 := "msg-1"
+	steps := []RunStep{
+		{ID: "step-1", StepNumber: 1, MessageID: &msg1, Status: "completed", StartTime: "2026-08-18T00:00:00.000Z"},
+		{ID: "step-2", StepNumber: 2, Status: "completed", StartTime: "2026-08-18T00:00:01.000Z"},
+	}
+	if err := client.FinishRun(context.Background(), runID, "completed", len(steps), steps, ""); err != nil {
 		t.Fatal(err)
 	}
 	if len(mock.FinishedRuns) != 1 {
 		t.Fatalf("FINISH not recorded: %v", mock.FinishedRuns)
 	}
 	f := mock.FinishedRuns[0]
-	if f.RunID != runID || f.Status != "completed" || f.TotalSteps != 4 {
+	if f.RunID != runID || f.Status != "completed" || f.TotalSteps != 2 {
 		t.Errorf("FINISH payload = %+v", f)
+	}
+	// Issue #114: steps ride IN the FINISH payload (the CLI has no /steps
+	// endpoint) with the CLI step shape: id, stepNumber, messageId
+	// (null-able), status, startTime.
+	if len(f.Steps) != 2 || f.Steps[0].StepNumber != 1 || f.Steps[0].MessageID == nil || *f.Steps[0].MessageID != "msg-1" ||
+		f.Steps[1].StepNumber != 2 || f.Steps[1].MessageID != nil || f.Steps[1].StartTime == "" {
+		t.Errorf("FINISH steps = %+v, want 2 CLI-shaped steps", f.Steps)
+	}
+}
+
+func TestFinishRunErrorTruncation(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+
+	client, _ := New("tok", testConfig(mock.URL(), nil))
+
+	// errorMessage must be truncated to 5000 runes (CLI parity:
+	// truncateString(errorMessage, 5000) in database.ts) — a full Go stack
+	// trace must not blow the cap.
+	long := strings.Repeat("エ", 6000)
+	if err := client.FinishRun(context.Background(), "run-0001", "failed", 0, nil, long); err != nil {
+		t.Fatal(err)
+	}
+	finished := mock.FinishedRunsSnapshot()
+	if len(finished) != 1 || finished[0].RunID != "run-0001" || finished[0].Status != "failed" {
+		t.Fatalf("finished runs = %+v, want run-0001 failed", finished)
+	}
+	if got := len([]rune(finished[0].ErrorMessage)); got != 5000 {
+		t.Errorf("errorMessage runes = %d, want 5000 (truncated)", got)
 	}
 }
 
@@ -806,8 +844,8 @@ func TestCrossHostRedirectStripsToken(t *testing.T) {
 		t.Fatal(err)
 	}
 	_ = sameResp.Body.Close()
-	if got := <-sameKey; got != token {
-		t.Errorf("same-host redirect carried x-codebuff-api-key %q, want %q kept", got, token)
+	if got := <-sameKey; got != "" {
+		t.Errorf("same-host request carried x-codebuff-api-key %q, want absent (client no longer sends it, issue #107)", got)
 	}
 }
 
@@ -1231,8 +1269,10 @@ func TestClassifyDeploymentOutsideHoursRetryable(t *testing.T) {
 
 // TestStealthProfileResolvedOncePerRequest verifies that for TLS_FINGERPRINT
 // auto/random the concrete profile is resolved ONCE per request: newRequest
-// stashes it (and applies its headers), and the dialer reads the same stash
-// for the ClientHello — so headers and TLS fingerprint never mismatch.
+// stashes it, and the dialer reads the same stash for the ClientHello — so
+// the TLS fingerprint always matches the resolved profile. The request
+// carries the CLI UA and NO browser headers (#109): header application is
+// inverted — only the utls ClientHello impersonates the browser.
 func TestStealthProfileResolvedOncePerRequest(t *testing.T) {
 	client, err := New("tok-a", testConfig("", func(c *config.Config) { c.TLSFingerprint = "auto" }))
 	if err != nil {
@@ -1249,9 +1289,15 @@ func TestStealthProfileResolvedOncePerRequest(t *testing.T) {
 	if stashed.ID == stealth.ProfileIDAuto || stashed.ID == stealth.ProfileIDRandom {
 		t.Fatalf("stashed profile %s is not concrete (auto must resolve once)", stashed.ID)
 	}
-	// The browser headers were applied from the SAME concrete profile.
-	if got := req.Header.Get("User-Agent"); got != stashed.UserAgent {
-		t.Errorf("request User-Agent %q != stashed profile User-Agent %q", got, stashed.UserAgent)
+	// The request carries the pinned CLI UA, not the profile's browser UA.
+	if got := req.Header.Get("User-Agent"); got != cliUserAgent {
+		t.Errorf("request User-Agent %q != the CLI UA %q (no browser persona on API calls, #109)", got, cliUserAgent)
+	}
+	for _, hdr := range []string{"Sec-Fetch-Site", "Sec-Fetch-Mode", "Sec-Fetch-Dest",
+		"Sec-CH-UA", "Sec-CH-UA-Mobile", "Sec-CH-UA-Platform"} {
+		if got := req.Header.Get(hdr); got != "" {
+			t.Errorf("%s = %q on an upstream API request, want absent (#109)", hdr, got)
+		}
 	}
 	// The dialer must use the stashed profile for this request's dial.
 	if dial := client.dialProfileFor(req.Context()); dial != stashed {
@@ -1388,15 +1434,21 @@ func TestGetSessionWithOptsHeaders(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	st, err := client.GetSessionWithOpts(context.Background(), "inst-1", true, true)
+	st, err := client.GetSessionWithOpts(context.Background(), "inst-1", true)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if st.Status != "active" {
 		t.Errorf("status = %q, want active", st.Status)
 	}
-	if gotCompact != "1" || gotHeartbeat != "1" || gotInstance != "inst-1" {
-		t.Errorf("headers: compact=%q, heartbeat=%q, instance=%q", gotCompact, gotHeartbeat, gotInstance)
+	if gotCompact != "1" || gotInstance != "inst-1" {
+		t.Errorf("headers: compact=%q, instance=%q (want 1 / inst-1)", gotCompact, gotInstance)
+	}
+	// Gap #2: the CLI never beats — x-freebuff-heartbeat is Desktop-only
+	// (reference/freebuff freebuff-models.ts:1212-1215), so a compact poll
+	// must NOT carry it.
+	if gotHeartbeat != "" {
+		t.Errorf("x-freebuff-heartbeat = %q, want absent on compact polls", gotHeartbeat)
 	}
 }
 
@@ -1514,8 +1566,9 @@ func newRetryClient(t *testing.T, baseURL string, retries int, fingerprint strin
 	return client, rt
 }
 
-// TestDumpRedactsTokenHeaders verifies the debug dump redacts both the
-// Authorization header and x-codebuff-api-key (which carries the same token).
+// TestDumpRedactsTokenHeaders verifies the debug dump redacts the
+// Authorization header (the only credential on the wire since #107 dropped
+// x-codebuff-api-key; the redaction list still covers it defensively).
 // Regression: dump() only redacted Authorization, so DEBUG_DUMP=true leaked
 // the plaintext token into dump/ files via x-codebuff-api-key.
 func TestDumpRedactsTokenHeaders(t *testing.T) {
@@ -1555,8 +1608,11 @@ func TestDumpRedactsTokenHeaders(t *testing.T) {
 	if !strings.Contains(dump, "Authorization: [redacted]") {
 		t.Errorf("dump file missing redacted Authorization header:\n%s", dump)
 	}
-	if !strings.Contains(dump, "X-Codebuff-Api-Key: [redacted]") {
-		t.Errorf("dump file missing redacted X-Codebuff-Api-Key header:\n%s", dump)
+	// #107: x-codebuff-api-key is no longer sent, so it must not appear in
+	// the dump at all (the defensive redaction list stays for any future
+	// setter).
+	if strings.Contains(strings.ToLower(dump), "x-codebuff-api-key") {
+		t.Errorf("dump file contains an x-codebuff-api-key header line (never sent now):\n%s", dump)
 	}
 }
 
@@ -1744,26 +1800,23 @@ func TestRetryRotatesPinnedFingerprint(t *testing.T) {
 	if id != stealth.ProfileIDSafari18 {
 		t.Errorf("stealthProfile = %s, want safari18 (chrome126 rotated to a distinct JA3)", id)
 	}
-	// The retried request carried the rotated profile's browser headers:
-	// the first attempt used chrome126, the retry re-applied safari18.
+	// Headers stay CLI-shaped across the retry (#109): the fingerprint
+	// rotates at the TLS layer only; no browser persona ever touches the API
+	// request, so there are no Sec-CH-UA/Sec-Fetch-* headers to carry over.
 	if rt.calls.Load() != 2 {
 		t.Fatalf("upstream attempts = %d, want 2", rt.calls.Load())
 	}
-	if got := rt.seenHeaders[0].Get("User-Agent"); got != stealth.ProfileChrome126.UserAgent {
-		t.Errorf("attempt 1 User-Agent = %q, want chrome126", got)
+	for i, wantAttempt := range []string{"attempt 1", "attempt 2 (rotated)"} {
+		if got := rt.seenHeaders[i].Get("User-Agent"); got != cliUserAgent {
+			t.Errorf("%s User-Agent = %q, want the CLI UA %q", wantAttempt, got, cliUserAgent)
+		}
 	}
-	if got := rt.seenHeaders[1].Get("User-Agent"); got != stealth.ProfileSafari18.UserAgent {
-		t.Errorf("attempt 2 User-Agent = %q, want safari18 (rotated)", got)
-	}
-	// The retry rotated to Safari18, which has no Client Hints: the Chromium
-	// Sec-CH-UA* headers from attempt 1 must be GONE, not carried onto a
-	// Safari TLS fingerprint.
-	if got := rt.seenHeaders[0].Get("Sec-CH-UA"); got == "" {
-		t.Error("attempt 1 Sec-CH-UA empty, want chrome126 client hints")
-	}
-	for _, hdr := range []string{"Sec-CH-UA", "Sec-CH-UA-Mobile", "Sec-CH-UA-Platform"} {
-		if got := rt.seenHeaders[1].Get(hdr); got != "" {
-			t.Errorf("attempt 2 %s = %q, want deleted (Safari18 has no Client Hints)", hdr, got)
+	for _, hdr := range []string{"Sec-CH-UA", "Sec-CH-UA-Mobile", "Sec-CH-UA-Platform",
+		"Sec-Fetch-Site", "Sec-Fetch-Mode", "Sec-Fetch-Dest"} {
+		for i := 0; i < 2; i++ {
+			if got := rt.seenHeaders[i].Get(hdr); got != "" {
+				t.Errorf("attempt %d %s = %q, want absent (no browser headers on API calls, #109)", i+1, hdr, got)
+			}
 		}
 	}
 }
@@ -2195,6 +2248,44 @@ func TestEnsureCliSystemMarkerBranches(t *testing.T) {
 		}
 	})
 
+	t.Run("phrase mid-string in string prepends marker", func(t *testing.T) {
+		// #110: the server gate is a TRIMMED PREFIX test at position 0 — a
+		// system message that merely mentions the phrase mid-string must NOT
+		// suppress the canonical prefix.
+		content := "Please act as " + cliSystemMarkerPhrase + " and be concise."
+		p := map[string]any{"messages": []any{
+			map[string]any{"role": "system", "content": content},
+			map[string]any{"role": "user", "content": "hi"},
+		}}
+		ensureCliSystemMarker(p)
+		msgs := p["messages"].([]any)
+		if len(msgs) != 2 {
+			t.Fatalf("messages = %v, want length 2", msgs)
+		}
+		got := msgs[0].(map[string]any)["content"].(string)
+		if !strings.HasPrefix(got, cliSystemMarker+"\n\n") || !strings.Contains(got, content) {
+			t.Errorf("system content = %q, want marker prepended to the mid-string mention", got)
+		}
+	})
+
+	t.Run("phrase mid-string in structured part prepends marker", func(t *testing.T) {
+		parts := []any{
+			map[string]any{"type": "text", "text": "Remember: " + cliSystemMarkerPhrase + "."},
+		}
+		p := map[string]any{"messages": []any{
+			map[string]any{"role": "system", "content": parts},
+		}}
+		ensureCliSystemMarker(p)
+		msgs := p["messages"].([]any)
+		gotParts, ok := msgs[0].(map[string]any)["content"].([]any)
+		if !ok || len(gotParts) != 2 {
+			t.Fatalf("system parts = %v, want 2 with marker prepended", msgs[0])
+		}
+		if gotParts[0].(map[string]any)["text"] != cliSystemMarker {
+			t.Errorf("marker part = %v, want the CLI marker first", gotParts[0])
+		}
+	})
+
 	t.Run("structured system content array prepends marker", func(t *testing.T) {
 		originalParts := []any{
 			map[string]any{"type": "text", "text": "custom instructions"},
@@ -2452,8 +2543,8 @@ func TestRedirectMultihop(t *testing.T) {
 		if got := <-bKeySeen; got != "" {
 			t.Errorf("intermediate host B received token %q, want stripped", got)
 		}
-		if got := <-aKeySeen; got != token {
-			t.Errorf("loop-back hop to A carried %q, want %q kept", got, token)
+		if got := <-aKeySeen; got != "" {
+			t.Errorf("loop-back hop to A carried %q, want absent (client no longer sends x-codebuff-api-key, issue #107)", got)
 		}
 	})
 
@@ -2894,11 +2985,13 @@ func TestFullChatLifecycleChained(t *testing.T) {
 	if len(mock.RecordedChatHeaders) != 1 {
 		t.Fatalf("recorded chat headers = %d, want 1", len(mock.RecordedChatHeaders))
 	}
-	if got := mock.RecordedChatHeaders[0].Get("x-freebuff-instance-id"); got != st.InstanceID {
-		t.Errorf("chat x-freebuff-instance-id = %q, want %q", got, st.InstanceID)
+	// #106: the chat POST carries no instance/model headers — they ride in
+	// the body metadata only.
+	if got := mock.RecordedChatHeaders[0].Get("x-freebuff-instance-id"); got != "" {
+		t.Errorf("chat x-freebuff-instance-id = %q, want absent (#106)", got)
 	}
-	if got := mock.RecordedChatHeaders[0].Get("x-freebuff-model"); got != "m" {
-		t.Errorf("chat x-freebuff-model = %q, want m", got)
+	if got := mock.RecordedChatHeaders[0].Get("x-freebuff-model"); got != "" {
+		t.Errorf("chat x-freebuff-model = %q, want absent (#106)", got)
 	}
 	if !mock.BodyContains(`"freebuff_instance_id":"` + st.InstanceID + `"`) {
 		t.Error("chat body missing freebuff_instance_id in codebuff_metadata")
@@ -2907,7 +3000,7 @@ func TestFullChatLifecycleChained(t *testing.T) {
 		t.Error("chat body missing run_id in codebuff_metadata")
 	}
 
-	if err := client.FinishRun(ctx, runID, 3); err != nil {
+	if err := client.FinishRun(ctx, runID, "completed", 3, nil, ""); err != nil {
 		t.Fatalf("FinishRun: %v", err)
 	}
 	if err := client.EndSession(ctx, st.InstanceID); err != nil {
@@ -2926,9 +3019,9 @@ func TestFullChatLifecycleChained(t *testing.T) {
 	}
 }
 
-// TestCompactHeartbeatAbsentTolerant is E2E flow 8: a compact heartbeat poll
-// without quota/offer fields parses cleanly with nil maps.
-func TestCompactHeartbeatAbsentTolerant(t *testing.T) {
+// TestCompactPollAbsentTolerant is E2E flow 8: a compact poll without quota/
+// offer fields parses cleanly with nil maps, and carries no heartbeat header.
+func TestCompactPollAbsentTolerant(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	gotCompact := make(chan string, 1)
@@ -2944,9 +3037,9 @@ func TestCompactHeartbeatAbsentTolerant(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	st, err := client.GetSessionWithOpts(context.Background(), "inst-1", true, true)
+	st, err := client.GetSessionWithOpts(context.Background(), "inst-1", true)
 	if err != nil {
-		t.Fatalf("compact heartbeat poll: %v", err)
+		t.Fatalf("compact poll: %v", err)
 	}
 	if st.Status != "active" || st.InstanceID != "inst-1" {
 		t.Errorf("state = %+v, want active inst-1", st)
@@ -2960,8 +3053,8 @@ func TestCompactHeartbeatAbsentTolerant(t *testing.T) {
 	if got := <-gotCompact; got != "1" {
 		t.Errorf("compact header = %q, want 1", got)
 	}
-	if got := <-gotHeartbeat; got != "1" {
-		t.Errorf("heartbeat header = %q, want 1", got)
+	if got := <-gotHeartbeat; got != "" {
+		t.Errorf("heartbeat header = %q, want absent (CLI never beats)", got)
 	}
 }
 
@@ -3006,6 +3099,9 @@ func TestChatCompletionsRetriesCapacityDeferredSameSession(t *testing.T) {
 		mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
 			if calls.Add(1) == 1 {
 				w.Header().Set("Content-Type", "application/json")
+				// #105: a short retry-after — the client must sleep it (floor
+				// 10s) before re-POSTing, not retry immediately.
+				w.Header().Set("Retry-After", "1")
 				w.WriteHeader(http.StatusTooManyRequests)
 				_, _ = io.WriteString(w, deferred)
 				return
@@ -3018,11 +3114,16 @@ func TestChatCompletionsRetriesCapacityDeferredSameSession(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		start := time.Now()
 		rc, err := client.ChatCompletions(context.Background(), ChatOptions{Model: "m", RunID: "r", SessionInstanceID: "inst-1"}, body)
 		if err != nil {
 			t.Fatalf("ChatCompletions after capacity-deferred retry: %v", err)
 		}
 		_ = rc.Close()
+		// The retry-after (1s) must have been honored before the retry POST.
+		if elapsed := time.Since(start); elapsed < 900*time.Millisecond {
+			t.Errorf("capacity-deferred retry elapsed %v, want >= the 1s Retry-After sleep (#105)", elapsed)
+		}
 
 		if got := calls.Load(); got != 2 {
 			t.Errorf("upstream chat calls = %d, want 2 (original + same-session retry)", got)
@@ -3033,9 +3134,13 @@ func TestChatCompletionsRetriesCapacityDeferredSameSession(t *testing.T) {
 		if len(mock.RecordedChatHeaders) != 2 {
 			t.Fatalf("recorded %d chat requests, want 2", len(mock.RecordedChatHeaders))
 		}
-		// Same session on the retry: instance id header identical.
-		if got := mock.RecordedChatHeaders[1].Get("x-freebuff-instance-id"); got != "inst-1" {
-			t.Errorf("retry x-freebuff-instance-id = %q, want inst-1 (same session)", got)
+		// Same session on the retry: the instance id rides in the body
+		// metadata, not the chat headers (#106).
+		if got := mock.RecordedChatHeaders[1].Get("x-freebuff-instance-id"); got != "" {
+			t.Errorf("retry x-freebuff-instance-id = %q, want absent (chat headers carry no instance id)", got)
+		}
+		if !strings.Contains(mock.RecordedChatBodies[0], `"freebuff_instance_id":"inst-1"`) {
+			t.Error("chat body missing freebuff_instance_id in codebuff_metadata")
 		}
 		if mock.RecordedChatBodies[0] != mock.RecordedChatBodies[1] {
 			t.Error("retried body differs from original (must be byte-identical)")
@@ -3049,6 +3154,7 @@ func TestChatCompletionsRetriesCapacityDeferredSameSession(t *testing.T) {
 		mock2.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
 			calls2.Add(1)
 			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Retry-After", "1")
 			w.WriteHeader(http.StatusTooManyRequests)
 			_, _ = io.WriteString(w, deferred)
 		}
@@ -3109,6 +3215,7 @@ func TestChatCompletionsRetriesCapacityDeferredSameSession(t *testing.T) {
 		mock4.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
 			if calls4.Add(1)%2 == 1 { // first call of each request: deferred
 				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Retry-After", "1")
 				w.WriteHeader(http.StatusTooManyRequests)
 				_, _ = io.WriteString(w, deferred)
 				return
@@ -3233,10 +3340,11 @@ func TestChatSendsActingUserID(t *testing.T) {
 	})
 }
 
-// TestInjectEnvelopeTraceSessionIDAndStableClientID verifies #80: the
-// envelope injects trace_session_id when carried by ChatOptions and derives
-// client_id stably from the run id (never a fresh per-request draw).
-func TestInjectEnvelopeTraceSessionIDAndStableClientID(t *testing.T) {
+// TestInjectEnvelopeTraceSessionIDAndFreshClientID verifies #80+#103: the
+// envelope injects trace_session_id when carried by ChatOptions (stable per
+// run) while client_id is a FRESH random draw per call (never derived from
+// the run id).
+func TestInjectEnvelopeTraceSessionIDAndFreshClientID(t *testing.T) {
 	out, err := injectEnvelope([]byte(`{"model":"m"}`), "free", ChatOptions{RunID: "run-1", TraceSessionID: "trace-abc"})
 	if err != nil {
 		t.Fatal(err)
@@ -3249,18 +3357,18 @@ func TestInjectEnvelopeTraceSessionIDAndStableClientID(t *testing.T) {
 	if md["trace_session_id"] != "trace-abc" {
 		t.Errorf("trace_session_id = %v, want trace-abc", md["trace_session_id"])
 	}
-	if md["client_id"] != "run:run-1" {
-		t.Errorf("client_id = %v, want run:run-1 (stable per run)", md["client_id"])
+	if id, _ := md["client_id"].(string); !regexp.MustCompile(`^[a-z0-9]{13}$`).MatchString(id) || strings.HasPrefix(id, "run:") {
+		t.Errorf("client_id = %v, want a fresh unprefixed 13-char base36 draw (#103)", md["client_id"])
 	}
-	// Re-injecting the same run yields the same client_id across requests.
+	// Re-injecting the same run yields a DIFFERENT client_id across calls.
 	out2, err := injectEnvelope([]byte(`{"model":"m"}`), "free", ChatOptions{RunID: "run-1"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	var sent2 map[string]any
 	_ = json.Unmarshal(out2, &sent2)
-	if md2 := sent2["codebuff_metadata"].(map[string]any); md2["client_id"] != "run:run-1" {
-		t.Errorf("client_id = %v, want stable run:run-1 across requests", md2["client_id"])
+	if md2 := sent2["codebuff_metadata"].(map[string]any); md2["client_id"] == md["client_id"] {
+		t.Errorf("client_id = %v, want a fresh draw per request (same run)", md2["client_id"])
 	}
 	// Without a run id the SDK-faithful 13-char base36 draw is kept.
 	out3, err := injectEnvelope([]byte(`{"model":"m"}`), "free", ChatOptions{})

--- a/internal/upstream/client_test.go
+++ b/internal/upstream/client_test.go
@@ -3072,8 +3072,9 @@ func TestClassifyCapacityDeferred(t *testing.T) {
 	if !errors.Is(err, ErrCapacityDeferred) {
 		t.Errorf("err = %v, want ErrCapacityDeferred", err)
 	}
-	// Unwraps to a Retryable UpstreamError so generic server paths surface
-	// 503 upstream_retryable once the client-side budget is exhausted.
+	// Unwraps to a Retryable UpstreamError (errors.As finds it), but
+	// writeError surfaces 429 free_mode_capacity_deferred + Retry-After
+	// via its dedicated CapacityDeferredError branch (#105).
 	var ue *UpstreamError
 	if !errors.As(err, &ue) || !ue.Retryable {
 		t.Errorf("err = %v, want unwrap to Retryable UpstreamError", err)

--- a/internal/upstream/client_test.go
+++ b/internal/upstream/client_test.go
@@ -267,7 +267,7 @@ func TestErrorClassification(t *testing.T) {
 	}{
 		{"run invalid", 400, `{"error":"runId not found"}`, ErrRunInvalid},
 		{"run not running", 400, `{"error":"runId not running"}`, ErrRunInvalid},
-		{"session superseded", 400, `{"error":"session_superseded"}`, ErrSessionInvalid},
+		{"session superseded", 400, `{"error":"session_superseded"}`, ErrSessionSuperseded},
 		{"session expired", 400, `{"error":"session_expired"}`, ErrSessionInvalid},
 		{"update required", 400, `{"error":"freebuff_update_required"}`, ErrSessionInvalid},
 		{"auth", 401, `{"error":"unauthorized"}`, ErrAuthRejected},
@@ -1533,8 +1533,11 @@ type flakyRT struct {
 
 func (f *flakyRT) RoundTrip(req *http.Request) (*http.Response, error) {
 	f.calls.Add(1)
-	b, _ := io.ReadAll(req.Body)
-	_ = req.Body.Close()
+	var b []byte
+	if req.Body != nil {
+		b, _ = io.ReadAll(req.Body)
+		_ = req.Body.Close()
+	}
 	f.seen = append(f.seen, b)
 	f.seenHeaders = append(f.seenHeaders, req.Header.Clone())
 	if int(f.calls.Load()) <= f.failN {
@@ -3300,16 +3303,17 @@ func TestClassifySessionLimitReached(t *testing.T) {
 	}
 }
 
-// TestChatSendsActingUserID verifies #79: when USER_ID is configured the
-// client sends x-freebuff-acting-user-id on the chat path (CLI parity);
-// when unset the header is omitted.
+// TestChatSendsActingUserID verifies #79: when ACTING_USER_ID is configured
+// the client sends x-freebuff-acting-user-id on the chat path (the CLI
+// sends the account's own id derived from /api/v1/me); when unset the
+// header is omitted.
 func TestChatSendsActingUserID(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	mock.ChatBody = testutil.SSEEvent(`{"id":"x","object":"chat.completion.chunk","choices":[]}`)
 
 	t.Run("set", func(t *testing.T) {
-		client, err := New("tok-a", testConfig(mock.URL(), func(c *config.Config) { c.UserID = "user-123" }))
+		client, err := New("tok-a", testConfig(mock.URL(), func(c *config.Config) { c.ActingUserID = "user-123" }))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3339,6 +3343,89 @@ func TestChatSendsActingUserID(t *testing.T) {
 			t.Errorf("x-freebuff-acting-user-id = %q, want unset", got)
 		}
 	})
+}
+
+// TestWaitingRoomChainWireFidelity verifies #124: the pre-session ad chain
+// matches the CLI wire shape — header UA Freebuff-CLI/0.0.149 (never the
+// old 2.0.42 login UA), body userAgent = the Chrome-124 browser UA,
+// device carries the host IANA timezone/locale, messages stays [] with no
+// sessionId (fresh waiting-room), and the streak GET inherits newRequest's
+// cliUserAgent (no UA override).
+func TestWaitingRoomChainWireFidelity(t *testing.T) {
+	var mu sync.Mutex
+	var adsHeaders, streakHeaders http.Header
+	var adsBody map[string]any
+	adsHits, streakHits := 0, 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch {
+		case r.URL.Path == "/api/v1/ads" && r.Method == http.MethodPost:
+			adsHits++
+			adsHeaders = r.Header.Clone()
+			_ = json.NewDecoder(r.Body).Decode(&adsBody)
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"ads":[],"provider":"gravity"}`)
+		case r.URL.Path == "/api/v1/freebuff/streak" && r.Method == http.MethodGet:
+			streakHits++
+			streakHeaders = r.Header.Clone()
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	client, err := New("tok-a", testConfig(ts.URL, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.FireWaitingRoomChain(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+	if adsHits == 0 {
+		t.Fatal("ads request not fired")
+	}
+	if streakHits == 0 {
+		t.Fatal("streak request not fired")
+	}
+	// Header UA: Freebuff-CLI/<installed binary version>.
+	if got := adsHeaders.Get("User-Agent"); got != freebuffCliUA {
+		t.Errorf("ads header User-Agent = %q, want %q", got, freebuffCliUA)
+	}
+	// Body userAgent: the shared Chrome-124 browser UA (ad targeting).
+	if got := adsBody["userAgent"]; got != adBrowserUserAgent {
+		t.Errorf("ads body userAgent = %q, want %q", got, adBrowserUserAgent)
+	}
+	// Device block: host-derived IANA tz/locale, not hardcoded UTC/en-US.
+	device, ok := adsBody["device"].(map[string]any)
+	if !ok {
+		t.Fatalf("ads body device = %T, want object", adsBody["device"])
+	}
+	tz, _ := device["timezone"].(string)
+	if tz == "" || tz == "Local" {
+		t.Errorf("ads device timezone = %q, want host IANA name or UTC", tz)
+	} else if _, err := time.LoadLocation(tz); err != nil {
+		t.Errorf("ads device timezone %q is not a valid IANA zone", tz)
+	}
+	loc, _ := device["locale"].(string)
+	if loc == "" || loc == "C" || loc == "POSIX" || strings.Contains(loc, "_") {
+		t.Errorf("ads device locale = %q, want a BCP-47-style locale (e.g. en-US)", loc)
+	}
+	// Faithful details kept: empty messages and NO sessionId (the chain
+	// fires before a session exists).
+	if msgs, _ := adsBody["messages"].([]any); len(msgs) != 0 {
+		t.Errorf("ads body messages = %v, want []", msgs)
+	}
+	if _, hasSession := adsBody["sessionId"]; hasSession {
+		t.Error("ads body carries sessionId, want omitted (fresh waiting-room)")
+	}
+	// Streak GET: no UA override — it inherits newRequest's cliUserAgent.
+	if got := streakHeaders.Get("User-Agent"); got != cliUserAgent {
+		t.Errorf("streak User-Agent = %q, want %q (cliUserAgent, no override)", got, cliUserAgent)
+	}
 }
 
 // TestInjectEnvelopeTraceSessionIDAndFreshClientID verifies #80+#103: the


### PR DESCRIPTION
Ships all anti-ban gaps from the CLI RE study: 13 P1s (#103-#115, commits 7baa076+be8c8fc) + 11 P2s (#116-#126, commit 652e135). go build, go vet, full go test ./... green (hermetic). Research grounded in the vendored official FreeBuff CLI (reference/freebuff == installed binary 0.0.149, verified byte-identical vs github.com/CodebuffAI/freebuff).

**P1 — wire identity (7baa076, be8c8fc):**
- #103 fresh random client_id per chat call (no sess:/run: prefixes)
- #104 heartbeat removed; plain jittered ~30s±20% compact GET polls (20s→300s backoff honoring Retry-After)
- #105 free_mode_capacity_deferred: client sleeps retry-after (floor 10s); server surfaces 429 + Retry-After (10s default)
- #106 chat POSTs: no x-freebuff-model / x-freebuff-instance-id headers
- #107 Bearer-only auth (x-codebuff-api-key dropped)
- #108/#109 UA pinned ai-sdk/openai-compatible/1.0.0/codebuff; no browser header persona on API paths (utls TLS impersonation kept)
- #110 system-prompt marker: trimmed prefix test at position 0
- #111/#112 plain reasoning_effort (no DeepSeek thinking block); 08/13 ladders; medium→high on DeepSeek
- #113 llm_step_number (1-based per-run) in codebuff_metadata
- #114 FINISH carries steps[] + honest status + errorMessage≤5000; phantom /steps removed
- #115 30-min grace fast path; DELETE on exit even when persisting

**P2 — session/wire/egress (652e135):**
- #116 428 waiting_room_required ends session (invalidate+reacquire once); 503 + Retry-After, never 502
- #117 402 never retried
- #118 ip_capped: full retryAfter ±20% jitter, 3/day cap until Pacific midnight
- #119 session_superseded terminal (no in-request auto-reacquire); 409
- #120 session POST bodyless (no Content-Type); DELETE Bearer-only
- #121 registry fallback pruned 5 dead model ids
- #122 spend ledger daily bucket at Pacific midnight (DST-aware); production feeder wired
- #123 egress probe gated to on-demand (doctor), no background fixed loop
- #124 ads chain: Freebuff-CLI/0.0.149 header UA, Chrome-124 body UA, host tz/locale
- #125 login poll 5s, keeps polling on 5xx/transport, UA 1.0.0
- #126 USER_ID → ACTING_USER_ID (legacy alias kept), ban-risk documented

All 24 issues (#103-#126) closed.