### PR TITLE
fix(registry): prune retired fallback model ids

### DIFF
--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -24,13 +24,13 @@ import (
 // Test models must map to agents with EXCLUSIVE ownership in the registry
 // FALLBACK map (see internal/registry/registry_test.go expectedFallback):
 // the five base2-free models are first-seen-assigned to the generic
-// base2-free agent, while glm-5.2 and laguna-s-2.1 are owned by their
+// base2-free agent, while glm-5.2 and claude-fable-5 are owned by their
 // dedicated one-model agents. Tests pin the offline (fallback) state.
 const (
 	modelA = "z-ai/glm-5.2"
-	modelB = "poolside/laguna-s-2.1"
+	modelB = "anthropic/claude-fable-5"
 	agentA = "base2-free-glm"
-	agentB = "base2-free-laguna-s-2-1"
+	agentB = "base2-free-fable"
 )
 
 // newTestPool wires one mock upstream per token through real clients and

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -73,10 +73,14 @@ var LimitedTierModels = map[string]bool{
 }
 
 // fallbackAgents is the hardcoded model→agent fallback used when the sources
-// are unreachable. Ported verbatim from registry.js (lines 14-41), entry
-// order preserved: first-seen assignment decides which agent owns models that
-// appear in several entries (e.g. the gemini helpers all list the same two
-// models; file-picker-max comes first).
+// are unreachable. Based on registry.js (lines 14-41) with the rows upstream
+// retired from FREE_MODE_AGENT_MODELS pruned (laguna-s-2.1, ling-3.0-flash,
+// greg-2-ultra, greg-2-super): advertising dead model ids in the offline
+// fallback surfaces them via /v1/models and trips upstream
+// 403 free_mode_invalid_agent_model. Entry order preserved: first-seen
+// assignment decides which agent owns models that appear in several entries
+// (e.g. the gemini helpers all list the same two models; file-picker-max
+// comes first).
 var fallbackAgents = []agentModels{
 	{agent: "base2-free", models: []string{
 		"deepseek/deepseek-v4-pro",
@@ -91,11 +95,6 @@ var fallbackAgents = []agentModels{
 	{agent: "base2-free-deepseek-flash", models: []string{"deepseek/deepseek-v4-flash"}},
 	{agent: "base2-free-mimo", models: []string{"mimo/mimo-v2.5"}},
 	{agent: "base2-free-glm", models: []string{"z-ai/glm-5.2"}},
-	{agent: "base2-free-laguna-s-2-1", models: []string{"poolside/laguna-s-2.1"}},
-	{agent: "base2-free-laguna-s-2-1-openrouter", models: []string{"openrouter/poolside/laguna-s-2.1"}},
-	{agent: "base2-free-ling-3-flash", models: []string{"inclusionai/ling-3.0-flash:free"}},
-	{agent: "base2-free-greg-2-ultra", models: []string{"crof/greg-2-ultra"}},
-	{agent: "base2-free-greg-2-super", models: []string{"crof/greg-2-super"}},
 	{agent: "base2-free-fable", models: []string{"anthropic/claude-fable-5"}},
 	{agent: "file-picker", models: []string{"google/gemini-2.5-flash-lite"}},
 	{agent: "file-picker-max", models: []string{"google/gemini-3.1-flash-lite", "google/gemini-3.5-flash-lite"}},

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -28,27 +28,23 @@ func fileSource(t *testing.T, path string) string {
 	return "file:///" + filepath.ToSlash(abs)
 }
 
-// expectedFallback is the model→agent map the JS fallback table (lines
-// 14-41) must produce: first-seen assignment in entry order, so the five
-// base2-free models belong to base2-free (not their dedicated one-model
-// agents), and the gemini helper models belong to file-picker / file-picker-max
-// (which precede file-lister / researcher-* / basher).
+// expectedFallback is the model→agent map the pruned fallback table (based
+// on registry.js lines 14-41, minus the rows upstream retired from
+// FREE_MODE_AGENT_MODELS) must produce: first-seen assignment in entry order,
+// so the five base2-free models belong to base2-free (not their dedicated
+// one-model agents), and the gemini helper models belong to file-picker /
+// file-picker-max (which precede file-lister / researcher-* / basher).
 var expectedFallback = map[string]string{
-	"deepseek/deepseek-v4-pro":         "base2-free",
-	"deepseek/deepseek-v4-flash":       "base2-free",
-	"minimax/minimax-m3":               "base2-free",
-	"openai/gpt-5.6-luna":              "base2-free",
-	"mimo/mimo-v2.5":                   "base2-free",
-	"z-ai/glm-5.2":                     "base2-free-glm",
-	"poolside/laguna-s-2.1":            "base2-free-laguna-s-2-1",
-	"openrouter/poolside/laguna-s-2.1": "base2-free-laguna-s-2-1-openrouter",
-	"inclusionai/ling-3.0-flash:free":  "base2-free-ling-3-flash",
-	"crof/greg-2-ultra":                "base2-free-greg-2-ultra",
-	"crof/greg-2-super":                "base2-free-greg-2-super",
-	"anthropic/claude-fable-5":         "base2-free-fable",
-	"google/gemini-2.5-flash-lite":     "file-picker",
-	"google/gemini-3.1-flash-lite":     "file-picker-max",
-	"google/gemini-3.5-flash-lite":     "file-picker-max",
+	"deepseek/deepseek-v4-pro":     "base2-free",
+	"deepseek/deepseek-v4-flash":   "base2-free",
+	"minimax/minimax-m3":           "base2-free",
+	"openai/gpt-5.6-luna":          "base2-free",
+	"mimo/mimo-v2.5":               "base2-free",
+	"z-ai/glm-5.2":                 "base2-free-glm",
+	"anthropic/claude-fable-5":     "base2-free-fable",
+	"google/gemini-2.5-flash-lite": "file-picker",
+	"google/gemini-3.1-flash-lite": "file-picker-max",
+	"google/gemini-3.5-flash-lite": "file-picker-max",
 }
 
 func TestFallbackMap(t *testing.T) {
@@ -96,6 +92,42 @@ func TestFallbackMap(t *testing.T) {
 
 	if _, err := r.AgentForModel("does/not-exist"); !errors.Is(err, ErrModelNotFound) {
 		t.Errorf("unknown model err = %v, want ErrModelNotFound", err)
+	}
+}
+
+// TestFallbackPrunesRetiredModels guards issue #121: the offline fallback
+// must not advertise model ids upstream retired from FREE_MODE_AGENT_MODELS.
+// Advertising them surfaces dead ids via /v1/models and trips upstream
+// 403 free_mode_invalid_agent_model.
+func TestFallbackPrunesRetiredModels(t *testing.T) {
+	r := New(nil, nil)
+	r.LoadFallback()
+
+	tests := []struct {
+		model string
+		agent string
+	}{
+		{model: "poolside/laguna-s-2.1", agent: "base2-free-laguna-s-2-1"},
+		{model: "openrouter/poolside/laguna-s-2.1", agent: "base2-free-laguna-s-2-1-openrouter"},
+		{model: "inclusionai/ling-3.0-flash:free", agent: "base2-free-ling-3-flash"},
+		{model: "crof/greg-2-ultra", agent: "base2-free-greg-2-ultra"},
+		{model: "crof/greg-2-super", agent: "base2-free-greg-2-super"},
+	}
+
+	models := r.Models()
+	agentIDs := r.AgentIDs()
+	for _, tc := range tests {
+		t.Run(tc.model, func(t *testing.T) {
+			if _, err := r.AgentForModel(tc.model); !errors.Is(err, ErrModelNotFound) {
+				t.Errorf("AgentForModel(%q) err = %v, want ErrModelNotFound", tc.model, err)
+			}
+			if contains(models, tc.model) {
+				t.Errorf("Models() still advertises retired model %q", tc.model)
+			}
+			if contains(agentIDs, tc.agent) {
+				t.Errorf("AgentIDs() still lists retired agent %q", tc.agent)
+			}
+		})
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -603,8 +603,12 @@ func TestModelsEndpoint(t *testing.T) {
 	if out.Object != "list" {
 		t.Errorf("object = %q, want list", out.Object)
 	}
-	if len(out.Data) < 15 {
-		t.Errorf("models = %d, want >= 15", len(out.Data))
+	// Floor matches the pruned offline fallback table (10 models after the
+	// upstream-retired rows were dropped, see internal/registry
+	// expectedFallback): guards against the endpoint serving an empty
+	// registry, not against future upstream additions.
+	if len(out.Data) < 10 {
+		t.Errorf("models = %d, want >= 10", len(out.Data))
 	}
 	for i, m := range out.Data {
 		if m.ID == "" || m.Object != "model" || m.OwnedBy == "" {
@@ -649,8 +653,10 @@ func TestHealthz(t *testing.T) {
 	if out.UptimeSeconds < 0 {
 		t.Errorf("uptime_seconds = %v, want >= 0", out.UptimeSeconds)
 	}
-	if out.Models < 15 {
-		t.Errorf("models = %d, want >= 15", out.Models)
+	// Same floor as TestModelsEndpoint: the pruned offline fallback has 10
+	// models.
+	if out.Models < 10 {
+		t.Errorf("models = %d, want >= 10", out.Models)
 	}
 	if len(out.Tokens) != 2 {
 		t.Errorf("tokens = %d, want 2", len(out.Tokens))


### PR DESCRIPTION
## Summary

Prune five retired model/agent rows from the offline registry fallback.

The fallback still advertised model IDs that were removed from upstream `FREE_MODE_AGENT_MODELS`. During fallback state, those IDs could therefore appear in `/v1/models` even though upstream rejects requests for them with `free_mode_invalid_agent_model`.

Removed models:

- `poolside/laguna-s-2.1`
- `openrouter/poolside/laguna-s-2.1`
- `inclusionai/ling-3.0-flash:free`
- `crof/greg-2-ultra`
- `crof/greg-2-super`

## Changes

- prune the five retired fallback agent rows
- update fallback expectations from 15 to 10 models
- replace the retired Laguna pool-test fixture with the still-valid Fable dedicated agent
- update fallback-dependent `/v1/models` and `/healthz` test floors
- add a regression test ensuring retired models and agents are absent from:
  - `AgentForModel`
  - `Models`
  - `AgentIDs`

Live registry refresh behavior is unchanged.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- `golangci-lint run`
- `git diff --check`

Closes #121