### PR TITLE
fix(anti-ban): P2 #116-#126 — wire identity, spend ledger, egress probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ All keys can be set via environment variables or the JSON config file passed to 
 | `IDLE_ROTATION_TIMEOUT` | `0` | Finish runs after this idle period (`0` = disabled; `SAFE_MODE` sets 30m when unset) |
 | `SAFE_MODE` | `true` | Apply anti-ban presets (see below; set `false` to disable) |
 | `REQUEST_JITTER` | `0s` | Random delay range `[0, REQUEST_JITTER)` before upstream calls (`SAFE_MODE` sets 2s when unset) |
+| `EGRESS_PROBE_ENABLED` | `false` | Keep the periodic egress probe loop running (GET `cloudflare.com/cdn-cgi/trace` on a jittered interval through the same utls stealth dialer as API traffic). Off by default: the official CLI never talks to `cloudflare.com`, so a clockwork probe from your IP is a machine signature — the one-shot startup probe and `-doctor` still run regardless |
 | `CLI_VERSION` | `0.10.7` | Upstream CLI version string used in the request envelope |
 | `MODEL_ALIASES` | `""` | Map aliases to real model IDs, e.g. `gpt-4o:deepseek/deepseek-v4-pro`. When unset, built-in aliases apply: `deepseek-chat` → `deepseek/deepseek-v4-flash`, `gpt-4o` → `deepseek/deepseek-v4-pro`, `claude-3-5-sonnet` → `anthropic/claude-fable-5`. An explicit value (even empty) suppresses all defaults |
 | `TRANSIENT_RETRIES` | `1` | Max additional attempts after a transient transport failure; `0` disables |

--- a/cmd/freebuff-proxy/doctor.go
+++ b/cmd/freebuff-proxy/doctor.go
@@ -226,13 +226,16 @@ func runDoctor(configPath string) {
 		ok(fmt.Sprintf("TLS connection to %s:%s succeeded", targetHost, targetPort))
 	}
 
-	// Egress region check: one live probe of the direct outbound path
-	// through a plain dialer, read back from the cache the doctor shares
-	// with the runtime. A failed probe is a warning, not a doctor failure —
-	// the proxy keeps working, only the region readout is missing.
+	// Egress region check: one live probe of the direct outbound path, read
+	// back from the cache the doctor shares with the runtime. The probe uses
+	// the same utls stealth dialer as API traffic when TLS_FINGERPRINT is
+	// set (issue #123 — a Go-default TLS handshake to the Cloudflare edge is
+	// itself a fingerprint mismatch); with no fingerprint it falls back to
+	// the plain direct dialer. A failed probe is a warning, not a doctor
+	// failure — the proxy keeps working, only the region readout is missing.
 	egressCache := egress.NewCache()
 	probeCtx, probeCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	res := egress.Probe(probeCtx, egress.DirectDialer(5*time.Second), 5*time.Second)
+	res := egress.ProbeTLS(probeCtx, egress.StealthDialer(cfg.TLSFingerprint), 5*time.Second)
 	probeCancel()
 	egressCache.Set("direct", res)
 	if line, isWarn := egressRegionRow(egressCache); isWarn {

--- a/cmd/freebuff-proxy/main.go
+++ b/cmd/freebuff-proxy/main.go
@@ -240,12 +240,23 @@ func main() {
 	// Egress probing: report the country/IP the direct outbound path appears
 	// to come from (ban-avoidance diagnostics; the upstream hard-blocks
 	// proxy/VPN egress, so the direct route is the only outbound path).
-	// Results are cached and refreshed every 10 minutes; failures are
-	// logged and cached with Err set (fail-open).
+	// The official CLI never talks to cloudflare.com, so by default only ONE
+	// probe runs at startup (fills the cache + risk-engine geo feed) — the
+	// periodic loop is opt-in via EGRESS_PROBE_ENABLED (issue #123). When
+	// enabled, the loop jitters its interval and routes through the same
+	// utls stealth dialer as API traffic so no Go-default TLS fingerprint
+	// ever reaches the Cloudflare edge.
 	egressCache := egress.NewCache()
-	if paths := egressPaths(); len(paths) > 0 {
-		go egress.RunLoop(ctx, logger, egressCache, paths, egress.ProbeTimeout, egress.DefaultTTL)
-		logger.Info("egress probes started", "paths", len(paths))
+	if paths := egressPaths(cfg); len(paths) > 0 {
+		if cfg.EgressProbeEnabled {
+			go egress.RunLoop(ctx, logger, egressCache, paths, egress.ProbeTimeout, egress.DefaultTTL)
+			logger.Info("egress probes started (periodic, jittered)", "paths", len(paths))
+		} else {
+			// One-shot startup probe: fills the region readout and the risk
+			// engine's geo feed without the 10-minute clockwork signature.
+			go egress.ProbeOnce(ctx, logger, egressCache, paths, egress.ProbeTimeout)
+			logger.Info("egress probe scheduled once at startup", "paths", len(paths))
+		}
 	}
 
 	// Issue #62: the dashboard login wizard drives the same headless OAuth
@@ -453,10 +464,18 @@ func ignoredExeAdjacentEnv(cwd, exePath string) string {
 
 // egressPaths returns the outbound probe paths: the direct connection only
 // (proxy routes were removed — the upstream hard-blocks proxy/VPN egress,
-// so any proxied path is pure ban risk). The risk engine's geo feed and the
-// doctor's "Egress region" row read results back from the shared cache.
-func egressPaths() []egress.Path {
-	return []egress.Path{{Key: "direct", Dialer: egress.DirectDialer(egress.ProbeTimeout)}}
+// so any proxied path is pure ban risk). When TLS_FINGERPRINT is
+// configured, the path also carries the same utls stealth dialer used for
+// API traffic, so even a probe request never presents Go's default TLS
+// fingerprint to the Cloudflare edge (issue #123). The risk engine's geo
+// feed and the doctor's "Egress region" row read results back from the
+// shared cache.
+func egressPaths(cfg config.Config) []egress.Path {
+	p := egress.Path{Key: "direct", Dialer: egress.DirectDialer(egress.ProbeTimeout)}
+	if dialTLS := egress.StealthDialer(cfg.TLSFingerprint); dialTLS != nil {
+		p.DialTLS = dialTLS
+	}
+	return []egress.Path{p}
 }
 
 // refreshLoop refreshes the registry immediately, then every interval.

--- a/cmd/freebuff-proxy/main_test.go
+++ b/cmd/freebuff-proxy/main_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"freebuff-proxy/internal/config"
 	"freebuff-proxy/internal/egress"
 )
 
@@ -163,14 +164,40 @@ func TestEgressCacheTTL(t *testing.T) {
 
 // TestEgressPaths pins the probe-path construction (the cmd package's
 // highest-value pure function): the direct connection is the only outbound
-// route (proxy routes were removed — the upstream hard-blocks proxy egress).
+// route (proxy routes were removed — the upstream hard-blocks proxy egress),
+// and the utls stealth dialer rides along when TLS_FINGERPRINT is
+// configured so the probe never presents Go's default TLS fingerprint to
+// the Cloudflare edge (issue #123).
 func TestEgressPaths(t *testing.T) {
-	paths := egressPaths()
+	paths := egressPaths(config.Config{})
 	if len(paths) != 1 {
 		t.Fatalf("paths = %d, want 1 (direct only)", len(paths))
 	}
 	if paths[0].Key != "direct" {
 		t.Errorf("paths[0].Key = %q, want direct", paths[0].Key)
+	}
+	if paths[0].Dialer == nil {
+		t.Error("paths[0].Dialer is nil, want the direct dialer")
+	}
+	if paths[0].DialTLS != nil {
+		t.Error("paths[0].DialTLS set without a TLS_FINGERPRINT, want nil (plain Go TLS)")
+	}
+
+	// With a fingerprint, the path carries the utls stealth dialer.
+	paths = egressPaths(config.Config{TLSFingerprint: "chrome126"})
+	if paths[0].DialTLS == nil {
+		t.Error("paths[0].DialTLS nil with TLS_FINGERPRINT=chrome126, want the stealth dialer")
+	}
+
+	// auto is a valid profile name too (SafeMode's default).
+	if paths = egressPaths(config.Config{TLSFingerprint: "auto"}); paths[0].DialTLS == nil {
+		t.Error("paths[0].DialTLS nil with TLS_FINGERPRINT=auto, want the stealth dialer")
+	}
+
+	// An unknown fingerprint is not a panic: it falls back to plain TLS.
+	paths = egressPaths(config.Config{TLSFingerprint: "nope"})
+	if paths[0].DialTLS != nil {
+		t.Error("paths[0].DialTLS set for unknown fingerprint, want nil fallback")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,13 +34,14 @@ type Config struct {
 	AdminToken            string // bearer token required for POST /admin/reload ("" = unauthenticated in default deployments)
 	HTTP2Upstream         bool   // true = negotiate HTTP/2 with the upstream so the ALPN matches real browsers (HTTP2_UPSTREAM); false forces HTTP/1.1 (#51)
 	CostMode              string // "" (omit) or "free"; A/B pending, PRD §8
-	UserID                string // optional FreeBuff account id sent as x-freebuff-acting-user-id (CLI parity; empty = omitted)
+	UserID                string // optional x-freebuff-acting-user-id (trusted server-to-server header — the CLI never sends it; enabling is a BAN RISK; empty = omitted, the CLI-parity default)
 	TLSFingerprint        string // "" (plain Go transport) | chrome120 | chrome126 | safari17 | safari18 | firefox120 | firefox128 | edge126 | random | auto
 	RegistryRefresh       time.Duration
 	DebugDump             bool
 	LogFile               string
 	LogLevel              string            // "" (use -v/default) or debug|info|warn|error
 	MaxMessagesPerDay     int               // 0 = unlimited: per-token cap on successful chats per 24h
+	MaxSpendPerDay        int64             // 0 = unlimited: ADVISORY per-token Pacific-day spend ceiling in ledger units (tokens from upstream usage blocks; issue #122). Never blocks — the upstream $ ceilings ($15 full / $5 limited / $0.50 restricted, compose by minimum, server-enforced) are the real gate. Surfaced as SpendLimit/SpendPct on /healthz so operator comparisons align with the Pacific-midnight reset.
 	IdleRotationTimeout   time.Duration     // 0 = disabled: pause rotation/refresh after this idle period
 	SafeMode              bool              // true = apply recommended anti-ban safe defaults
 	HybridMode            bool              // true = relay client tokens like bridge AND serve token-less requests from the pool
@@ -118,6 +119,16 @@ type Config struct {
 	// session create after an upstream 428 waiting_room_required (issue
 	// #94(b), gated stub — best-effort, never blocks the request).
 	WaitingRoomChain bool
+	// EgressProbeEnabled, when set (EGRESS_PROBE_ENABLED=false default),
+	// keeps the periodic egress probe loop running: the gateway GETs
+	// https://www.cloudflare.com/cdn-cgi/trace on a jittered interval
+	// through the same utls stealth dialer as API traffic (issue #123).
+	// Off by default because the official CLI never talks to
+	// cloudflare.com — a clockwork probe from the gateway IP is a machine
+	// signature with a Go-default JA3 that mismatches the API traffic's
+	// browser fingerprint. The one-shot startup probe (and -doctor) still
+	// run regardless; this knob only controls the recurring loop.
+	EgressProbeEnabled bool
 	// EnvFile is the .env path actually loaded ("" when none existed).
 	// Resolved via ResolveEnvFile (issue #39): ./.env in the working
 	// directory wins; otherwise the platform config dir is tried.
@@ -171,6 +182,7 @@ type rawConfig struct {
 	LogFile                          string   `json:"LOG_FILE"`
 	LogLevel                         string   `json:"LOG_LEVEL"`
 	MaxMessagesPerDay                *int     `json:"MAX_MESSAGES_PER_DAY"`
+	MaxSpendPerDay                   *int     `json:"MAX_SPEND_PER_DAY"`
 	IdleRotationTimeout              string   `json:"IDLE_ROTATION_TIMEOUT"`
 	SafeMode                         bool     `json:"SAFE_MODE"`
 	HybridMode                       bool     `json:"HYBRID_MODE"`
@@ -196,6 +208,7 @@ type rawConfig struct {
 	FallbackModels                   string   `json:"FALLBACK_MODEL"`
 	AdoptCLISession                  bool     `json:"ADOPT_CLI_SESSION"`
 	WaitingRoomChain                 bool     `json:"WAITING_ROOM_CHAIN"`
+	EgressProbeEnabled               bool     `json:"EGRESS_PROBE_ENABLED"`
 }
 
 func defaultRawConfig() rawConfig {
@@ -208,6 +221,7 @@ func defaultRawConfig() rawConfig {
 		RegistryRefresh:                  "6h",
 		CostMode:                         "free", // free-tier mode; omission routes requests as PAID and fresh free accounts get 402 "Out of credits" (upstream check: cost_mode !== 'free' → billing)
 		MaxMessagesPerDay:                nil,
+		MaxSpendPerDay:                   nil,   // 0 = unlimited advisory spend ceiling (never enforced)
 		IdleRotationTimeout:              "",    // "" = disabled (unset → SAFE_MODE preset may fill)
 		SafeMode:                         true,  // anti-ban presets on by default; set SAFE_MODE=false to disable
 		HybridMode:                       false, // relay client tokens AND serve the pool (off by default)
@@ -227,6 +241,7 @@ func defaultRawConfig() rawConfig {
 		SessionReAdmitLead:               "60s",       // #99: pre-emptive re-admit lead
 		SessionProbeCacheTTL:             "15s",       // #60: admission probe cache TTL
 		FallbackAfter:                    "10000",     // #100: queue-wait fallback threshold (ms)
+		EgressProbeEnabled:               false,       // anti-ban (#123): periodic cloudflare.com probes are opt-in; only the one-shot startup probe runs by default
 	}
 }
 
@@ -358,6 +373,7 @@ func Load(configPath string) (Config, error) {
 	overrideString(&raw.LogFile, "LOG_FILE")
 	overrideString(&raw.LogLevel, "LOG_LEVEL")
 	overrideInt(&raw.MaxMessagesPerDay, "MAX_MESSAGES_PER_DAY")
+	overrideInt(&raw.MaxSpendPerDay, "MAX_SPEND_PER_DAY")
 	overrideString(&raw.IdleRotationTimeout, "IDLE_ROTATION_TIMEOUT")
 	overrideBool(&raw.SafeMode, "SAFE_MODE")
 	overrideBool(&raw.HybridMode, "HYBRID_MODE")
@@ -383,6 +399,7 @@ func Load(configPath string) (Config, error) {
 	overrideString(&raw.FallbackModels, "FALLBACK_MODEL")
 	overrideBool(&raw.AdoptCLISession, "ADOPT_CLI_SESSION")
 	overrideBool(&raw.WaitingRoomChain, "WAITING_ROOM_CHAIN")
+	overrideBool(&raw.EgressProbeEnabled, "EGRESS_PROBE_ENABLED")
 
 	parseDuration := func(raw, name string) (time.Duration, error) {
 		d, err := time.ParseDuration(strings.TrimSpace(raw))
@@ -502,6 +519,16 @@ func Load(configPath string) (Config, error) {
 		maxMessagesPerDay = *raw.MaxMessagesPerDay
 	}
 
+	// MAX_SPEND_PER_DAY (issue #122): advisory per-token Pacific-day spend
+	// ceiling in ledger units, default 0 (unlimited). Deliberately NOT
+	// enforced — the upstream $ ceilings are server-side and the proxy
+	// cannot know the account's restricted cohort; surfaced as
+	// SpendLimit/SpendPct on /healthz.
+	maxSpendPerDay := int64(0)
+	if raw.MaxSpendPerDay != nil {
+		maxSpendPerDay = int64(*raw.MaxSpendPerDay)
+	}
+
 	// TRANSIENT_RETRIES: nil defaults to 1 (one additional attempt after a
 	// transient transport failure); an explicit 0 disables retries.
 	transientRetries := 1
@@ -565,6 +592,7 @@ func Load(configPath string) (Config, error) {
 		LogFile:                          strings.TrimSpace(raw.LogFile),
 		LogLevel:                         strings.TrimSpace(raw.LogLevel),
 		MaxMessagesPerDay:                maxMessagesPerDay,
+		MaxSpendPerDay:                   maxSpendPerDay,
 		IdleRotationTimeout:              idleRotationTimeout,
 		SafeMode:                         raw.SafeMode,
 		HybridMode:                       raw.HybridMode,
@@ -589,6 +617,7 @@ func Load(configPath string) (Config, error) {
 		FallbackModels:                   fallbackModels,
 		AdoptCLISession:                  raw.AdoptCLISession,
 		WaitingRoomChain:                 raw.WaitingRoomChain,
+		EgressProbeEnabled:               raw.EgressProbeEnabled,
 		EnvFile:                          envFileUsed,
 	}
 
@@ -715,6 +744,8 @@ func (c Config) Validate() error {
 		return errors.New(`COST_MODE must be "free" or unset -- any other value (e.g. a typo) routes requests as PAID and fresh free accounts get 402 "Out of credits"`)
 	case c.MaxMessagesPerDay < 0:
 		return errors.New("MAX_MESSAGES_PER_DAY cannot be negative")
+	case c.MaxSpendPerDay < 0:
+		return errors.New("MAX_SPEND_PER_DAY cannot be negative")
 	}
 
 	if c.WebhookURL != "" {
@@ -875,6 +906,7 @@ func applyDotenv(raw *rawConfig, path string) error {
 	overrideStringFrom(&raw.LogFile, get, "LOG_FILE")
 	overrideStringFrom(&raw.LogLevel, get, "LOG_LEVEL")
 	overrideIntFrom(&raw.MaxMessagesPerDay, get, "MAX_MESSAGES_PER_DAY")
+	overrideIntFrom(&raw.MaxSpendPerDay, get, "MAX_SPEND_PER_DAY")
 	overrideStringFrom(&raw.IdleRotationTimeout, get, "IDLE_ROTATION_TIMEOUT")
 	// The remaining keys mirror the real-environment override set in Load.
 	// AUTO_DISCOVER_TOKEN is intentionally env-only (it controls the .env
@@ -902,6 +934,7 @@ func applyDotenv(raw *rawConfig, path string) error {
 	overrideStringFrom(&raw.FallbackModels, get, "FALLBACK_MODEL")
 	overrideBoolFrom(&raw.AdoptCLISession, get, "ADOPT_CLI_SESSION")
 	overrideBoolFrom(&raw.WaitingRoomChain, get, "WAITING_ROOM_CHAIN")
+	overrideBoolFrom(&raw.EgressProbeEnabled, get, "EGRESS_PROBE_ENABLED")
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -24,6 +24,7 @@ var envKeys = []string{
 	"SESSION_PERSIST", "SESSION_STATE_FILE",
 	"HTTP2_UPSTREAM",
 	"WEBHOOK_URL", "FALLBACK_AFTER_MS", "FALLBACK_MODEL", "ADOPT_CLI_SESSION", "WAITING_ROOM_CHAIN",
+	"EGRESS_PROBE_ENABLED",
 }
 
 // TestMain strips ambient freebuff-proxy config env vars for the whole test
@@ -564,6 +565,7 @@ func TestValidate(t *testing.T) {
 		{"zero registry refresh", func(c *Config) { c.RegistryRefresh = 0 }},
 		{"bad cost mode", func(c *Config) { c.CostMode = "Free" }},
 		{"negative max messages", func(c *Config) { c.MaxMessagesPerDay = -1 }},
+		{"negative max spend", func(c *Config) { c.MaxSpendPerDay = -1 }},
 		{"session persist with empty state file", func(c *Config) { c.SessionPersist = true; c.SessionStateFile = "" }},
 		{"invalid listen port non-int", func(c *Config) { c.ListenAddr = "127.0.0.1:abc" }},
 		{"invalid listen port overflow", func(c *Config) { c.ListenAddr = "127.0.0.1:99999" }},
@@ -1112,6 +1114,62 @@ func TestMaxMessagesPerDay(t *testing.T) {
 	}
 }
 
+// TestMaxSpendPerDay pins the advisory spend-ceiling knob (issue #122):
+// default 0 (unlimited), env override, unparseable env ignored, JSON file
+// value, and .env value. The knob is advisory-only — the upstream $ ceilings
+// are server-enforced and the pool never blocks on it.
+func TestMaxSpendPerDay(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("AUTH_TOKENS", "tok")
+
+	// default: 0 (unlimited)
+	if cfg, err := Load(""); err != nil {
+		t.Fatalf("Load: %v", err)
+	} else if cfg.MaxSpendPerDay != 0 {
+		t.Errorf("MaxSpendPerDay = %d, want 0 (unlimited default)", cfg.MaxSpendPerDay)
+	}
+
+	// env override
+	t.Setenv("MAX_SPEND_PER_DAY", "1000")
+	if cfg, err := Load(""); err != nil {
+		t.Fatalf("Load (env): %v", err)
+	} else if cfg.MaxSpendPerDay != 1000 {
+		t.Errorf("MaxSpendPerDay = %d, want 1000 (env)", cfg.MaxSpendPerDay)
+	}
+
+	// unparseable env value is ignored (keeps the file value)
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"MAX_SPEND_PER_DAY": 250}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("MAX_SPEND_PER_DAY", "soon")
+	if cfg, err := Load(path); err != nil {
+		t.Fatalf("Load (bad env + file): %v", err)
+	} else if cfg.MaxSpendPerDay != 250 {
+		t.Errorf("MaxSpendPerDay = %d, want 250 (bad env ignored, file kept)", cfg.MaxSpendPerDay)
+	}
+
+	// JSON file value
+	t.Setenv("MAX_SPEND_PER_DAY", "")
+	if cfg, err := Load(path); err != nil {
+		t.Fatalf("Load (file): %v", err)
+	} else if cfg.MaxSpendPerDay != 250 {
+		t.Errorf("MaxSpendPerDay = %d, want 250 (file)", cfg.MaxSpendPerDay)
+	}
+
+	// .env value (clearEnv chdirs to a fresh temp dir, so ./.env is the
+	// file ResolveEnvFile reads)
+	t.Setenv("MAX_SPEND_PER_DAY", "")
+	if err := os.WriteFile(".env", []byte("AUTH_TOKENS=tok\nMAX_SPEND_PER_DAY=75\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if cfg, err := Load(""); err != nil {
+		t.Fatalf("Load (.env): %v", err)
+	} else if cfg.MaxSpendPerDay != 75 {
+		t.Errorf("MaxSpendPerDay = %d, want 75 (from .env)", cfg.MaxSpendPerDay)
+	}
+}
+
 func TestIdleRotationTimeout(t *testing.T) {
 	clearEnv(t)
 	t.Setenv("AUTH_TOKENS", "tok")
@@ -1555,6 +1613,7 @@ func TestDotenvFullKeySet(t *testing.T) {
 		"CLI_VERSION=9.9.9",
 		"MODEL_ALIASES=gpt-4o:deepseek/deepseek-v4-flash,glm:z-ai/glm-5.2",
 		"TRANSIENT_RETRIES=2",
+		"MAX_SPEND_PER_DAY=500",
 	}, "\n")
 	if err := os.WriteFile(".env", []byte(content), 0o644); err != nil {
 		t.Fatal(err)
@@ -1581,6 +1640,9 @@ func TestDotenvFullKeySet(t *testing.T) {
 	}
 	if cfg.TransientRetries != 2 {
 		t.Errorf("TransientRetries = %d, want 2 (from .env)", cfg.TransientRetries)
+	}
+	if cfg.MaxSpendPerDay != 500 {
+		t.Errorf("MaxSpendPerDay = %d, want 500 (from .env)", cfg.MaxSpendPerDay)
 	}
 }
 

--- a/internal/config/config_wave6_test.go
+++ b/internal/config/config_wave6_test.go
@@ -187,6 +187,53 @@ func TestAdoptCLISessionParsed(t *testing.T) {
 	}
 }
 
+// --- #123: EGRESS_PROBE_ENABLED ---------------------------------------------
+
+func TestEgressProbeEnabledParsed(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("AUTH_TOKENS", "tok-1")
+
+	// Default: periodic egress probing is OFF (anti-ban, #123); the
+	// one-shot startup probe still runs.
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.EgressProbeEnabled {
+		t.Error("EgressProbeEnabled = true, want false default (periodic probes opt-in)")
+	}
+
+	// Explicit enable turns the periodic loop on.
+	t.Setenv("EGRESS_PROBE_ENABLED", "true")
+	cfg, err = Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.EgressProbeEnabled {
+		t.Error("EgressProbeEnabled = false after EGRESS_PROBE_ENABLED=true")
+	}
+
+	// Garbage value is silently ignored, default stands.
+	t.Setenv("EGRESS_PROBE_ENABLED", "garbage")
+	cfg, err = Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.EgressProbeEnabled {
+		t.Error("EgressProbeEnabled = true from garbage EGRESS_PROBE_ENABLED value")
+	}
+
+	// Explicit false also wins.
+	t.Setenv("EGRESS_PROBE_ENABLED", "false")
+	cfg, err = Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.EgressProbeEnabled {
+		t.Error("EgressProbeEnabled = true after EGRESS_PROBE_ENABLED=false")
+	}
+}
+
 // --- #39: XDG / AppData config search ---------------------------------------
 
 func TestEnvFileCandidatesOrderAndShape(t *testing.T) {

--- a/internal/convert/convert.go
+++ b/internal/convert/convert.go
@@ -37,14 +37,17 @@ const maxSchemaDepth = 12
 // maxSchemaDepth (12x memory amplification). Tests may shrink it.
 var maxSchemaNodes = 100_000
 
-// capHint returns a+b clamped to MaxInt. Go's map/slice runtimes panic on a
-// negative or oversized allocation hint (makemap: size out of range /
-// makeslice: cap out of range), so guarding the sum keeps request-driven
-// preallocation safe even for pathological inputs. CodeQL: "size computation
-// for allocation may overflow" (convert.go:432,754,905,1006).
+// capHint returns a+b for use as a make() size hint, or 0 when the sum would
+// overflow int. An unguarded len(a)+len(b) hint can wrap negative and panic
+// the runtime (makeslice: "cap out of range" / "len out of range"; makemap
+// clamps negative hints but a wrapped positive is still wrong). On overflow
+// we drop the hint entirely and let the container grow dynamically - the
+// hint is pure preallocation optimization, never correctness. CodeQL:
+// "size computation for allocation may overflow" (go/allocation-size-overflow,
+// convert.go:432,754,905,1006).
 func capHint(a, b int) int {
 	if a > math.MaxInt-b {
-		return math.MaxInt
+		return 0
 	}
 	return a + b
 }

--- a/internal/convert/convert.go
+++ b/internal/convert/convert.go
@@ -37,6 +37,18 @@ const maxSchemaDepth = 12
 // maxSchemaDepth (12x memory amplification). Tests may shrink it.
 var maxSchemaNodes = 100_000
 
+// capHint returns a+b clamped to MaxInt. Go's map/slice runtimes panic on a
+// negative or oversized allocation hint (makemap: size out of range /
+// makeslice: cap out of range), so guarding the sum keeps request-driven
+// preallocation safe even for pathological inputs. CodeQL: "size computation
+// for allocation may overflow" (convert.go:432,754,905,1006).
+func capHint(a, b int) int {
+	if a > math.MaxInt-b {
+		return math.MaxInt
+	}
+	return a + b
+}
+
 // upstreamKeys is the whitelist of chat-completions body keys forwarded to
 // the upstream, plus messages/model which are always kept. Ported from
 // freebuff-api-kiprana's _UPSTREAM_CHAT_KEYS. Note "stream" is NOT
@@ -429,7 +441,7 @@ func compressMessages(messages []any) ([]any, int) {
 	}
 
 	// Pass 2: rebuild, replacing the dropped span with one marker message.
-	out := make([]any, 0, n-dropped+1)
+	out := make([]any, 0, capHint(n-dropped, 1))
 	for i := 0; i < n; i++ {
 		if i < keepStart {
 			m, ok := messages[i].(map[string]any)
@@ -751,7 +763,7 @@ func mergeDefinitions(parent, local map[string]any) map[string]any {
 	if local == nil {
 		return parent
 	}
-	merged := make(map[string]any, len(parent)+len(local))
+	merged := make(map[string]any, capHint(len(parent), len(local)))
 	for k, v := range parent {
 		merged[k] = v
 	}
@@ -902,7 +914,7 @@ func withoutRef(node map[string]any) map[string]any {
 // mergeMaps combines base with override; override wins on key collision
 // (JS object spread semantics).
 func mergeMaps(base, override map[string]any) map[string]any {
-	out := make(map[string]any, len(base)+len(override))
+	out := make(map[string]any, capHint(len(base), len(override)))
 	for k, v := range base {
 		out[k] = v
 	}
@@ -1003,7 +1015,7 @@ func simplifyNullableCombinator(schema map[string]any, key string) map[string]an
 		delete(schema, key)
 	case len(filtered) == 1:
 		if single, isMap := filtered[0].(map[string]any); isMap {
-			merged := make(map[string]any, len(schema)+len(single))
+			merged := make(map[string]any, capHint(len(schema), len(single)))
 			for k, v := range schema {
 				if k != key {
 					merged[k] = v

--- a/internal/convert/convert_test.go
+++ b/internal/convert/convert_test.go
@@ -3,6 +3,7 @@ package convert
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -2108,5 +2109,30 @@ func BenchmarkNormalizeToolSchema(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		budget := maxSchemaNodes
 		_ = normalizeToolSchemaCached(params, &budget)
+	}
+}
+
+// capHint guards allocation-size hints against int overflow; a negative or
+// wrapped hint panics Go's map/slice runtime (makemap/smakeslice: size out
+// of range). CodeQL: "size computation for allocation may overflow".
+func TestCapHint(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b int
+		want int
+	}{
+		{"zero", 0, 0, 0},
+		{"normal", 3, 5, 8},
+		{"slice cap", 4, 1, 5},
+		{"at max", math.MaxInt, 0, math.MaxInt},
+		{"clamped", math.MaxInt, 1, math.MaxInt},
+		{"clamped both", 1 << 20, math.MaxInt, math.MaxInt},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := capHint(tc.a, tc.b); got != tc.want {
+				t.Fatalf("capHint(%d, %d) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/convert/convert_test.go
+++ b/internal/convert/convert_test.go
@@ -2112,9 +2112,11 @@ func BenchmarkNormalizeToolSchema(b *testing.B) {
 	}
 }
 
-// capHint guards allocation-size hints against int overflow; a negative or
-// wrapped hint panics Go's map/slice runtime (makemap/smakeslice: size out
-// of range). CodeQL: "size computation for allocation may overflow".
+// capHint guards allocation-size hints against int overflow; a wrapped hint
+// panics Go's slice runtime (makeslice: cap out of range) and corrupts map
+// preallocation. Overflowing inputs must fall back to 0 (no hint) so the
+// container grows dynamically. CodeQL: "size computation for allocation may
+// overflow".
 func TestCapHint(t *testing.T) {
 	cases := []struct {
 		name string
@@ -2125,8 +2127,8 @@ func TestCapHint(t *testing.T) {
 		{"normal", 3, 5, 8},
 		{"slice cap", 4, 1, 5},
 		{"at max", math.MaxInt, 0, math.MaxInt},
-		{"clamped", math.MaxInt, 1, math.MaxInt},
-		{"clamped both", 1 << 20, math.MaxInt, math.MaxInt},
+		{"overflow drops hint", math.MaxInt, 1, 0},
+		{"overflow drops hint both", 1 << 20, math.MaxInt, 0},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/egress/probe.go
+++ b/internal/egress/probe.go
@@ -8,6 +8,8 @@ package egress
 import (
 	"bufio"
 	"context"
+	cryptoRand "crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"log/slog"
 	"net"
@@ -25,8 +27,15 @@ import (
 var ProbeURL = "https://www.cloudflare.com/cdn-cgi/trace"
 
 // DefaultTTL is how long a cached probe result stays fresh and the default
-// interval between background probes.
+// interval between periodic probes when EGRESS_PROBE_ENABLED is set.
 const DefaultTTL = 10 * time.Minute
+
+// DefaultJitter is the symmetric ± fraction applied to the periodic probe
+// interval so the loop never fires on a fixed clock (issue #123). It
+// mirrors the official CLI's session-poll cadence of 30s ± 20% symmetric
+// jitter (reference: use-freebuff-session.ts POLL_INTERVAL_ACTIVE_MS with
+// utils/polling-backoff.ts jitterPollIntervalMs).
+const DefaultJitter = 0.2
 
 // ProbeTimeout bounds a single probe request end to end (dial, TLS, body).
 const ProbeTimeout = 10 * time.Second
@@ -45,6 +54,23 @@ type Result struct {
 // TLS, non-200 status, unreadable body — returns Result{Err: err}; the
 // probe never retries and never touches the configured upstream auth.
 func Probe(ctx context.Context, dialer func(ctx context.Context, network, addr string) (net.Conn, error), timeout time.Duration) Result {
+	return probeOnce(ctx, timeout, dialer, nil)
+}
+
+// ProbeTLS is Probe for a DialTLSContext dialer — the utls stealth dialer
+// the gateway already uses for API traffic (issue #123) — so the probe's
+// ClientHello matches the gateway's other traffic instead of standing out
+// as Go's default TLS fingerprint. A nil dialTLS falls back to the plain
+// direct dialer, so callers can pass StealthDialer(fingerprint) and get a
+// sane default when no fingerprint is configured.
+func ProbeTLS(ctx context.Context, dialTLS func(ctx context.Context, network, addr string) (net.Conn, error), timeout time.Duration) Result {
+	return probeOnce(ctx, timeout, nil, dialTLS)
+}
+
+// probeOnce is the shared Probe/ProbeTLS body. dialer is used as the
+// transport's DialContext (plain TCP + Go TLS); when dialTLS is non-nil it
+// replaces the TLS layer (utls stealth) and dialer is ignored.
+func probeOnce(ctx context.Context, timeout time.Duration, dialer, dialTLS func(ctx context.Context, network, addr string) (net.Conn, error)) Result {
 	if dialer == nil {
 		dialer = DirectDialer(timeout)
 	}
@@ -58,6 +84,9 @@ func Probe(ctx context.Context, dialer func(ctx context.Context, network, addr s
 		MaxIdleConns:        1,
 		IdleConnTimeout:     DefaultTTL,
 		TLSHandshakeTimeout: timeout,
+	}
+	if dialTLS != nil {
+		tr.DialTLSContext = dialTLS
 	}
 	defer tr.CloseIdleConnections()
 	client := &http.Client{Transport: tr, Timeout: timeout}
@@ -101,15 +130,69 @@ func DirectDialer(timeout time.Duration) func(ctx context.Context, network, addr
 }
 
 // Path identifies one egress path to probe: the cache key ("direct") and
-// the dialer that routes the probe connection.
+// the dialer that routes the probe connection. DialTLS is optional: when
+// set, the transport dials TLS through it (the utls stealth dialer, issue
+// #123) instead of Go's default handshake.
 type Path struct {
-	Key    string
-	Dialer func(ctx context.Context, network, addr string) (net.Conn, error)
+	Key     string
+	Dialer  func(ctx context.Context, network, addr string) (net.Conn, error)
+	DialTLS func(ctx context.Context, network, addr string) (net.Conn, error)
 }
 
-// RunLoop probes all paths once at startup, then every interval until ctx
-// is canceled, storing each result into cache. Probe failures are logged
-// and cached with Err set (fail-open); the loop keeps running.
+// StealthDialer returns a DialTLSContext for the probe that impersonates
+// the given TLS fingerprint — the same utls dialer construction as the
+// upstream API client (stealth.Dialer over the direct base dial, h1 ALPN)
+// — so a probe request is indistinguishable from API traffic at the TLS
+// layer (issue #123). Returns nil when fingerprint is empty or unknown;
+// ProbeTLS then falls back to Go's plain TLS, so the call stays safe.
+func StealthDialer(fingerprint string) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	if fingerprint == "" {
+		return nil
+	}
+	profile, ok := stealth.Lookup(fingerprint)
+	if !ok {
+		return nil
+	}
+	// baseDial nil = the stealth dialer's default net.Dialer: direct egress
+	// only, never a proxy. h1 ALPN matches the plain http.Transport below.
+	return stealth.Dialer(profile, nil, false, []string{"http/1.1"})
+}
+
+// ProbeOnce runs a single probe pass over paths — one request per path,
+// results stored into cache, successes fed to the risk engine, failures
+// logged — and returns. The gateway uses it for the startup one-shot when
+// the periodic loop is disabled (issue #123); RunLoop calls it for its
+// first pass and each tick.
+func ProbeOnce(ctx context.Context, logger *slog.Logger, cache *Cache, paths []Path, timeout time.Duration) {
+	if cache == nil {
+		panic("egress: ProbeOnce requires a non-nil cache")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	for key, r := range probeAll(ctx, paths, timeout) {
+		cache.Set(key, r)
+		if r.Err != nil {
+			logger.Warn("egress probe failed", "path", key, "err", r.Err)
+		} else {
+			logger.Debug("egress probe", "path", key, "ip", r.IP, "country", r.Country)
+			// Passive ban-risk feed (#64): every successful probe
+			// contributes an egress-geo sample to the shared risk
+			// engine. Read-only; the engine only warns.
+			stealth.DefaultRiskEngine.Observe(stealth.RiskSample{
+				At:       time.Now(),
+				EgressIP: r.IP,
+				Country:  r.Country,
+			})
+		}
+	}
+}
+
+// RunLoop probes all paths once at startup, then on a jittered interval
+// until ctx is canceled, storing each result into cache. Probe failures are
+// logged and cached with Err set (fail-open); the loop keeps running. The
+// interval is jittered ±DefaultJitter so the gateway never probes on a
+// fixed clock (issue #123, mirroring the CLI's 30s ±20% poll cadence).
 func RunLoop(ctx context.Context, logger *slog.Logger, cache *Cache, paths []Path, timeout, interval time.Duration) {
 	if cache == nil {
 		panic("egress: RunLoop requires a non-nil cache")
@@ -118,40 +201,43 @@ func RunLoop(ctx context.Context, logger *slog.Logger, cache *Cache, paths []Pat
 		logger = slog.Default()
 	}
 	if interval <= 0 {
-		// time.NewTicker panics on a non-positive interval; fall back to the
+		// time.NewTimer panics on a non-positive duration; fall back to the
 		// default so a misconfigured caller gets periodic probing instead of
 		// a crash. (Audit B7.)
 		interval = DefaultTTL
 	}
-	run := func() {
-		for key, r := range probeAll(ctx, paths, timeout) {
-			cache.Set(key, r)
-			if r.Err != nil {
-				logger.Warn("egress probe failed", "path", key, "err", r.Err)
-			} else {
-				logger.Debug("egress probe", "path", key, "ip", r.IP, "country", r.Country)
-				// Passive ban-risk feed (#64): every successful probe
-				// contributes an egress-geo sample to the shared risk
-				// engine. Read-only; the engine only warns.
-				stealth.DefaultRiskEngine.Observe(stealth.RiskSample{
-					At:       time.Now(),
-					EgressIP: r.IP,
-					Country:  r.Country,
-				})
-			}
-		}
-	}
-	run()
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
+	ProbeOnce(ctx, logger, cache, paths, timeout)
+	timer := time.NewTimer(jittered(interval))
+	defer timer.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
-			run()
+		case <-timer.C:
+			ProbeOnce(ctx, logger, cache, paths, timeout)
+			timer.Reset(jittered(interval))
 		}
 	}
+}
+
+// jittered returns interval adjusted by a symmetric ±DefaultJitter uniform
+// draw, matching the official CLI's symmetric session-poll jitter
+// (reference: utils/polling-backoff.ts jitterPollIntervalMs — 30s ± 20%).
+// crypto/rand (not math/rand) matches the request-jitter pattern in the
+// upstream client, so the cadence sequence is not reproducible from the
+// process seed.
+func jittered(interval time.Duration) time.Duration {
+	if interval <= 0 {
+		return interval
+	}
+	span := int64(float64(interval) * DefaultJitter)
+	if span <= 0 {
+		return interval
+	}
+	var b [8]byte
+	_, _ = cryptoRand.Read(b[:])
+	u := binary.BigEndian.Uint64(b[:])
+	return interval - time.Duration(span) + time.Duration(u%(2*uint64(span)+1))
 }
 
 // probeAll probes every path concurrently and returns one Result per key.
@@ -165,7 +251,12 @@ func probeAll(ctx context.Context, paths []Path, timeout time.Duration) map[stri
 		wg.Add(1)
 		go func(p Path) {
 			defer wg.Done()
-			r := Probe(ctx, p.Dialer, timeout)
+			var r Result
+			if p.DialTLS != nil {
+				r = ProbeTLS(ctx, p.DialTLS, timeout)
+			} else {
+				r = Probe(ctx, p.Dialer, timeout)
+			}
 			mu.Lock()
 			results[p.Key] = r
 			mu.Unlock()

--- a/internal/egress/probe_test.go
+++ b/internal/egress/probe_test.go
@@ -2,6 +2,7 @@ package egress
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -53,6 +54,73 @@ func TestProbeParsesTrace(t *testing.T) {
 	}
 	if dialed.Load() == 0 {
 		t.Error("probe did not dial through the provided dialer")
+	}
+}
+
+// TestProbeTLSGuardsDialTLS pins the issue #123 stealth path: ProbeTLS
+// dials the TLS layer through the given DialTLSContext (the utls dialer)
+// instead of Go's default handshake, so the probe's ClientHello matches the
+// gateway's API traffic.
+func TestProbeTLSGuardsDialTLS(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ip=203.0.113.9\nloc=CA\n"))
+	}))
+	defer ts.Close()
+
+	orig := ProbeURL
+	ProbeURL = ts.URL
+	defer func() { ProbeURL = orig }()
+
+	var tlsDialed atomic.Int64
+	dialTLS := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		tlsDialed.Add(1)
+		// The httptest cert is self-signed and issued to example.com;
+		// InsecureSkipVerify stands in for the utls dialer's verification.
+		return tls.Dial(network, addr, &tls.Config{InsecureSkipVerify: true, ServerName: "example.com"})
+	}
+	res := ProbeTLS(context.Background(), dialTLS, 5*time.Second)
+	if res.Err != nil {
+		t.Fatalf("ProbeTLS failed: %v", res.Err)
+	}
+	if res.IP != "203.0.113.9" || res.Country != "CA" {
+		t.Errorf("ProbeTLS = ip %q loc %q, want 203.0.113.9 / CA", res.IP, res.Country)
+	}
+	if tlsDialed.Load() == 0 {
+		t.Error("ProbeTLS did not dial TLS through the provided dialTLS")
+	}
+}
+
+// TestProbeTLSNilFallback pins that a nil dialTLS degrades to the plain
+// direct dialer (Go TLS), so StealthDialer("") stays safe.
+func TestProbeTLSNilFallback(t *testing.T) {
+	ts := traceServer(t, "ip=203.0.113.10\nloc=CA\n", http.StatusOK)
+	orig := ProbeURL
+	ProbeURL = ts.URL
+	defer func() { ProbeURL = orig }()
+
+	res := ProbeTLS(context.Background(), nil, 5*time.Second)
+	if res.Err != nil {
+		t.Fatalf("ProbeTLS(nil) failed: %v", res.Err)
+	}
+	if res.IP != "203.0.113.10" || res.Country != "CA" {
+		t.Errorf("ProbeTLS(nil) = ip %q loc %q, want 203.0.113.10 / CA", res.IP, res.Country)
+	}
+}
+
+// TestStealthDialer pins the fingerprint → utls dialer mapping: known
+// fingerprints (incl. auto, SafeMode's default) yield a dialer, empty or
+// unknown fingerprints yield nil (plain-TLS fallback).
+func TestStealthDialer(t *testing.T) {
+	for _, fp := range []string{"", "nope"} {
+		if d := StealthDialer(fp); d != nil {
+			t.Errorf("StealthDialer(%q) = non-nil, want nil", fp)
+		}
+	}
+	for _, fp := range []string{"chrome126", "auto", "random", "safari18", "CHROME120"} {
+		if d := StealthDialer(fp); d == nil {
+			t.Errorf("StealthDialer(%q) = nil, want the utls dialer", fp)
+		}
 	}
 }
 
@@ -332,6 +400,53 @@ func TestRunLoop(t *testing.T) {
 		}()
 		RunLoop(context.Background(), slog.Default(), nil, nil, 5*time.Second, time.Minute)
 	})
+}
+
+// TestProbeOnce pins the startup one-shot contract (issue #123): a single
+// pass probes exactly once, caches the result, and never loops — the
+// default behavior when EGRESS_PROBE_ENABLED is off.
+func TestProbeOnce(t *testing.T) {
+	ts := traceServer(t, "ip=198.51.100.7\nloc=DE\n", http.StatusOK)
+	old := ProbeURL
+	ProbeURL = ts.URL
+	defer func() { ProbeURL = old }()
+
+	var probes atomic.Int64
+	dialer := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		probes.Add(1)
+		return DirectDialer(5*time.Second)(ctx, network, addr)
+	}
+	cache := NewCache()
+	ProbeOnce(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), cache,
+		[]Path{{Key: "direct", Dialer: dialer}}, 5*time.Second)
+	r, ok := cache.Get("direct")
+	if !ok || r.Err != nil || r.IP != "198.51.100.7" || r.Country != "DE" {
+		t.Errorf("cached result = %+v (ok=%v), want parsed success", r, ok)
+	}
+	if got := probes.Load(); got != 1 {
+		t.Errorf("probes = %d, want exactly 1 (single pass, no loop)", got)
+	}
+}
+
+// TestJittered pins the ±DefaultJitter symmetric jitter: every draw stays
+// within [interval×(1-jitter), interval×(1+jitter)], and non-positive
+// intervals pass through unchanged (no timer panic).
+func TestJittered(t *testing.T) {
+	base := 10 * time.Minute
+	lo := time.Duration(float64(base) * (1 - DefaultJitter))
+	hi := time.Duration(float64(base) * (1 + DefaultJitter))
+	for i := 0; i < 200; i++ {
+		got := jittered(base)
+		if got < lo || got > hi {
+			t.Fatalf("jittered(%v) = %v, want within [%v, %v]", base, got, lo, hi)
+		}
+	}
+	if got := jittered(0); got != 0 {
+		t.Errorf("jittered(0) = %v, want 0", got)
+	}
+	if got := jittered(-time.Minute); got != -time.Minute {
+		t.Errorf("jittered(-1m) = %v, want unchanged", got)
+	}
 }
 
 // TestCache guards the in-package TTL cache: get/set round-trip, expiry,

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -9,9 +9,10 @@
 //     that token, try the next.
 //   - session waiting room → remember the best position, try the next token;
 //     when every token fails, the pool surfaces the highest-precedence
-//     non-empty error bucket (ban > country-blocked > rate-limit >
-//     waiting-room > daily cap) instead of a generic 502 — a queued token
-//     surfaces 503 + Retry-After as soon as no higher bucket is populated.
+//     non-empty error bucket (ban > country-blocked > model-IP-limited >
+//     rate-limit > waiting-room > daily cap) instead of a generic 502 — a
+//     queued token surfaces 503 + Retry-After as soon as no higher bucket
+//     is populated.
 //   - run-invalid / session-invalid recoveries are NOT handled here: the
 //     caller (server) retries once via a fresh Acquire after invalidating.
 //   - anything else → next token; all failed → combined error (only when no
@@ -222,6 +223,16 @@ type Pool struct {
 	bridge      map[string]*bridgeEntry
 	bridgeOrder []string
 
+	// unfit is the per-(egress, model) unfit registry (issue #74 P2): models
+	// refused upstream with limited_ip on this egress are marked unfit for
+	// modelUnfitTTL so new requests are refused fast (409 model_ip_limited)
+	// and re-admission does not burn a daily session slot. The server guards
+	// NEW requests against it; Acquire deliberately does NOT consult it (the
+	// chat recovery loop re-acquires through the plain acquire closure and
+	// must reach a different token in mixed-tier pools). Guarded by unfitMu.
+	unfitMu sync.Mutex
+	unfit   map[unfitKey]unfitEntry
+
 	// store persists session state across restarts (SESSION_PERSIST); nil
 	// disables. Injected by the caller (main) via SetSessionStore so there
 	// is exactly one store shared by pooled and bridge entries.
@@ -264,7 +275,7 @@ func New(cfg *config.Config, clients []*upstream.Client, sessions []*session.Man
 		return nil, fmt.Errorf("pool: %d sessions for %d tokens", len(sessions), len(cfg.AuthTokens))
 	}
 
-	p := &Pool{reg: reg, logger: slog.Default(), bridge: make(map[string]*bridgeEntry)}
+	p := &Pool{reg: reg, logger: slog.Default(), bridge: make(map[string]*bridgeEntry), unfit: make(map[unfitKey]unfitEntry)}
 	p.cfg.Store(cfg)
 	p.msgsPerToken = make([][]time.Time, len(cfg.AuthTokens))
 	p.spendPerToken = make([]*spendLedger, len(cfg.AuthTokens))
@@ -521,6 +532,7 @@ func (p *Pool) Acquire(ctx context.Context, model string) (*Lease, error) {
 	var ipCapped []*upstream.IpCappedError
 	var banned []*upstream.BanError
 	var countryBlocked []*upstream.CountryBlockedError
+	var modelLimited []*upstream.LimitedIpError
 	var dailyLimited []*upstream.RateLimitError
 
 	for _, idx := range order {
@@ -629,6 +641,18 @@ func (p *Pool) Acquire(ctx context.Context, model string) (*Lease, error) {
 				tok.runs.CooldownCountryBlocked(cbe)
 				countryBlocked = append(countryBlocked, cbe)
 			}
+			if lie := asLimitedIp(err); lie != nil {
+				// Issue #74 P2: the egress IP cannot serve this model
+				// (limited_ip). The session row is fine — it stays bound to
+				// its admitted model — so nothing is invalidated or cooled
+				// per-token: the (egress, model) pair is marked unfit so
+				// new requests are refused fast instead of re-admitting and
+				// burning a daily session slot on every token.
+				p.MarkModelUnfit(model, lie)
+				modelLimited = append(modelLimited, lie)
+				errs = append(errs, fmt.Sprintf("%s: %v", name, err))
+				continue
+			}
 			errs = append(errs, fmt.Sprintf("%s: %v", name, err))
 			continue
 		}
@@ -692,11 +716,11 @@ func (p *Pool) Acquire(ctx context.Context, model string) (*Lease, error) {
 
 	// Failover precedence (PRD §6 error matrix): when buckets are mixed the
 	// highest-precedence non-empty bucket wins — ban > country-blocked >
-	// rate-limit > ip-capped > waiting-room > daily cap. Each bucket
-	// contributes its best error (first ban, longest rate window, first
-	// ip_capped, lowest queue position, earliest daily reset). Only when
-	// every bucket is empty — all tokens failed with errors outside the
-	// matrix — is the generic error surfaced.
+	// model-IP-limited > rate-limit > ip-capped > waiting-room > daily cap.
+	// Each bucket contributes its best error (first ban, longest rate
+	// window, first ip_capped, lowest queue position, earliest daily
+	// reset). Only when every bucket is empty — all tokens failed with
+	// errors outside the matrix — is the generic error surfaced.
 	// Issue #85: quota-capped tokens were excluded in acquireOrder (never
 	// attempted); their rate-limit reasons land here so a fully-capped pool
 	// surfaces a real 429 with the earliest window reset instead of a
@@ -707,6 +731,14 @@ func (p *Pool) Acquire(ctx context.Context, model string) (*Lease, error) {
 	}
 	if len(countryBlocked) > 0 {
 		return nil, countryBlocked[0]
+	}
+	if len(modelLimited) > 0 {
+		// Egress-model gate dominates per-token windows (issue #74 P2):
+		// every token shares the one egress, so no token can serve the
+		// model within the unfit window — retrying any token is pointless.
+		// Surface the refusal (409 model_ip_limited) and let the server's
+		// new-request guard fast-refuse until the window lapses.
+		return nil, modelLimited[0]
 	}
 	if len(rateLimited) > 0 {
 		// Pool exhausted (issue #48): every token failed and the highest-
@@ -2238,6 +2270,15 @@ func asCountryBlocked(err error) *upstream.CountryBlockedError {
 	var cbe *upstream.CountryBlockedError
 	if errors.As(err, &cbe) {
 		return cbe
+	}
+	return nil
+}
+
+// asLimitedIp extracts a LimitedIpError from err (nil when absent).
+func asLimitedIp(err error) *upstream.LimitedIpError {
+	var lie *upstream.LimitedIpError
+	if errors.As(err, &lie) {
+		return lie
 	}
 	return nil
 }

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -147,8 +147,9 @@ type TokenSnapshot struct {
 	UsagePct             int    // percentage of daily limit used (0 when unlimited)
 	RiskLevel            string // "low", "moderate", "high", "critical" account safety indicator (#6)
 	// Spend24h / SpendDay / SpendWeek / SpendMonth are the local per-token
-	// spend ledger (issue #87): tokens spent in the rolling 24h window and
-	// the current UTC day/week/month buckets (with rollover). Fed by
+	// spend ledger (issue #87/#122): tokens spent in the rolling 24h window
+	// and the current Pacific day/week/month buckets (with rollover —
+	// boundaries are America/Los_Angeles wall-clock, DST-correct). Fed by
 	// pool.RecordSpend from chat usage blocks; surfaced next to Messages24h.
 	Spend24h        int64
 	SpendDay        int64
@@ -157,6 +158,16 @@ type TokenSnapshot struct {
 	SpendDayStart   time.Time
 	SpendWeekStart  time.Time
 	SpendMonthStart time.Time
+	// SpendLimit is the configured MAX_SPEND_PER_DAY ADVISORY ceiling in
+	// ledger units (0 = unlimited). Never enforced: the upstream $ ceilings
+	// ($15 full / $5 limited / $0.50 restricted, server-enforced, issue
+	// #122) are the real gate and the proxy cannot know the account's
+	// restricted cohort. SpendPct is the Pacific-day bucket's percentage of
+	// SpendLimit (0 when unlimited). SpendLimited counts upstream
+	// spend_limited refusals observed for this token since process start.
+	SpendLimit   int64
+	SpendPct     int
+	SpendLimited int
 	// TierAccess / CountryCode / CountryBlockReason are the token's last
 	// known upstream session tier and region-block state. CountryBlockReason
 	// is non-empty when the account (or its egress region) is blocked;
@@ -663,6 +674,15 @@ func (p *Pool) Acquire(ctx context.Context, model string) (*Lease, error) {
 			if rle := asRateLimit(err); rle != nil {
 				tok.runs.CooldownRateLimit(rle)
 				rateLimited = append(rateLimited, rle)
+				// Issue #122: the fresh-admission spend ceiling is the
+				// upstream's primary spend gate, so an admission-path
+				// spend_limited counts on the ledger too (same counter as
+				// the chat-path refusal in CooldownTokenRateLimit).
+				if rle.Status == "spend_limited" {
+					p.spendMu.Lock()
+					p.recordSpendLimited(idx)
+					p.spendMu.Unlock()
+				}
 			}
 			if ice := asIpCapped(err); ice != nil {
 				tok.runs.CooldownIpCapped(ice)
@@ -720,6 +740,13 @@ func (p *Pool) Acquire(ctx context.Context, model string) (*Lease, error) {
 			if rle := asRateLimit(err); rle != nil {
 				tok.runs.CooldownRateLimit(rle)
 				rateLimited = append(rateLimited, rle)
+				// Issue #122: count run-start spend_limited refusals on the
+				// ledger (same counter as the chat-path refusal).
+				if rle.Status == "spend_limited" {
+					p.spendMu.Lock()
+					p.recordSpendLimited(idx)
+					p.spendMu.Unlock()
+				}
 			}
 			if ice := asIpCapped(err); ice != nil {
 				tok.runs.CooldownIpCapped(ice)
@@ -1046,6 +1073,14 @@ func (p *Pool) AcquireBridge(ctx context.Context, clientToken, model string) (*L
 		}
 		if rle := asRateLimit(err); rle != nil {
 			entry.runs.CooldownRateLimit(rle)
+			// Issue #122: count admission-path spend_limited refusals on
+			// the bridge entry's ledger (same counter as the chat-path
+			// refusal in CooldownBridgeRateLimit).
+			if rle.Status == "spend_limited" {
+				p.bridgeMu.Lock()
+				p.bridgeRecordSpendLimited(entry)
+				p.bridgeMu.Unlock()
+			}
 		}
 		if ice := asIpCapped(err); ice != nil {
 			entry.runs.CooldownIpCapped(ice)
@@ -1070,6 +1105,13 @@ func (p *Pool) AcquireBridge(ctx context.Context, clientToken, model string) (*L
 		}
 		if rle := asRateLimit(err); rle != nil {
 			entry.runs.CooldownRateLimit(rle)
+			// Issue #122: count run-start spend_limited refusals on the
+			// bridge entry's ledger (same counter as the chat-path refusal).
+			if rle.Status == "spend_limited" {
+				p.bridgeMu.Lock()
+				p.bridgeRecordSpendLimited(entry)
+				p.bridgeMu.Unlock()
+			}
 		}
 		if ice := asIpCapped(err); ice != nil {
 			entry.runs.CooldownIpCapped(ice)
@@ -1306,18 +1348,29 @@ func (p *Pool) CooldownToken(token int, d time.Duration) {
 
 // CooldownTokenRateLimit applies a rate-limit cooldown to token
 // (remembered so Acquire surfaces 429 + Retry-After during the window).
-// Out-of-range tokens are ignored.
+// Out-of-range tokens are ignored. When the refusal is spend_limited
+// (issue #122), the event is also counted on the token's spend ledger —
+// the $ ceiling is server-enforced, so the ledger only records the event.
 func (p *Pool) CooldownTokenRateLimit(token int, rle *upstream.RateLimitError) {
 	toks := p.toks.Load()
 	if token < 0 || token >= len(*toks) || rle == nil {
 		return
 	}
 	(*toks)[token].runs.CooldownRateLimit(rle)
+	if rle.Status == "spend_limited" {
+		p.spendMu.Lock()
+		p.recordSpendLimited(token)
+		p.spendMu.Unlock()
+	}
 }
 
 // CooldownTokenIpCapped applies an ip_capped cooldown to token, bounded to
-// the error's RetryAfter ONLY (no Pacific-midnight fallback — ip_capped is
-// admission-only, not a quota reset). Out-of-range tokens are ignored.
+// the error's RetryAfter (+jitter) — no Pacific-midnight fallback for first
+// refusals (ip_capped is admission-only, not a quota reset). #118 bounds
+// the re-admission loop in runs.CooldownIpCapped: after
+// maxIpCappedReAdmitsPerDay refusals in one Pacific day the token is locked
+// until the next reset (remembered error surfaces the remaining window).
+// Out-of-range tokens are ignored.
 func (p *Pool) CooldownTokenIpCapped(token int, ice *upstream.IpCappedError) {
 	toks := p.toks.Load()
 	if token < 0 || token >= len(*toks) || ice == nil {
@@ -1377,16 +1430,27 @@ func (p *Pool) CooldownBridge(lease *Lease, d time.Duration) {
 }
 
 // CooldownBridgeRateLimit applies a rate-limit cooldown to the bridge entry
-// (remembered so AcquireBridge surfaces 429 + Retry-After).
+// (remembered so AcquireBridge surfaces 429 + Retry-After). When the refusal
+// is spend_limited (issue #122), the event is also counted on the entry's
+// spend ledger — the $ ceiling is server-enforced, so the ledger only
+// records the event.
 func (p *Pool) CooldownBridgeRateLimit(lease *Lease, rle *upstream.RateLimitError) {
 	if lease == nil || lease.Bridge == nil || rle == nil {
 		return
 	}
 	lease.Bridge.runs.CooldownRateLimit(rle)
+	if rle.Status == "spend_limited" {
+		p.bridgeMu.Lock()
+		p.bridgeRecordSpendLimited(lease.Bridge)
+		p.bridgeMu.Unlock()
+	}
 }
 
 // CooldownBridgeIpCapped applies an ip_capped cooldown to the bridge entry,
-// bounded to the error's RetryAfter ONLY (no Pacific-midnight fallback).
+// bounded to the error's RetryAfter (+jitter) — no Pacific-midnight
+// fallback for first refusals; #118 caps the re-admission loop per Pacific
+// day in runs.CooldownIpCapped (terminal until the next reset once
+// maxIpCappedReAdmitsPerDay is exhausted).
 func (p *Pool) CooldownBridgeIpCapped(lease *Lease, ice *upstream.IpCappedError) {
 	if lease == nil || lease.Bridge == nil || ice == nil {
 		return
@@ -1549,6 +1613,7 @@ func (p *Pool) Snapshot() []TokenSnapshot {
 	toks := p.toks.Load()
 	out := make([]TokenSnapshot, 0, len(*toks))
 	dailyLimit := p.cfg.Load().MaxMessagesPerDay
+	spendLimit := p.cfg.Load().MaxSpendPerDay
 	for i, tok := range *toks {
 		rs := tok.runs.Snapshot()
 		ss := tok.session.Snapshot()
@@ -1599,6 +1664,17 @@ func (p *Pool) Snapshot() []TokenSnapshot {
 
 		spend := p.spendSnapshot(i)
 
+		// Advisory spend ceiling (issue #122): the Pacific-day bucket vs
+		// MAX_SPEND_PER_DAY, capped at 100% like UsagePct. Informational
+		// only — the upstream $ ceilings are server-enforced.
+		spendPct := 0
+		if spendLimit > 0 {
+			spendPct = int((spend.Day * 100) / spendLimit)
+			if spendPct > 100 {
+				spendPct = 100
+			}
+		}
+
 		out = append(out, TokenSnapshot{
 			Token:                   i,
 			CooldownUntil:           rs.CooldownUntil,
@@ -1628,6 +1704,9 @@ func (p *Pool) Snapshot() []TokenSnapshot {
 			SpendDayStart:           spend.DayStart,
 			SpendWeekStart:          spend.WeekStart,
 			SpendMonthStart:         spend.MonthStart,
+			SpendLimit:              spendLimit,
+			SpendPct:                spendPct,
+			SpendLimited:            spend.SpendLimited,
 		})
 	}
 	return out

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -24,13 +24,14 @@ import (
 // Test models must map to agents with EXCLUSIVE ownership in the registry
 // FALLBACK map (see internal/registry/registry_test.go expectedFallback):
 // the five base2-free models are first-seen-assigned to the generic
-// base2-free agent, while glm-5.2 and laguna-s-2.1 are owned by their
+// base2-free agent, while glm-5.2 and claude-fable-5 are owned by their
 // dedicated one-model agents. Tests pin the offline (fallback) state.
+// (The laguna-s-2.1 pair was retired from the fallback in issue #121.)
 const (
 	modelA = "z-ai/glm-5.2"
-	modelB = "poolside/laguna-s-2.1"
+	modelB = "anthropic/claude-fable-5"
 	agentA = "base2-free-glm"
-	agentB = "base2-free-laguna-s-2-1"
+	agentB = "base2-free-fable"
 )
 
 // newTestPool wires one mock upstream per token through real clients and
@@ -1816,10 +1817,11 @@ func TestPoolSnapshotTransientRetryCounters(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// The first upstream call (agent-runs START during Acquire) fails at the
-	// transport level once; TRANSIENT_RETRIES replays it and succeeds.
-	client.SetTransport(&flakyFirstRT{base: http.DefaultTransport})
-
+	// #120: the session POST is bodyless (no GetBody) and cannot be replayed
+	// by the transient retry (mirrors the CLI's bare bodyless fetch) —
+	// pre-admit the session on the healthy transport, then arm the flaky
+	// transport so its first victim is the agent-runs START during Acquire:
+	// a replayable request, which is what this test exercises.
 	sess := session.NewManager(client)
 	reg := registry.New(cfg, nil)
 	reg.LoadFallback()
@@ -1827,6 +1829,13 @@ func TestPoolSnapshotTransientRetryCounters(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if _, err := sess.EnsureSessionForModel(context.Background(), modelA); err != nil {
+		t.Fatal(err)
+	}
+	// The first upstream call (agent-runs START during Acquire) fails at the
+	// transport level once; TRANSIENT_RETRIES replays it and succeeds.
+	client.SetTransport(&flakyFirstRT{base: http.DefaultTransport})
 
 	lease, err := p.Acquire(context.Background(), modelA)
 	if err != nil {
@@ -2433,16 +2442,16 @@ func TestAcquireIpCappedCooldownBounded(t *testing.T) {
 		t.Errorf("RetryAfter = %s, want 45s (bounded to retryAfterMs)", ice.RetryAfter)
 	}
 
-	// Cooldown is bounded to the retry window, NOT the Pacific midnight
-	// quota lock (which would be many hours away).
+	// Cooldown is bounded to the retry window (+ the CLI-style up-to-20%
+	// jitter since #118), NOT the Pacific midnight quota lock (which would
+	// be many hours away).
 	snap := p.Snapshot()[0]
 	if snap.CooldownUntil.IsZero() {
 		t.Fatal("CooldownUntil zero, want bounded window")
 	}
-	want := time.Now().Add(45 * time.Second)
-	diff := snap.CooldownUntil.Sub(want)
-	if diff < -2*time.Second || diff > 2*time.Second {
-		t.Errorf("CooldownUntil = %v, want ≈ now+45s (bounded), not Pacific midnight", snap.CooldownUntil)
+	maxWant := time.Now().Add(45*time.Second + 45*time.Second/5 + time.Second)
+	if snap.CooldownUntil.Before(time.Now()) || snap.CooldownUntil.After(maxWant) {
+		t.Errorf("CooldownUntil = %v, want now..now+45s(+20%% jitter), not Pacific midnight", snap.CooldownUntil)
 	}
 
 	// While the window is active, a second acquire surfaces the remembered
@@ -2467,10 +2476,11 @@ func TestPoolCooldownTokenIpCappedBounded(t *testing.T) {
 	if snap.CooldownUntil.IsZero() {
 		t.Fatal("CooldownUntil zero, want bounded window")
 	}
-	want := time.Now().Add(30 * time.Second)
-	diff := snap.CooldownUntil.Sub(want)
-	if diff < -2*time.Second || diff > 2*time.Second {
-		t.Errorf("CooldownUntil = %v, want ≈ now+30s (bounded), not Pacific midnight", snap.CooldownUntil)
+	// #118: the window is the full retryAfterMs plus up to 20% jitter (the
+	// CLI's poll-jitter pattern), never the Pacific-midnight quota lock.
+	maxWant := time.Now().Add(30*time.Second + 30*time.Second/5 + time.Second)
+	if snap.CooldownUntil.Before(time.Now()) || snap.CooldownUntil.After(maxWant) {
+		t.Errorf("CooldownUntil = %v, want now..now+30s(+20%% jitter), not Pacific midnight", snap.CooldownUntil)
 	}
 
 	// Out-of-range tokens are ignored without panicking.

--- a/internal/pool/spend.go
+++ b/internal/pool/spend.go
@@ -1,16 +1,34 @@
 package pool
 
 // Local per-token spend ledger (issue #87): an in-memory rolling 24h token
-// spend window plus UTC day/week/month buckets with rollover, mirroring the
-// reference account quota bookkeeping (reference/freebuff-reverse
-// internal/accounts/record.go QuotaUsed/QuotaPeriodStart and
-// internal/quota/quota.go BucketStart/NeedsRollover). Updated from chat
-// usage (pool.RecordSpend, fed by the server's parsed usage blocks) and
+// spend window plus Pacific day/week/month buckets with rollover (issue
+// #122: all period boundaries are America/Los_Angeles wall-clock — 00:00
+// Pacific, Monday 00:00 Pacific, 1st 00:00 Pacific — resolving to
+// 07:00/08:00 UTC by DST, matching the CLI's getZonedDayBounds /
+// getZonedWeekBounds, reference/freebuff/common/src/util/zoned-time.ts:78-92,
+// and the upstream wire periods pacific_day / pacific_week). Updated from
+// chat usage (pool.RecordSpend, fed by the server's parsed usage blocks) and
 // surfaced next to Messages24h in the healthz token snapshot.
 
 import (
+	"sync"
 	"time"
 )
+
+// pacificLoc returns the cached America/Los_Angeles location, or nil when
+// the IANA tzdata database is unavailable. time.LoadLocation consults
+// ZONEINFO, the system zoneinfo, $GOROOT/lib/time/zoneinfo.zip, and the
+// time/tzdata import in that order (go/src/time/zoneinfo.go LoadLocation);
+// a stripped single-binary deployment with none of those gets nil and the
+// callers fall back to bucketStartFallback, mirroring
+// upstream.pacificMidnightFallback.
+var pacificLoc = sync.OnceValue(func() *time.Location {
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		return nil
+	}
+	return loc
+})
 
 // spendEntry is one recorded spend amount at a point in time (rolling 24h
 // window).
@@ -23,14 +41,20 @@ type spendEntry struct {
 type spendLedger struct {
 	// rolling is the 24h window: amounts with timestamps, pruned on access.
 	rolling []spendEntry
-	// UTC day/week/month buckets with their period start (unix); roll over
-	// per BucketStart/NeedsRollover semantics.
+	// Pacific day/week/month buckets with their period start (unix); roll
+	// over per BucketStart/NeedsRollover semantics (issue #122: boundaries
+	// are America/Los_Angeles wall-clock, DST-correct).
 	dayUsed    int64
 	dayStart   int64
 	weekUsed   int64
 	weekStart  int64
 	monthUsed  int64
 	monthStart int64
+	// spendLimited counts upstream spend_limited refusals observed for this
+	// token since process start (issue #122): the server-side $ ceiling is
+	// authoritative (the proxy cannot know the account's restricted cohort),
+	// so this is an event counter, not a gate.
+	spendLimited int
 }
 
 func newSpendLedger() *spendLedger { return &spendLedger{} }
@@ -65,40 +89,97 @@ func rollBucket(used, start int64, period string, now time.Time, tokens int64) (
 	return used + tokens, start
 }
 
-// bucketStart is the UTC start of the period containing now (mirrors
-// reference quota.BucketStart: day = UTC midnight, week = UTC Monday,
-// month = UTC 1st).
+// bucketStart is the start of the period containing now in Pacific
+// wall-clock (America/Los_Angeles): day = 00:00 Pacific, week = Monday
+// 00:00 Pacific, month = 1st 00:00 Pacific. All resolve to 07:00 UTC during
+// PDT and 08:00 UTC during PST, mirroring the CLI's getZonedDayBounds /
+// getZonedWeekBounds (reference/freebuff/common/src/util/zoned-time.ts:78-92,
+// weekStartsOn = Monday) and the upstream wire periods pacific_day /
+// pacific_week with resetTimeZone America/Los_Angeles. Month has no CLI
+// equivalent and uses the Pacific calendar month for consistency. time.Date
+// interprets the wall clock in the location and resolves DST transitions via
+// the zone rules (go/src/time/time.go Date), so no fixed UTC offset is used.
 func bucketStart(now time.Time, period string) int64 {
+	loc := pacificLoc()
+	if loc == nil {
+		return bucketStartFallback(now, period)
+	}
+	n := now.In(loc)
+	switch period {
+	case "week":
+		days := (int(n.Weekday()) + 6) % 7 // Monday=0 … Sunday=6
+		return time.Date(n.Year(), n.Month(), n.Day(), 0, 0, 0, 0, loc).
+			AddDate(0, 0, -days).UTC().Unix()
+	case "month":
+		return time.Date(n.Year(), n.Month(), 1, 0, 0, 0, 0, loc).UTC().Unix()
+	default: // day
+		return time.Date(n.Year(), n.Month(), n.Day(), 0, 0, 0, 0, loc).UTC().Unix()
+	}
+}
+
+// bucketStartFallback approximates bucketStart without the IANA tzdata
+// database: America/Los_Angeles is UTC-7 during PDT (roughly March-
+// November) and UTC-8 during PST (roughly November-March). The month range
+// is the documented approximation; the exact DST transition dates require
+// tzdata (mirrors upstream.pacificMidnightFallback). The "start after now"
+// guard keeps the result ≤ now, as bucketStart guarantees.
+func bucketStartFallback(now time.Time, period string) int64 {
 	u := now.UTC()
+	hour := 7 // PDT
+	if u.Month() < time.March || u.Month() > time.November {
+		hour = 8 // PST: December, January, February
+	}
 	switch period {
 	case "week":
 		weekday := int(u.Weekday())
 		if weekday == 0 {
 			weekday = 7
 		}
-		return time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, time.UTC).
-			AddDate(0, 0, -(weekday - 1)).Unix()
+		start := time.Date(u.Year(), u.Month(), u.Day(), hour, 0, 0, 0, time.UTC).
+			AddDate(0, 0, -(weekday - 1))
+		if start.After(u) {
+			start = start.AddDate(0, 0, -7)
+		}
+		return start.Unix()
 	case "month":
-		return time.Date(u.Year(), u.Month(), 1, 0, 0, 0, 0, time.UTC).Unix()
+		start := time.Date(u.Year(), u.Month(), 1, hour, 0, 0, 0, time.UTC)
+		if start.After(u) {
+			start = start.AddDate(0, -1, 0)
+		}
+		return start.Unix()
 	default: // day
-		return time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, time.UTC).Unix()
+		start := time.Date(u.Year(), u.Month(), u.Day(), hour, 0, 0, 0, time.UTC)
+		if start.After(u) {
+			start = start.AddDate(0, 0, -1)
+		}
+		return start.Unix()
 	}
 }
 
 // needsRollover reports whether a bucket whose window started at start has
-// closed by now (mirrors reference quota.NeedsRollover).
+// closed by now. The window ends at the next Pacific-wall-clock period
+// boundary: midnight+1 day, Monday+7 days, 1st+1 month — calendar arithmetic
+// via AddDate, which shifts the UTC instant across DST transitions exactly
+// like the CLI's getZonedDayBounds / getZonedWeekBounds
+// (reference/freebuff/common/src/util/zoned-time.ts:78-92; AddDate
+// normalizes like Date, go/src/time/time.go). Without tzdata the fallback
+// buckets are fixed-hour (07:00/08:00 UTC), so 24h windows are exact there.
 func needsRollover(start int64, period string, now time.Time) bool {
 	if start == 0 {
 		return true
 	}
+	loc := pacificLoc()
 	end := time.Unix(start, 0).UTC()
+	if loc != nil {
+		end = end.In(loc)
+	}
 	switch period {
 	case "week":
-		end = end.Add(7 * 24 * time.Hour)
+		end = end.AddDate(0, 0, 7)
 	case "month":
 		end = end.AddDate(0, 1, 0)
 	default:
-		end = end.Add(24 * time.Hour)
+		end = end.AddDate(0, 0, 1)
 	}
 	return !now.Before(end)
 }
@@ -171,13 +252,14 @@ func (p *Pool) bridgeRecordSpend(entry *bridgeEntry, tokens int64) {
 
 // spendView is one ledger's snapshot for healthz (issue #87).
 type spendView struct {
-	Rolling24h int64
-	Day        int64
-	DayStart   time.Time
-	Week       int64
-	WeekStart  time.Time
-	Month      int64
-	MonthStart time.Time
+	Rolling24h   int64
+	Day          int64
+	DayStart     time.Time
+	Week         int64
+	WeekStart    time.Time
+	Month        int64
+	MonthStart   time.Time
+	SpendLimited int // upstream spend_limited refusals since process start (#122)
 }
 
 // spendSnapshot returns the fixed-token ledger view (index path).
@@ -211,14 +293,33 @@ func ledgerView(l *spendLedger) spendView {
 	}
 	now := time.Now()
 	return spendView{
-		Rolling24h: l.rolling24h(now),
-		Day:        l.dayUsed,
-		DayStart:   unixToTime(l.dayStart),
-		Week:       l.weekUsed,
-		WeekStart:  unixToTime(l.weekStart),
-		Month:      l.monthUsed,
-		MonthStart: unixToTime(l.monthStart),
+		Rolling24h:   l.rolling24h(now),
+		Day:          l.dayUsed,
+		DayStart:     unixToTime(l.dayStart),
+		Week:         l.weekUsed,
+		WeekStart:    unixToTime(l.weekStart),
+		Month:        l.monthUsed,
+		MonthStart:   unixToTime(l.monthStart),
+		SpendLimited: l.spendLimited,
 	}
+}
+
+// recordSpendLimited marks one upstream spend_limited refusal on the
+// fixed-token ledger (issue #122). Caller holds Pool.spendMu.
+func (p *Pool) recordSpendLimited(token int) {
+	if token < 0 || token >= len(p.spendPerToken) {
+		return
+	}
+	p.spendPerToken[token].spendLimited++
+}
+
+// bridgeRecordSpendLimited marks one upstream spend_limited refusal on a
+// bridge entry's ledger (issue #122). Caller holds Pool.bridgeMu.
+func (p *Pool) bridgeRecordSpendLimited(entry *bridgeEntry) {
+	if entry == nil {
+		return
+	}
+	entry.spend.spendLimited++
 }
 
 func unixToTime(sec int64) time.Time {

--- a/internal/pool/spend_test.go
+++ b/internal/pool/spend_test.go
@@ -1,0 +1,210 @@
+package pool
+
+// Issue #122: the spend ledger's day/week/month buckets roll at Pacific
+// wall-clock boundaries (America/Los_Angeles), DST-correct — 07:00 UTC
+// during PDT (summer) and 08:00 UTC during PST (winter) — mirroring the
+// CLI's getZonedDayBounds / getZonedWeekBounds
+// (reference/freebuff/common/src/util/zoned-time.ts:78-92, weekStartsOn =
+// Monday) and the upstream wire periods pacific_day / pacific_week with
+// resetTimeZone America/Los_Angeles. July dates exercise PDT, January
+// dates exercise PST.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"freebuff-proxy/internal/config"
+	"freebuff-proxy/internal/testutil"
+	"freebuff-proxy/internal/upstream"
+)
+
+func TestBucketStartPacificDay(t *testing.T) {
+	// July 2026 = PDT (UTC-7): the Pacific day starts at 07:00 UTC.
+	// 06:59 UTC is still the PREVIOUS Pacific day (23:59 PDT).
+	pdt := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
+	if got := bucketStart(pdt, "day"); got != time.Date(2026, time.July, 15, 7, 0, 0, 0, time.UTC).Unix() {
+		t.Errorf("bucketStart(July noon, day) = %v, want July 15 07:00 UTC (PDT)", time.Unix(got, 0).UTC())
+	}
+	before := time.Date(2026, time.July, 15, 6, 59, 0, 0, time.UTC)
+	if got := bucketStart(before, "day"); got != time.Date(2026, time.July, 14, 7, 0, 0, 0, time.UTC).Unix() {
+		t.Errorf("bucketStart(July 06:59 UTC, day) = %v, want July 14 07:00 UTC (PDT day not yet rolled)", time.Unix(got, 0).UTC())
+	}
+
+	// January 2026 = PST (UTC-8): the Pacific day starts at 08:00 UTC.
+	pst := time.Date(2026, time.January, 15, 12, 0, 0, 0, time.UTC)
+	if got := bucketStart(pst, "day"); got != time.Date(2026, time.January, 15, 8, 0, 0, 0, time.UTC).Unix() {
+		t.Errorf("bucketStart(January noon, day) = %v, want January 15 08:00 UTC (PST)", time.Unix(got, 0).UTC())
+	}
+	beforePST := time.Date(2026, time.January, 15, 7, 59, 0, 0, time.UTC)
+	if got := bucketStart(beforePST, "day"); got != time.Date(2026, time.January, 14, 8, 0, 0, 0, time.UTC).Unix() {
+		t.Errorf("bucketStart(January 07:59 UTC, day) = %v, want January 14 08:00 UTC (PST day not yet rolled)", time.Unix(got, 0).UTC())
+	}
+}
+
+// TestSpendLedgerPacificDayRollover pins the day-bucket rollover across the
+// Pacific-midnight boundary in both PDT (July) and PST (January): spend
+// before the boundary lands in the previous Pacific day, spend at/after it
+// starts a fresh bucket.
+func TestSpendLedgerPacificDayRollover(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		midnightUTC time.Time // 00:00 Pacific on the roll day
+		prevDayUTC  time.Time // 00:00 Pacific on the day before
+	}{
+		{
+			name:        "PDT July",
+			midnightUTC: time.Date(2026, time.July, 16, 7, 0, 0, 0, time.UTC),
+			prevDayUTC:  time.Date(2026, time.July, 15, 7, 0, 0, 0, time.UTC),
+		},
+		{
+			name:        "PST January",
+			midnightUTC: time.Date(2026, time.January, 16, 8, 0, 0, 0, time.UTC),
+			prevDayUTC:  time.Date(2026, time.January, 15, 8, 0, 0, 0, time.UTC),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ledger := newSpendLedger()
+			// One minute before the Pacific-midnight boundary: still the
+			// previous Pacific day.
+			before := tc.midnightUTC.Add(-time.Minute)
+			ledger.add(100, before)
+			v := ledgerView(ledger)
+			if v.Day != 100 {
+				t.Fatalf("day after first add = %d, want 100", v.Day)
+			}
+			if v.DayStart.Unix() != tc.prevDayUTC.Unix() {
+				t.Errorf("DayStart before boundary = %v, want %v (previous Pacific day)", v.DayStart, tc.prevDayUTC)
+			}
+
+			// At the boundary the bucket rolls: the new day starts fresh.
+			ledger.add(50, tc.midnightUTC)
+			v = ledgerView(ledger)
+			if v.Day != 50 {
+				t.Errorf("day after rollover = %d, want 50 (bucket reset at Pacific midnight)", v.Day)
+			}
+			if v.DayStart.Unix() != tc.midnightUTC.Unix() {
+				t.Errorf("DayStart after boundary = %v, want %v", v.DayStart, tc.midnightUTC)
+			}
+		})
+	}
+}
+
+func TestBucketStartPacificWeek(t *testing.T) {
+	// July 13 2026 is a Monday; in PDT (UTC-7) the Pacific week starts at
+	// 07:00 UTC that day.
+	thu := time.Date(2026, time.July, 16, 12, 0, 0, 0, time.UTC) // Thursday
+	if got := bucketStart(thu, "week"); got != time.Date(2026, time.July, 13, 7, 0, 0, 0, time.UTC).Unix() {
+		t.Errorf("bucketStart(July Thursday, week) = %v, want Monday July 13 07:00 UTC (PDT)", time.Unix(got, 0).UTC())
+	}
+	// January 12 2026 is a Monday; in PST (UTC-8) the week starts at
+	// 08:00 UTC.
+	janThu := time.Date(2026, time.January, 15, 12, 0, 0, 0, time.UTC)
+	if got := bucketStart(janThu, "week"); got != time.Date(2026, time.January, 12, 8, 0, 0, 0, time.UTC).Unix() {
+		t.Errorf("bucketStart(January Thursday, week) = %v, want Monday January 12 08:00 UTC (PST)", time.Unix(got, 0).UTC())
+	}
+	// A Sunday is the LAST day of the Pacific week.
+	sun := time.Date(2026, time.July, 19, 23, 0, 0, 0, time.UTC)
+	if got := bucketStart(sun, "week"); got != time.Date(2026, time.July, 13, 7, 0, 0, 0, time.UTC).Unix() {
+		t.Errorf("bucketStart(July Sunday, week) = %v, want Monday July 13 07:00 UTC", time.Unix(got, 0).UTC())
+	}
+}
+
+func TestBucketStartPacificMonth(t *testing.T) {
+	// Month has no CLI equivalent; it uses the Pacific calendar month for
+	// consistency with the day/week buckets (issue #122).
+	mid := time.Date(2026, time.July, 16, 12, 0, 0, 0, time.UTC)
+	if got := bucketStart(mid, "month"); got != time.Date(2026, time.July, 1, 7, 0, 0, 0, time.UTC).Unix() {
+		t.Errorf("bucketStart(July, month) = %v, want July 1 07:00 UTC (PDT)", time.Unix(got, 0).UTC())
+	}
+	jan := time.Date(2026, time.January, 16, 12, 0, 0, 0, time.UTC)
+	if got := bucketStart(jan, "month"); got != time.Date(2026, time.January, 1, 8, 0, 0, 0, time.UTC).Unix() {
+		t.Errorf("bucketStart(January, month) = %v, want January 1 08:00 UTC (PST)", time.Unix(got, 0).UTC())
+	}
+}
+
+// TestBucketStartFallback pins the tzdata-less fallback (mirrors
+// upstream.pacificMidnightFallback): Pacific is UTC-7 (07:00 UTC midnight)
+// March-November and UTC-8 (08:00 UTC) otherwise, and bucketStart always
+// returns a start <= now.
+func TestBucketStartFallback(t *testing.T) {
+	july := time.Date(2026, time.July, 15, 12, 0, 0, 0, time.UTC)
+	if got := bucketStartFallback(july, "day"); got != time.Date(2026, time.July, 15, 7, 0, 0, 0, time.UTC).Unix() {
+		t.Errorf("fallback July day = %v, want July 15 07:00 UTC", time.Unix(got, 0).UTC())
+	}
+	jan := time.Date(2026, time.January, 15, 12, 0, 0, 0, time.UTC)
+	if got := bucketStartFallback(jan, "day"); got != time.Date(2026, time.January, 15, 8, 0, 0, 0, time.UTC).Unix() {
+		t.Errorf("fallback January day = %v, want January 15 08:00 UTC", time.Unix(got, 0).UTC())
+	}
+	// Pre-midnight instant: 06:00 UTC July 15 is still Pacific July 14.
+	pre := time.Date(2026, time.July, 15, 6, 0, 0, 0, time.UTC)
+	if got := bucketStartFallback(pre, "day"); got != time.Date(2026, time.July, 14, 7, 0, 0, 0, time.UTC).Unix() {
+		t.Errorf("fallback pre-midnight day = %v, want July 14 07:00 UTC", time.Unix(got, 0).UTC())
+	}
+}
+
+// TestRecordSpendLimited pins issue #122's event counter: an upstream
+// spend_limited refusal is counted per token on the ledger, while a plain
+// rate_limited refusal is not (the $ ceiling is server-enforced; the ledger
+// only records the event).
+func TestRecordSpendLimited(t *testing.T) {
+	p := newTestPool(t, testutil.NewMock())
+	lease, err := p.Acquire(context.Background(), modelA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.CooldownTokenRateLimit(lease.Token, &upstream.RateLimitError{Status: "spend_limited", RetryAfter: time.Minute})
+	p.CooldownTokenRateLimit(lease.Token, &upstream.RateLimitError{Status: "rate_limited", RetryAfter: time.Minute})
+	p.CooldownTokenRateLimit(lease.Token, &upstream.RateLimitError{Status: "spend_limited", RetryAfter: time.Minute})
+	p.LeaseRelease(lease)
+
+	snaps := p.Snapshot()
+	if len(snaps) != 1 {
+		t.Fatalf("tokens = %d, want 1", len(snaps))
+	}
+	if snaps[0].SpendLimited != 2 {
+		t.Errorf("SpendLimited = %d, want 2 (only spend_limited refusals counted)", snaps[0].SpendLimited)
+	}
+
+	// Bridge path counts on the bridge entry's ledger.
+	bp := newBridgePool(t, testutil.NewMock())
+	blease, err := bp.AcquireBridge(context.Background(), "client-tok", modelA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bp.CooldownBridgeRateLimit(blease, &upstream.RateLimitError{Status: "spend_limited", RetryAfter: time.Minute})
+	bp.CooldownBridgeRateLimit(blease, &upstream.RateLimitError{Status: "rate_limited", RetryAfter: time.Minute})
+	bv := bp.bridgeSpendSnapshot(blease.Bridge)
+	if bv.SpendLimited != 1 {
+		t.Errorf("bridge SpendLimited = %d, want 1 (only spend_limited counted)", bv.SpendLimited)
+	}
+	bp.LeaseRelease(blease)
+}
+
+// TestSpendPct pins the advisory ceiling surface (issue #122): the
+// Pacific-day bucket vs MAX_SPEND_PER_DAY, capped at 100%.
+func TestSpendPct(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	p := newTestPoolCfg(t, func(c *config.Config) { c.MaxSpendPerDay = 1000 }, mock)
+	lease, err := p.Acquire(context.Background(), modelA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.RecordSpend(lease, 300)
+	p.LeaseRelease(lease)
+
+	snaps := p.Snapshot()
+	if len(snaps) != 1 {
+		t.Fatalf("tokens = %d, want 1", len(snaps))
+	}
+	if snaps[0].SpendLimit != 1000 {
+		t.Errorf("SpendLimit = %d, want 1000 (MAX_SPEND_PER_DAY)", snaps[0].SpendLimit)
+	}
+	if snaps[0].SpendPct != 30 {
+		t.Errorf("SpendPct = %d, want 30 (300 of 1000)", snaps[0].SpendPct)
+	}
+	if snaps[0].SpendDay != 300 {
+		t.Errorf("SpendDay = %d, want 300", snaps[0].SpendDay)
+	}
+}

--- a/internal/pool/unfit.go
+++ b/internal/pool/unfit.go
@@ -1,0 +1,74 @@
+package pool
+
+import (
+	"time"
+
+	"freebuff-proxy/internal/upstream"
+)
+
+// modelUnfitTTL is how long a (egress, model) pair stays marked unfit after
+// an upstream limited_ip refusal. A var (not const) so tests can shrink it.
+var modelUnfitTTL = 5 * time.Minute
+
+// unfitEgress is the pool's only egress: the direct connection (SOCKS5/HTTP
+// proxy support was removed — the pool has exactly one egress). The registry
+// still keys (egress, model) so a proxy re-introduction can key per egress
+// without changing the registry shape.
+const unfitEgress = "direct"
+
+// unfitKey is one (egress, model) pair in the model-unfit registry.
+type unfitKey struct {
+	egress string
+	model  string
+}
+
+// unfitEntry is one registry entry: when the (egress, model) pair is unfit
+// until, and the refusal that marked it (for surfacing to the client).
+type unfitEntry struct {
+	until time.Time
+	err   *upstream.LimitedIpError
+}
+
+// MarkModelUnfit records that the pool's egress cannot serve model for the
+// next modelUnfitTTL (upstream limited_ip refusal: the session row is fine,
+// but this egress IP cannot serve this model). nil lie is tolerated; when
+// non-nil its Model is set to the marked model so the surfaced error is
+// self-describing.
+func (p *Pool) MarkModelUnfit(model string, lie *upstream.LimitedIpError) {
+	if lie != nil {
+		lie.Model = model
+	}
+	until := time.Now().Add(modelUnfitTTL)
+	p.unfitMu.Lock()
+	p.unfit[unfitKey{egress: unfitEgress, model: model}] = unfitEntry{until: until, err: lie}
+	p.unfitMu.Unlock()
+	p.logger.Debug("pool: model marked unfit on egress", "egress", unfitEgress, "model", model, "until", until.Format(time.RFC3339))
+}
+
+// ClearModelUnfit removes the unfit mark for model (called after a
+// successful chat on the model: the refusal window is over).
+func (p *Pool) ClearModelUnfit(model string) {
+	p.unfitMu.Lock()
+	delete(p.unfit, unfitKey{egress: unfitEgress, model: model})
+	p.unfitMu.Unlock()
+	p.logger.Debug("pool: model unfit mark cleared", "egress", unfitEgress, "model", model)
+}
+
+// ModelUnfit reports whether model is currently marked unfit on the pool's
+// egress. The zero time.Time means "not unfit"; a nil error means the entry
+// was marked with no refusal detail. Expired entries are purged lazily.
+func (p *Pool) ModelUnfit(model string) (time.Time, *upstream.LimitedIpError) {
+	key := unfitKey{egress: unfitEgress, model: model}
+	now := time.Now()
+	p.unfitMu.Lock()
+	defer p.unfitMu.Unlock()
+	e, ok := p.unfit[key]
+	if !ok {
+		return time.Time{}, nil
+	}
+	if !now.Before(e.until) {
+		delete(p.unfit, key)
+		return time.Time{}, nil
+	}
+	return e.until, e.err
+}

--- a/internal/pool/unfit_test.go
+++ b/internal/pool/unfit_test.go
@@ -1,0 +1,202 @@
+package pool
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"freebuff-proxy/internal/testutil"
+	"freebuff-proxy/internal/upstream"
+)
+
+// limitedBody is the upstream limited_ip refusal wire shape: a 409
+// session_model_mismatch response whose message carries the "limited"
+// marker. classifyError maps that pair to upstream.LimitedIpError (issue
+// #74 P2); SessionMode cannot express it, so tests script it through
+// SessionHandler (see mockupstream.go).
+const limitedBody = `{"status":"session_model_mismatch","message":"model limited on this egress IP"}`
+
+// limitedSessionHandler scripts every session POST as a limited_ip refusal
+// and every session GET as the (irrelevant) ended state, mirroring the
+// handler shape of TestAcquireIpCappedCooldownBounded.
+func limitedSessionHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPost {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = io.WriteString(w, limitedBody)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = io.WriteString(w, `{"status":"ended"}`)
+}
+
+// TestModelUnfitRegistry covers the (egress, model) unfit registry unit
+// behavior: mark/read/clear, nil-lie tolerance, and TTL expiry with the
+// shrunk-window restore.
+func TestModelUnfitRegistry(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	p := newTestPool(t, mock)
+
+	// Absent entry: zero time, nil error.
+	if until, lie := p.ModelUnfit(modelA); !until.IsZero() || lie != nil {
+		t.Fatalf("ModelUnfit on fresh pool = %v/%v, want zero/nil", until, lie)
+	}
+
+	// Mark: until ≈ now+5m, the lie's Model is set to the marked model and
+	// its body is preserved.
+	lie := &upstream.LimitedIpError{Body: "model limited on this egress IP"}
+	p.MarkModelUnfit(modelA, lie)
+	until, got := p.ModelUnfit(modelA)
+	if until.IsZero() {
+		t.Fatal("ModelUnfit after mark = zero time, want ≈ now+5m")
+	}
+	want := time.Now().Add(5 * time.Minute)
+	if d := until.Sub(want); d < -2*time.Second || d > 2*time.Second {
+		t.Errorf("until = %v, want ≈ now+5m (delta %v)", until, d)
+	}
+	if got == nil {
+		t.Fatal("ModelUnfit lie = nil, want the marked error")
+	}
+	if got.Model != modelA {
+		t.Errorf("lie.Model = %q, want %q", got.Model, modelA)
+	}
+	if got.Body != "model limited on this egress IP" {
+		t.Errorf("lie.Body = %q, want preserved body", got.Body)
+	}
+
+	// Clear: entry gone.
+	p.ClearModelUnfit(modelA)
+	if until, lie := p.ModelUnfit(modelA); !until.IsZero() || lie != nil {
+		t.Fatalf("ModelUnfit after clear = %v/%v, want zero/nil", until, lie)
+	}
+
+	// Nil-lie mark: entry present, error nil.
+	p.MarkModelUnfit(modelA, nil)
+	until, got = p.ModelUnfit(modelA)
+	if until.IsZero() || got != nil {
+		t.Fatalf("ModelUnfit with nil lie = %v/%v, want nonzero/nil", until, got)
+	}
+	p.ClearModelUnfit(modelA)
+
+	// Expiry: shrink the TTL, mark, wait past it — the entry is lazily
+	// purged. Restore the package var so later tests see the real window.
+	oldTTL := modelUnfitTTL
+	modelUnfitTTL = 10 * time.Millisecond
+	t.Cleanup(func() { modelUnfitTTL = oldTTL })
+	p.MarkModelUnfit(modelA, &upstream.LimitedIpError{Body: "limited"})
+	time.Sleep(20 * time.Millisecond)
+	if until, lie := p.ModelUnfit(modelA); !until.IsZero() || lie != nil {
+		t.Fatalf("ModelUnfit after TTL expiry = %v/%v, want zero/nil", until, lie)
+	}
+}
+
+// TestAcquireLimitedIpMarksModel covers the admission-path detection: a
+// session POST refused with the limited_ip shape surfaces
+// *upstream.LimitedIpError from Acquire and marks the (egress, model) pair
+// unfit.
+func TestAcquireLimitedIpMarksModel(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.SessionHandler = limitedSessionHandler
+	p := newTestPool(t, mock)
+
+	_, err := p.Acquire(context.Background(), modelA)
+	var lie *upstream.LimitedIpError
+	if !errors.As(err, &lie) {
+		t.Fatalf("Acquire err = %v, want *upstream.LimitedIpError", err)
+	}
+	if !errors.Is(err, upstream.ErrModelIPLimited) {
+		t.Error("Acquire err not unwrap-able to ErrModelIPLimited")
+	}
+	if lie.Model != modelA {
+		t.Errorf("surfaced lie.Model = %q, want %q", lie.Model, modelA)
+	}
+
+	// The refusal marked the (egress, model) pair unfit.
+	until, got := p.ModelUnfit(modelA)
+	if until.IsZero() {
+		t.Fatal("ModelUnfit after limited_ip admission = zero time, want marked")
+	}
+	if got == nil || got.Model != modelA {
+		t.Errorf("ModelUnfit lie = %v, want marked lie for %s", got, modelA)
+	}
+}
+
+// TestAcquireAllTokensLimitedSurfacesLimitedIp covers failover when every
+// token is limited_ip: Acquire surfaces the LimitedIpError bucket, not the
+// generic combined error.
+func TestAcquireAllTokensLimitedSurfacesLimitedIp(t *testing.T) {
+	mock0 := testutil.NewMock()
+	defer mock0.Close()
+	mock0.SessionHandler = limitedSessionHandler
+	mock1 := testutil.NewMock()
+	defer mock1.Close()
+	mock1.SessionHandler = limitedSessionHandler
+	p := newTestPool(t, mock0, mock1)
+
+	_, err := p.Acquire(context.Background(), modelA)
+	var lie *upstream.LimitedIpError
+	if !errors.As(err, &lie) {
+		t.Fatalf("Acquire err = %v, want *upstream.LimitedIpError (not generic combined error)", err)
+	}
+	if lie.Model != modelA {
+		t.Errorf("surfaced lie.Model = %q, want %q", lie.Model, modelA)
+	}
+	if until, _ := p.ModelUnfit(modelA); until.IsZero() {
+		t.Fatal("ModelUnfit after all-tokens-limited acquire = zero time, want marked")
+	}
+}
+
+// TestAcquireNotBlockedByUnfit pins the retry contract: the registry must
+// NOT block Acquire itself. The chat recovery loop re-acquires through the
+// plain acquire closure and must reach a DIFFERENT token in mixed-tier
+// pools; only the server's new-request guard consults the registry.
+func TestAcquireNotBlockedByUnfit(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	p := newTestPool(t, mock)
+
+	p.MarkModelUnfit(modelA, &upstream.LimitedIpError{Body: "limited"})
+
+	lease, err := p.Acquire(context.Background(), modelA)
+	if err != nil {
+		t.Fatalf("Acquire blocked by unfit mark: %v", err)
+	}
+	if lease == nil {
+		t.Fatal("Acquire returned nil lease")
+	}
+	p.LeaseRelease(lease)
+
+	// The mark survives the successful acquire: the pool does not clear it
+	// (the server clears on the chat success path).
+	if until, _ := p.ModelUnfit(modelA); until.IsZero() {
+		t.Fatal("ModelUnfit cleared by Acquire, want mark intact (server clears on chat success)")
+	}
+}
+
+// TestAcquireBanBeatsLimitedIp covers the failover precedence: when one
+// token is banned and another is limited_ip, the ban bucket wins
+// (ban > country-blocked > model-IP-limited > rate-limit > ...).
+func TestAcquireBanBeatsLimitedIp(t *testing.T) {
+	mock0 := testutil.NewMock()
+	defer mock0.Close()
+	mock0.SessionMode = "banned"
+	mock1 := testutil.NewMock()
+	defer mock1.Close()
+	mock1.SessionHandler = limitedSessionHandler
+	p := newTestPool(t, mock0, mock1)
+
+	_, err := p.Acquire(context.Background(), modelA)
+	var be *upstream.BanError
+	if !errors.As(err, &be) {
+		t.Fatalf("Acquire err = %v, want *upstream.BanError (ban > model-IP-limited)", err)
+	}
+	// The limited token still marked the registry during the pass.
+	if until, _ := p.ModelUnfit(modelA); until.IsZero() {
+		t.Fatal("ModelUnfit not marked by the limited token during the pass")
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -73,10 +73,19 @@ var LimitedTierModels = map[string]bool{
 }
 
 // fallbackAgents is the hardcoded model→agent fallback used when the sources
-// are unreachable. Ported verbatim from registry.js (lines 14-41), entry
-// order preserved: first-seen assignment decides which agent owns models that
+// are unreachable. Ported from registry.js (lines 14-41), entry order
+// preserved: first-seen assignment decides which agent owns models that
 // appear in several entries (e.g. the gemini helpers all list the same two
 // models; file-picker-max comes first).
+//
+// Five rows that referenced retired agents (base2-free-laguna-s-2-1,
+// base2-free-laguna-s-2-1-openrouter, base2-free-ling-3-flash,
+// base2-free-greg-2-ultra, base2-free-greg-2-super) were pruned: they were
+// removed from FREE_MODE_AGENT_MODELS on 2026-08-04/08-07
+// (reference/freebuff/common/src/constants/free-agents.ts) and 403
+// free_mode_invalid_agent_model upstream, so a fallback advertising them
+// would list models that cannot run in boot / refresh-failure state
+// (issue #121).
 var fallbackAgents = []agentModels{
 	{agent: "base2-free", models: []string{
 		"deepseek/deepseek-v4-pro",
@@ -91,11 +100,6 @@ var fallbackAgents = []agentModels{
 	{agent: "base2-free-deepseek-flash", models: []string{"deepseek/deepseek-v4-flash"}},
 	{agent: "base2-free-mimo", models: []string{"mimo/mimo-v2.5"}},
 	{agent: "base2-free-glm", models: []string{"z-ai/glm-5.2"}},
-	{agent: "base2-free-laguna-s-2-1", models: []string{"poolside/laguna-s-2.1"}},
-	{agent: "base2-free-laguna-s-2-1-openrouter", models: []string{"openrouter/poolside/laguna-s-2.1"}},
-	{agent: "base2-free-ling-3-flash", models: []string{"inclusionai/ling-3.0-flash:free"}},
-	{agent: "base2-free-greg-2-ultra", models: []string{"crof/greg-2-ultra"}},
-	{agent: "base2-free-greg-2-super", models: []string{"crof/greg-2-super"}},
 	{agent: "base2-free-fable", models: []string{"anthropic/claude-fable-5"}},
 	{agent: "file-picker", models: []string{"google/gemini-2.5-flash-lite"}},
 	{agent: "file-picker-max", models: []string{"google/gemini-3.1-flash-lite", "google/gemini-3.5-flash-lite"}},

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -34,21 +34,16 @@ func fileSource(t *testing.T, path string) string {
 // agents), and the gemini helper models belong to file-picker / file-picker-max
 // (which precede file-lister / researcher-* / basher).
 var expectedFallback = map[string]string{
-	"deepseek/deepseek-v4-pro":         "base2-free",
-	"deepseek/deepseek-v4-flash":       "base2-free",
-	"minimax/minimax-m3":               "base2-free",
-	"openai/gpt-5.6-luna":              "base2-free",
-	"mimo/mimo-v2.5":                   "base2-free",
-	"z-ai/glm-5.2":                     "base2-free-glm",
-	"poolside/laguna-s-2.1":            "base2-free-laguna-s-2-1",
-	"openrouter/poolside/laguna-s-2.1": "base2-free-laguna-s-2-1-openrouter",
-	"inclusionai/ling-3.0-flash:free":  "base2-free-ling-3-flash",
-	"crof/greg-2-ultra":                "base2-free-greg-2-ultra",
-	"crof/greg-2-super":                "base2-free-greg-2-super",
-	"anthropic/claude-fable-5":         "base2-free-fable",
-	"google/gemini-2.5-flash-lite":     "file-picker",
-	"google/gemini-3.1-flash-lite":     "file-picker-max",
-	"google/gemini-3.5-flash-lite":     "file-picker-max",
+	"deepseek/deepseek-v4-pro":     "base2-free",
+	"deepseek/deepseek-v4-flash":   "base2-free",
+	"minimax/minimax-m3":           "base2-free",
+	"openai/gpt-5.6-luna":          "base2-free",
+	"mimo/mimo-v2.5":               "base2-free",
+	"z-ai/glm-5.2":                 "base2-free-glm",
+	"anthropic/claude-fable-5":     "base2-free-fable",
+	"google/gemini-2.5-flash-lite": "file-picker",
+	"google/gemini-3.1-flash-lite": "file-picker-max",
+	"google/gemini-3.5-flash-lite": "file-picker-max",
 }
 
 func TestFallbackMap(t *testing.T) {
@@ -96,6 +91,111 @@ func TestFallbackMap(t *testing.T) {
 
 	if _, err := r.AgentForModel("does/not-exist"); !errors.Is(err, ErrModelNotFound) {
 		t.Errorf("unknown model err = %v, want ErrModelNotFound", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Issue #121 — fallback must not advertise retired agents.
+// ---------------------------------------------------------------------------
+
+// liveFreeModeAgents is a snapshot of the FREE_MODE_AGENT_MODELS allowlist
+// (reference/freebuff/common/src/constants/free-agents.ts) for every agent
+// the fallback table lists. The vendored reference clone is gitignored and
+// only present in the main checkout, so the snapshot lives in the test
+// instead of being parsed at run time; keep it in sync with the reference
+// when free-agents.ts changes.
+var liveFreeModeAgents = map[string][]string{
+	"base2-free": {
+		"deepseek/deepseek-v4-pro",
+		"deepseek/deepseek-v4-flash",
+		"minimax/minimax-m3",
+		"openai/gpt-5.6-luna",
+		"mimo/mimo-v2.5",
+	},
+	"base2-free-deepseek":       {"deepseek/deepseek-v4-pro"},
+	"base2-free-deepseek-flash": {"deepseek/deepseek-v4-flash"},
+	"base2-free-mimo":           {"mimo/mimo-v2.5"},
+	"base2-free-minimax-m3":     {"minimax/minimax-m3"},
+	"base2-free-luna":           {"openai/gpt-5.6-luna"},
+	"base2-free-glm":            {"z-ai/glm-5.2"},
+	"base2-free-fable":          {"anthropic/claude-fable-5"},
+	"file-picker":               {"google/gemini-2.5-flash-lite"},
+	"file-picker-max":           {"google/gemini-3.1-flash-lite", "google/gemini-3.5-flash-lite"},
+	"file-lister":               {"google/gemini-3.1-flash-lite", "google/gemini-3.5-flash-lite"},
+	"researcher-web":            {"google/gemini-3.1-flash-lite", "google/gemini-3.5-flash-lite"},
+	"researcher-docs":           {"google/gemini-3.1-flash-lite", "google/gemini-3.5-flash-lite"},
+	"basher":                    {"google/gemini-3.1-flash-lite", "google/gemini-3.5-flash-lite"},
+	"code-reviewer-lite":        {"deepseek/deepseek-v4-pro", "deepseek/deepseek-v4-flash", "mimo/mimo-v2.5"},
+}
+
+// retiredFallbackAgents are the five fallback rows pruned for issue #121:
+// all were removed from FREE_MODE_AGENT_MODELS on 2026-08-04/08-07
+// (reference/freebuff/common/src/constants/free-agents.ts) and now 403
+// free_mode_invalid_agent_model upstream.
+var retiredFallbackAgents = []string{
+	"base2-free-laguna-s-2-1",
+	"base2-free-laguna-s-2-1-openrouter",
+	"base2-free-ling-3-flash",
+	"base2-free-greg-2-ultra",
+	"base2-free-greg-2-super",
+}
+
+// TestFallbackAgentsLiveOnly pins issue #121: every fallback agent and model
+// must exist in the live FREE_MODE_AGENT_MODELS allowlist, the five retired
+// rows must stay pruned, and the alive rows the JS fallback table lists must
+// still be present. In fallback state (boot before first refresh, or refresh
+// failures) /v1/models is built from this table, so a dead row would advertise
+// a model that cannot run.
+func TestFallbackAgentsLiveOnly(t *testing.T) {
+	fallback := make(map[string][]string, len(fallbackAgents))
+	for _, entry := range fallbackAgents {
+		fallback[entry.agent] = entry.models
+	}
+
+	// Every fallback entry must exist in the live allowlist with its models
+	// allowed for that agent.
+	for agent, models := range fallback {
+		allowed, ok := liveFreeModeAgents[agent]
+		if !ok {
+			t.Errorf("fallback agent %q is absent from FREE_MODE_AGENT_MODELS (reference/freebuff/common/src/constants/free-agents.ts)", agent)
+			continue
+		}
+		for _, model := range models {
+			if !contains(allowed, model) {
+				t.Errorf("fallback agent %q model %q is not in its FREE_MODE_AGENT_MODELS allowlist", agent, model)
+			}
+		}
+	}
+
+	// The five retired rows must stay pruned.
+	for _, agent := range retiredFallbackAgents {
+		if _, ok := fallback[agent]; ok {
+			t.Errorf("retired fallback agent %q is still advertised (issue #121)", agent)
+		}
+	}
+
+	// The alive rows the JS fallback table lists must still be present.
+	for agent := range liveFreeModeAgents {
+		if _, ok := fallback[agent]; !ok {
+			t.Errorf("live fallback agent %q missing from fallbackAgents", agent)
+		}
+	}
+
+	// User-visible acceptance: in fallback state the dead model ids must not
+	// resolve to an agent (a request would otherwise send x-freebuff-model
+	// upstream and 403 free_mode_invalid_agent_model).
+	r := New(nil, nil)
+	r.LoadFallback()
+	for _, model := range []string{
+		"poolside/laguna-s-2.1",
+		"openrouter/poolside/laguna-s-2.1",
+		"inclusionai/ling-3.0-flash:free",
+		"crof/greg-2-ultra",
+		"crof/greg-2-super",
+	} {
+		if _, err := r.AgentForModel(model); !errors.Is(err, ErrModelNotFound) {
+			t.Errorf("AgentForModel(%q) after LoadFallback = %v, want ErrModelNotFound (issue #121)", model, err)
+		}
 	}
 }
 

--- a/internal/runs/runs.go
+++ b/internal/runs/runs.go
@@ -16,6 +16,7 @@ package runs
 import (
 	"context"
 	cryptoRand "crypto/rand"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -31,6 +32,21 @@ import (
 // DefaultCooldown is the token cooldown applied on upstream auth rejection
 // (PRD §5.3: "401 triggers 30-min token cooldown").
 const DefaultCooldown = 30 * time.Minute
+
+// maxIpCappedReAdmitsPerDay caps how many times one token may re-admit
+// (and be refused ip_capped again) per Pacific day before it is locked
+// until the next Pacific midnight. The CLI treats ip_capped as
+// terminal-until-reset — it never loops an automatic re-admission — so the
+// proxy mirrors that with this bounded budget instead of pacing an endless
+// POST loop (issue #118). Test-shrinkable like the pool's unfit TTL
+// (internal/pool/unfit.go modelUnfitTTL).
+var maxIpCappedReAdmitsPerDay = 3
+
+// ipCappedCooldownJitter is the ±fraction of retryAfterMs applied to the
+// ip_capped re-admission window so concurrent tokens do not re-admit in
+// lockstep (mirrors the CLI's 30s±20% poll jitter; reference/freebuff
+// cli/src/hooks/use-freebuff-session.ts).
+const ipCappedCooldownJitter = 0.2
 
 // countryBlockCooldown is the token cooldown applied when upstream reports a
 // region block (country_blocked): long enough to stop the request hammer
@@ -205,6 +221,17 @@ type RunManager struct {
 	// ip_capped + Retry-After instead of a generic cooldown 502.
 	ipCapped      *upstream.IpCappedError
 	ipCappedUntil time.Time
+	// ipCappedReAdmits counts how many times this token has been refused
+	// ip_capped during the current Pacific day (issue #118): after
+	// maxIpCappedReAdmitsPerDay refusals the token is locked until the
+	// next Pacific midnight instead of re-admitting in a pacing loop.
+	// Guarded by mu.
+	ipCappedReAdmits int
+	// ipCappedDayReset is the Pacific midnight that ends the day
+	// ipCappedReAdmits was counted in (upstream.NextPacificMidnight at the
+	// first refusal that day); a new midnight resets the budget. Guarded
+	// by mu.
+	ipCappedDayReset time.Time
 	// totalRequests is the cumulative count of Acquire leases handed out.
 	// It is kept separate from the per-run counters because rotated runs
 	// that get FINISHed leave the active+draining sets and would otherwise
@@ -621,6 +648,8 @@ func (m *RunManager) Cooldown(d time.Duration) {
 	m.banUntil = time.Time{}
 	m.countryUntil = time.Time{}
 	m.ipCappedUntil = time.Time{}
+	m.ipCappedReAdmits = 0
+	m.ipCappedDayReset = time.Time{}
 	m.mu.Unlock()
 }
 
@@ -636,6 +665,8 @@ func (m *RunManager) ClearCooldowns() {
 	m.countryUntil = time.Time{}
 	m.ipCapped = nil
 	m.ipCappedUntil = time.Time{}
+	m.ipCappedReAdmits = 0
+	m.ipCappedDayReset = time.Time{}
 	m.mu.Unlock()
 }
 
@@ -670,25 +701,63 @@ func (m *RunManager) CooldownRateLimit(rle *upstream.RateLimitError) {
 
 // CooldownIpCapped applies an ip_capped cooldown bounded to the body's
 // retryAfterMs ONLY — never the Pacific-midnight quota lock (ip_capped is
-// admission-only, not tied to a quota reset). Remembered so Acquires keep
-// surfacing 429 ip_capped + Retry-After during the short window instead of
+// admission-only, not tied to a quota reset). The window honors the FULL
+// retryAfterMs plus the CLI's ±20% poll jitter (#118). The CLI treats
+// ip_capped as terminal-until-reset — it never loops an automatic
+// re-admission — so the token's re-admission budget is capped at
+// maxIpCappedReAdmitsPerDay per Pacific day: once exhausted the token stays
+// locked (remembered 429 ip_capped + Retry-After reflecting the remaining
+// window) until the next Pacific midnight. Remembered so Acquires keep
+// surfacing 429 ip_capped + Retry-After during the window instead of
 // re-hitting upstream (mirrors CooldownRateLimit). Errors with
 // RetryAfter <= 0 are ignored.
 func (m *RunManager) CooldownIpCapped(ice *upstream.IpCappedError) {
-	if ice == nil {
+	if ice == nil || ice.RetryAfter <= 0 {
 		return
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if ice.RetryAfter <= 0 {
-		return
+	now := time.Now()
+	reset := upstream.NextPacificMidnight()
+	if m.ipCappedDayReset.IsZero() || !m.ipCappedDayReset.Equal(reset) {
+		// New Pacific day (or first refusal): fresh re-admission budget.
+		m.ipCappedReAdmits = 0
+		m.ipCappedDayReset = reset
 	}
-	m.ipCapped = ice
-	m.ipCappedUntil = time.Now().Add(ice.RetryAfter)
-	m.cooldownUntil = m.ipCappedUntil
+	m.ipCappedReAdmits++
 	m.rateLimit = nil
 	m.ban = nil
 	m.countryBlock = nil
+	if m.ipCappedReAdmits >= maxIpCappedReAdmitsPerDay {
+		// Budget exhausted: terminal until the next Pacific reset. Surface
+		// the REMAINING window as Retry-After so downstream 429s are honest
+		// about the lock instead of promising a re-admit that will not
+		// happen today.
+		terminal := *ice
+		terminal.RetryAfter = time.Until(reset)
+		m.ipCapped = &terminal
+		m.ipCappedUntil = reset
+		m.cooldownUntil = reset
+		return
+	}
+	m.ipCapped = ice
+	m.ipCappedUntil = now.Add(ice.RetryAfter).Add(ipCappedJitter(ice.RetryAfter))
+	m.cooldownUntil = m.ipCappedUntil
+}
+
+// ipCappedJitter returns a one-sided jitter of up to
+// ipCappedCooldownJitter (20%) of base, crypto/rand-seeded so concurrent
+// tokens never re-admit in lockstep (mirrors the CLI's 30s±20% poll
+// jitter; reference/freebuff cli/src/hooks/use-freebuff-session.ts).
+func ipCappedJitter(base time.Duration) time.Duration {
+	if base <= 0 {
+		return 0
+	}
+	var b [8]byte
+	_, _ = cryptoRand.Read(b[:])
+	u := binary.BigEndian.Uint64(b[:])
+	extra := int64(u % uint64(float64(base)*ipCappedCooldownJitter))
+	return time.Duration(extra)
 }
 
 // IpCappedError returns the remembered ip_capped error while its short

--- a/internal/runs/runs_test.go
+++ b/internal/runs/runs_test.go
@@ -499,6 +499,90 @@ func TestCountryBlockCooldown(t *testing.T) {
 	}
 }
 
+// TestCooldownIpCappedCapsReAdmits pins #118: the CLI treats ip_capped as
+// terminal-until-reset (never an automatic re-admission loop), so the
+// proxy's CooldownIpCapped honors the FULL retryAfterMs (+jitter) for the
+// first refusals of a Pacific day, then locks the token until the next
+// Pacific midnight after maxIpCappedReAdmitsPerDay — with the remembered
+// error's Retry-After reflecting the remaining window.
+func TestCooldownIpCappedCapsReAdmits(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mgr, _ := newTestManager(t, mock, time.Hour)
+
+	ice := &upstream.IpCappedError{ActiveUsersForIP: 8, Limit: 6, RetryAfter: 60 * time.Second, Body: `{"status":"ip_capped"}`}
+
+	// Refusals 1..max-1: bounded window = full retryAfterMs + jitter (the
+	// jitter only ever extends the window, never shrinks it).
+	for i := 1; i < maxIpCappedReAdmitsPerDay; i++ {
+		mgr.CooldownIpCapped(ice)
+		until := mgr.CooldownUntil()
+		if !time.Now().Before(until) {
+			t.Fatalf("refusal %d: cooldown already expired, want now+retryAfter(+jitter)", i)
+		}
+		if time.Until(until) < ice.RetryAfter-time.Second {
+			t.Errorf("refusal %d: window %v shorter than retryAfterMs %v (jitter must not shrink it)",
+				i, time.Until(until), ice.RetryAfter)
+		}
+		if got := mgr.IpCappedError(); got == nil || got.RetryAfter != 60*time.Second {
+			t.Errorf("refusal %d: IpCappedError = %+v, want remembered original window", i, got)
+		}
+	}
+
+	// Budget exhausted: terminal until the next Pacific midnight.
+	mgr.CooldownIpCapped(ice)
+	want := upstream.NextPacificMidnight()
+	if until := mgr.CooldownUntil(); until.Sub(want) > time.Second || want.Sub(until) > time.Second {
+		t.Errorf("terminal lock until = %v, want ~Pacific midnight %v", until, want)
+	}
+	got := mgr.IpCappedError()
+	if got == nil {
+		t.Fatal("IpCappedError() = nil after budget exhausted, want remembered terminal error")
+	}
+	if got.RetryAfter < time.Minute {
+		t.Errorf("terminal RetryAfter = %v, want the remaining window to midnight (>= 1m)", got.RetryAfter)
+	}
+
+	// Further refusals the same day must not move the lock (no re-admit loop).
+	first := mgr.CooldownUntil()
+	mgr.CooldownIpCapped(ice)
+	if until := mgr.CooldownUntil(); !until.Equal(first) {
+		t.Errorf("terminal lock moved on extra refusal: %v -> %v", first, until)
+	}
+
+	// Acquire skips the token during the terminal window (shared cooldown).
+	if _, err := mgr.Acquire(context.Background(), agentA); err == nil {
+		t.Error("Acquire during terminal ip_capped lock succeeded, want skip error")
+	}
+
+	// Pacific day rollover resets the budget: the next refusal gets a
+	// bounded window again instead of staying locked.
+	mgr.mu.Lock()
+	mgr.ipCappedDayReset = time.Time{} // force the "new day" branch
+	mgr.mu.Unlock()
+	mgr.CooldownIpCapped(ice)
+	until := mgr.CooldownUntil()
+	if until.Equal(want) {
+		t.Fatal("lock did not lift on the new Pacific day")
+	}
+	if !time.Now().Before(until) || time.Until(until) > ice.RetryAfter+2*time.Minute {
+		t.Errorf("post-reset window = %v, want now+retryAfterMs(+jitter)", time.Until(until))
+	}
+
+	// ClearCooldowns (dashboard unlock) resets the budget too.
+	mgr.CooldownIpCapped(ice)
+	mgr.CooldownIpCapped(ice)
+	mgr.CooldownIpCapped(ice)
+	if !time.Now().Before(mgr.CooldownUntil()) {
+		t.Fatal("expected terminal lock before ClearCooldowns")
+	}
+	mgr.ClearCooldowns()
+	mgr.CooldownIpCapped(ice)
+	if until := mgr.CooldownUntil(); !time.Now().Before(until) || time.Until(until) > ice.RetryAfter+2*time.Minute {
+		t.Errorf("post-ClearCooldowns window = %v, want bounded window (budget reset)", time.Until(until))
+	}
+}
+
 func TestCountryBlockDoesNotDowngradeBan(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()

--- a/internal/server/auth_internal_test.go
+++ b/internal/server/auth_internal_test.go
@@ -436,3 +436,41 @@ func TestQuotaSummaryTierAndGlmPromo(t *testing.T) {
 		}
 	}
 }
+
+// TestWriteErrorModelIPLimited pins the Issue #74 P2 writeError mapping:
+// *upstream.LimitedIpError → 409, code model_ip_limited, Retry-After = ceil
+// seconds of lie.RetryAfter (only when > 0 — the body window is surfaced but
+// never sets the unfit registry TTL).
+func TestWriteErrorModelIPLimited(t *testing.T) {
+	err := &upstream.LimitedIpError{
+		RetryAfter: 5 * time.Minute,
+		Body:       `{"status":"session_model_mismatch","message":"model z-ai/glm-5.2 is limited on this IP"}`,
+	}
+	status, body := errorResponse(t, err)
+	if status != http.StatusConflict {
+		t.Errorf("status = %d, want 409", status)
+	}
+	if body.Error.Code != "model_ip_limited" {
+		t.Errorf("code = %q, want model_ip_limited", body.Error.Code)
+	}
+	if !strings.Contains(body.Error.Message, "model limited on this egress IP") {
+		t.Errorf("message = %q, want limited-egress phrasing", body.Error.Message)
+	}
+
+	// Retry-After header: ceil seconds of RetryAfter, only when > 0.
+	s := &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	s.writeError(w, r, err)
+	if got := w.Header().Get("Retry-After"); got != "300" {
+		t.Errorf("Retry-After = %q, want 300", got)
+	}
+
+	// A zero RetryAfter must not emit the header.
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	s.writeError(w2, r2, &upstream.LimitedIpError{Body: "no window"})
+	if got := w2.Header().Get("Retry-After"); got != "" {
+		t.Errorf("Retry-After with zero RetryAfter = %q, want empty", got)
+	}
+}

--- a/internal/server/auth_internal_test.go
+++ b/internal/server/auth_internal_test.go
@@ -474,3 +474,43 @@ func TestWriteErrorModelIPLimited(t *testing.T) {
 		t.Errorf("Retry-After with zero RetryAfter = %q, want empty", got)
 	}
 }
+
+// TestWriteErrorWaitingRoomRequired pins #116: a 428 waiting_room_required
+// (FREEBUFF_GATE_CODES endsTheSession:true) must surface 503 with code
+// waiting_room_required + Retry-After — never the generic 502 default.
+func TestWriteErrorWaitingRoomRequired(t *testing.T) {
+	err := &upstream.WaitingRoomRequiredError{RetryAfter: 45 * time.Second, Detail: `{"error":"waiting_room_required"}`}
+	status, body := errorResponse(t, err)
+	if status != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", status)
+	}
+	if body.Error.Code != "waiting_room_required" {
+		t.Errorf("code = %q, want waiting_room_required (not upstream_unavailable)", body.Error.Code)
+	}
+	if !strings.Contains(body.Error.Message, "retry after 45s") {
+		t.Errorf("message = %q, want the Retry-After detail", body.Error.Message)
+	}
+
+	// Retry-After header is emitted from the error's window.
+	s := &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	s.writeError(w, r, err)
+	if got := w.Header().Get("Retry-After"); got != "45" {
+		t.Errorf("Retry-After = %q, want 45", got)
+	}
+}
+
+// TestWriteErrorSessionSuperseded pins #119: a 409 session_superseded chat
+// gate is terminal and surfaces 409 with code session_superseded (never the
+// session-invalid 502).
+func TestWriteErrorSessionSuperseded(t *testing.T) {
+	err := fmt.Errorf("%w: session_superseded (Retry-After 0s)", upstream.ErrSessionSuperseded)
+	status, body := errorResponse(t, err)
+	if status != http.StatusConflict {
+		t.Errorf("status = %d, want 409", status)
+	}
+	if body.Error.Code != "session_superseded" {
+		t.Errorf("code = %q, want session_superseded", body.Error.Code)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1890,7 +1890,7 @@ func (s *Server) chatCore(w http.ResponseWriter, r *http.Request, model string, 
 			}
 			phases.Since(phasetiming.TotalMS, start)
 			s.logger.Info(kind+" request refused", "model", model, "reason", "model_limited_on_egress", "until", until.Format(time.RFC3339))
-			var refuseErr error = upstream.ErrModelIPLimited
+			var refuseErr = upstream.ErrModelIPLimited
 			if lie != nil {
 				refuseErr = lie
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1875,6 +1875,30 @@ func (s *Server) chatCore(w http.ResponseWriter, r *http.Request, model string, 
 		// requests fall back to the pool.
 		bridge = tok != ""
 	}
+	// Issue #74 P2: refuse new requests fast when (egress, model) is marked
+	// unfit — the direct egress cannot serve this model for ~5 min. The
+	// pooled path only: bridge clients relay their own token (the client's
+	// own account may serve the model on this egress and their session
+	// slots are theirs to spend), so the registry never gates them.
+	// MarkModelUnfit always stores a LimitedIpError, so lie is non-nil in
+	// practice; the bare sentinel keeps the refusal deterministic if it
+	// ever is nil.
+	if !bridge {
+		if until, lie := s.pool.ModelUnfit(model); !until.IsZero() && time.Now().Before(until) {
+			if lie != nil {
+				lie.RetryAfter = time.Until(until)
+			}
+			phases.Since(phasetiming.TotalMS, start)
+			s.logger.Info(kind+" request refused", "model", model, "reason", "model_limited_on_egress", "until", until.Format(time.RFC3339))
+			var refuseErr error = upstream.ErrModelIPLimited
+			if lie != nil {
+				refuseErr = lie
+			}
+			s.traceChat(nil, model, time.Since(start).Milliseconds(), "error", "model_ip_limited", phases.All())
+			s.writeError(w, r, refuseErr)
+			return
+		}
+	}
 	// Acquire is timed per call; on the retry-once path the last acquire
 	// wins (that is the lease-producing one, matching the pool's
 	// per-attempt session/run phases).
@@ -2048,6 +2072,8 @@ func chatErrClass(err error) string {
 		return "banned"
 	case *upstream.IpCappedError:
 		return "ip_capped"
+	case *upstream.LimitedIpError:
+		return "model_ip_limited"
 	case *upstream.SessionLimitError:
 		return "session_limit_reached"
 	case *upstream.WaitingRoomError, *session.WaitingRoomError:
@@ -2144,11 +2170,32 @@ func (s *Server) chatAttempt(
 	for {
 		up, err = chat(ctx, lease, opts, normalized)
 		if err == nil {
+			// Issue #74 P2: a successful chat is egress-level proof the
+			// model is servable again — drop any (egress, model) unfit mark.
+			s.pool.ClearModelUnfit(effectiveModel)
 			released = true // Disarm deferred release: ownership transferred to caller
 			return up, lease, nil
 		}
 		attempts++
 		switch {
+		case errors.Is(err, upstream.ErrModelIPLimited):
+			// Issue #74 P2: the egress IP is limited for the requested
+			// model. Mark (egress, model) unfit for ~5 min so new requests
+			// refuse fast instead of re-admitting against a known-limited
+			// gate (each admission burns a daily session slot). Retry once
+			// through a fresh acquire — a different token (full-tier
+			// account) may still serve the model. The session is bound to
+			// its admitted model and is NOT invalidated.
+			var lie *upstream.LimitedIpError
+			if errors.As(err, &lie) {
+				s.pool.MarkModelUnfit(effectiveModel, lie)
+			} else {
+				s.pool.MarkModelUnfit(effectiveModel, nil)
+			}
+			release()
+			if attempts > 1 {
+				return nil, nil, err
+			}
 		case errors.Is(err, upstream.ErrSessionInvalid):
 			release()
 			invalidateSession(lease)
@@ -2778,6 +2825,7 @@ func (s *Server) writeError(w http.ResponseWriter, r *http.Request, err error) {
 	var rle *upstream.RateLimitError
 	var ice *upstream.IpCappedError
 	var sle *upstream.SessionLimitError
+	var lie *upstream.LimitedIpError
 	var be *upstream.BanError
 	var cbe *upstream.CountryBlockedError
 	var ce *upstream.CreditsError
@@ -2812,6 +2860,16 @@ func (s *Server) writeError(w http.ResponseWriter, r *http.Request, err error) {
 		message = sle.Body
 		if message == "" {
 			message = "session limit reached"
+		}
+	case errors.As(err, &lie):
+		// Issue #74 P2: the egress IP cannot serve the requested model.
+		// 409 (not a quota lock): a different egress or a full-tier token
+		// may still serve the model. The body's retryAfterMs is surfaced
+		// as Retry-After but does not set the unfit window.
+		status, code = http.StatusConflict, "model_ip_limited"
+		message, retryAfter = lie.Error(), lie.RetryAfter
+		if retryAfter < 0 {
+			retryAfter = 0
 		}
 	case errors.As(err, &wr):
 		status, code = http.StatusServiceUnavailable, "waiting_room_queued"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2211,6 +2211,24 @@ func (s *Server) chatAttempt(
 			if attempts > 1 {
 				return nil, nil, err
 			}
+		case errors.Is(err, upstream.ErrSessionSuperseded):
+			// 409 session_superseded chat gate: another process owns the
+			// account row (FREEBUFF_GATE_CODES endsTheSession:true). The CLI
+			// stops polling and never auto-rejoins — an automatic takeover
+			// would ping-pong with the live second client. Invalidate the
+			// dead row so the NEXT request re-joins, but surface the refusal
+			// as TERMINAL: no auto-POST (#119).
+			release()
+			invalidateSession(lease)
+			return nil, nil, err
+		case errors.Is(err, upstream.ErrCredits):
+			// 402: the CLI throws immediately and 402 is not in its
+			// retryable set (reference/freebuff packages/agent-runtime/src/
+			// run-agent-step.ts:1344 and sdk/src/error-utils.ts:16). A blind
+			// second chat POST after "out of credits" is a pacing pattern
+			// the CLI never exhibits (#117).
+			release()
+			return nil, nil, err
 		case errors.Is(err, upstream.ErrSessionInvalid):
 			release()
 			invalidateSession(lease)
@@ -2243,9 +2261,13 @@ func (s *Server) chatAttempt(
 			return nil, nil, err
 		case errors.Is(err, upstream.ErrIpCapped):
 			// ip_capped is admission-only (too many distinct users on the
-			// egress IP), NOT a quota reset: cool the token only until the
-			// body's retryAfterMs — never the Pacific-midnight lock — and
-			// never invalidate the session (existing sessions keep running).
+			// egress IP), NOT a quota reset: cool the token until the
+			// body's retryAfterMs (+jitter) — never the Pacific-midnight
+			// lock on first refusals — and never invalidate the session
+			// (existing sessions keep running). #118 bounds the re-admission
+			// loop: after maxIpCappedReAdmitsPerDay refusals in one Pacific
+			// day the token is locked until the next reset (see
+			// runs.CooldownIpCapped).
 			var ice *upstream.IpCappedError
 			if errors.As(err, &ice) {
 				cooldownIpCapped(lease, ice)
@@ -2590,9 +2612,21 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 			"Messages24h":          snap.Messages24h,
 			"DailyLimit":           snap.DailyLimit,
 			"UsagePct":             snap.UsagePct,
-			"RiskLevel":            snap.RiskLevel,
-			"tier":                 snap.TierAccess,
-			"country":              snap.CountryCode,
+			// Spend ledger (issue #87/#122): Pacific-day/week/month buckets
+			// plus the advisory MAX_SPEND_PER_DAY ceiling (SpendLimit/
+			// SpendPct, informational — the upstream $ ceilings are
+			// server-enforced) and the spend_limited refusal counter.
+			"Spend24h":      snap.Spend24h,
+			"SpendDay":      snap.SpendDay,
+			"SpendWeek":     snap.SpendWeek,
+			"SpendMonth":    snap.SpendMonth,
+			"SpendDayStart": snap.SpendDayStart,
+			"SpendLimit":    snap.SpendLimit,
+			"SpendPct":      snap.SpendPct,
+			"SpendLimited":  snap.SpendLimited,
+			"RiskLevel":     snap.RiskLevel,
+			"tier":          snap.TierAccess,
+			"country":       snap.CountryCode,
 		}
 		if len(snap.QuotaByModel) > 0 {
 			quota := make(map[string]any, len(snap.QuotaByModel))
@@ -2842,6 +2876,7 @@ func (s *Server) writeError(w http.ResponseWriter, r *http.Request, err error) {
 
 	var wr *session.WaitingRoomError
 	var uwr *upstream.WaitingRoomError
+	var uwrr *upstream.WaitingRoomRequiredError
 	var ue *upstream.UpstreamError
 	var rle *upstream.RateLimitError
 	var ice *upstream.IpCappedError
@@ -2899,6 +2934,14 @@ func (s *Server) writeError(w http.ResponseWriter, r *http.Request, err error) {
 	case errors.As(err, &uwr):
 		status, code = http.StatusServiceUnavailable, "waiting_room_queued"
 		message, retryAfter = uwr.Error(), uwr.RetryAfter
+	case errors.As(err, &uwrr):
+		// 428 waiting_room_required (FREEBUFF_GATE_CODES
+		// endsTheSession:true): the session row is ENDED upstream and the
+		// account must walk the reference pre-session flow before the next
+		// create. Terminal for this request — 503 + Retry-After, never the
+		// generic 502 (#116).
+		status, code = http.StatusServiceUnavailable, "waiting_room_required"
+		message, retryAfter = uwrr.Error(), uwrr.RetryAfter
 	case errors.As(err, &cde):
 		// #105 (server half): the client's capacity-deferred retry budget
 		// (TRANSIENT_RETRIES) is exhausted, so the free tier's transient
@@ -2941,6 +2984,12 @@ func (s *Server) writeError(w http.ResponseWriter, r *http.Request, err error) {
 		message = err.Error()
 	case errors.Is(err, upstream.ErrWaitingRoom):
 		status, code = http.StatusServiceUnavailable, "waiting_room_queued"
+		message = err.Error()
+	case errors.Is(err, upstream.ErrSessionSuperseded):
+		// 409 session_superseded chat gate: another process owns the
+		// account row — terminal for the client (#119). The next request
+		// re-joins via a fresh admission; no auto-POST here.
+		status, code = http.StatusConflict, "session_superseded"
 		message = err.Error()
 	case errors.As(err, &cbe):
 		status, code = http.StatusForbidden, "country_blocked"

--- a/internal/server/server_edge_test.go
+++ b/internal/server/server_edge_test.go
@@ -540,13 +540,15 @@ func TestChatCountryBlockCooldown(t *testing.T) {
 }
 
 // TestBridgeChatSessionInvalidBoundedRetry pins the bridge-path recovery
-// budget: a session_superseded chat error recreates the session once and
+// budget: a session-expired chat error recreates the session once and
 // retries, then fails with 502 — never an unbounded recreate loop.
+// (session_superseded is terminal since #119 — see
+// TestBridgeChatSessionSupersededTerminal.)
 func TestBridgeChatSessionInvalidBoundedRetry(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	mock.ChatStatus = http.StatusBadRequest
-	mock.ChatErrorBody = `{"error":{"message":"session_superseded"}}`
+	mock.ChatErrorBody = `{"error":{"message":"session_expired"}}`
 	ts, _ := newBridgeTestServer(t, mock)
 
 	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA),
@@ -562,6 +564,32 @@ func TestBridgeChatSessionInvalidBoundedRetry(t *testing.T) {
 	}
 	if got := mock.SessionCreates; got != 2 {
 		t.Errorf("upstream session creates = %d, want exactly 2 (session recreated once)", got)
+	}
+}
+
+// TestBridgeChatSessionSupersededTerminal pins #119 on the bridge path: a
+// 409 session_superseded chat gate is terminal — exactly one upstream chat
+// call and no session recreate, surfaced as 409 session_superseded.
+func TestBridgeChatSessionSupersededTerminal(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.ChatStatus = http.StatusConflict
+	mock.ChatErrorBody = `{"error":{"message":"session_superseded"}}`
+	ts, _ := newBridgeTestServer(t, mock)
+
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA),
+		map[string]string{"Authorization": "Bearer client-tok-ss"})
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, data)
+	}
+	if !strings.Contains(string(data), "session_superseded") {
+		t.Errorf("body missing session_superseded code: %s", data)
+	}
+	if got := len(mock.RecordedChatHeaders); got != 1 {
+		t.Errorf("upstream chat attempts = %d, want 1 (no auto-POST)", got)
+	}
+	if got := mock.SessionCreates; got != 1 {
+		t.Errorf("upstream session creates = %d, want exactly 1 (initial admission only)", got)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1798,3 +1798,210 @@ func TestBearerCaseInsensitiveVariants(t *testing.T) {
 		}
 	})
 }
+
+// --- Issue #74 P2: per-(egress, model) unfit registry ---
+
+// limitedChatBody renders the upstream 409 body classifyError maps to
+// upstream.LimitedIpError (session_model_mismatch + "limited" marker).
+func limitedChatBody() string {
+	return `{"status":"session_model_mismatch","message":"model ` + modelA + ` is limited on this IP"}`
+}
+
+// errorCode extracts the OpenAI error.code from a response body.
+func errorCode(t *testing.T, data []byte) string {
+	t.Helper()
+	var body struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(data, &body); err != nil {
+		t.Fatalf("body is not the OpenAI error shape: %v: %s", err, data)
+	}
+	return body.Error.Code
+}
+
+// writeRawJSON writes a pre-formatted JSON body (the mock's writeJSON helper
+// is unexported; scripted ChatHandler/SessionHandler tests write raw bodies).
+func writeRawJSON(w http.ResponseWriter, status int, raw string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = io.WriteString(w, raw)
+}
+
+// TestChatModelIPLimitedMarked pins the chat-level limited_ip flow: a 409
+// session_model_mismatch+limited chat error surfaces as 409 model_ip_limited
+// (never session-invalid, never a session invalidation) and marks the
+// (egress, model) pairing unfit.
+func TestChatModelIPLimitedMarked(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.ChatStatus = http.StatusConflict
+	mock.ChatErrorBody = limitedChatBody()
+	ts, p := newTestServer(t, nil, mock)
+	chatURL := ts.URL + "/v1/chat/completions"
+
+	resp, data := doJSON(t, http.MethodPost, chatURL, chatBody(modelA), nil)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, data)
+	}
+	if got := errorCode(t, data); got != "model_ip_limited" {
+		t.Errorf("code = %q, want model_ip_limited", got)
+	}
+	until, _ := p.ModelUnfit(modelA)
+	if until.IsZero() {
+		t.Error("pool unfit not set after limited chat")
+	}
+}
+
+// TestChatModelIPLimitedFastRefusal pins the fast-refusal guard: while
+// (egress, model) is marked unfit, a new request is refused at the entry
+// guard with 409 model_ip_limited and NO new upstream chat call. The first
+// (marking) request retries once inside chatAttempt, so it hits upstream
+// twice.
+func TestChatModelIPLimitedFastRefusal(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	var chatCalls atomic.Int32
+	mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
+		chatCalls.Add(1)
+		writeRawJSON(w, http.StatusConflict, limitedChatBody())
+	}
+	ts, p := newTestServer(t, nil, mock)
+	chatURL := ts.URL + "/v1/chat/completions"
+
+	// First request: the limited error marks unfit and chatAttempt retries
+	// once through a fresh acquire (a different token may still serve the
+	// model) before surfacing the 409 — exactly two upstream chat calls.
+	resp, data := doJSON(t, http.MethodPost, chatURL, chatBody(modelA), nil)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("first request status = %d, want 409: %s", resp.StatusCode, data)
+	}
+	if got := chatCalls.Load(); got != 2 {
+		t.Errorf("first request upstream chat calls = %d, want 2 (retry-once)", got)
+	}
+	if until, _ := p.ModelUnfit(modelA); until.IsZero() {
+		t.Fatal("unfit not marked after first request")
+	}
+
+	// Second request: refused at the entry guard — no upstream chat hit.
+	resp2, data2 := doJSON(t, http.MethodPost, chatURL, chatBody(modelA), nil)
+	if resp2.StatusCode != http.StatusConflict {
+		t.Fatalf("second request status = %d, want 409: %s", resp2.StatusCode, data2)
+	}
+	if got := errorCode(t, data2); got != "model_ip_limited" {
+		t.Errorf("second request code = %q, want model_ip_limited", got)
+	}
+	if got := chatCalls.Load(); got != 2 {
+		t.Errorf("second request upstream chat calls = %d, want 2 (fast-refused, no new chat)", got)
+	}
+}
+
+// TestChatModelIPLimitedSuccessClears pins the success-side clear: a
+// successful chat is egress-level proof the model is servable again, so the
+// unfit mark is dropped. The mark is cleared between requests (simulating
+// the window lapsing) so the second request passes the entry guard and
+// reaches chatAttempt, where its retry lands on the 200.
+func TestChatModelIPLimitedSuccessClears(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	var chatCalls atomic.Int32
+	mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
+		// Calls 1-2: request 1's two chatAttempt attempts both see the
+		// limited 409 (marking the pair unfit). Call 3: request 2's first
+		// attempt (re-marks). Call 4+: the upstream serves the model again,
+		// so request 2's retry lands on the 200 and clears the mark.
+		if chatCalls.Add(1) <= 3 {
+			writeRawJSON(w, http.StatusConflict, limitedChatBody())
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, testutil.SSEEvent(chunk("chatcmpl-u1", 1, `"choices":[{"index":0,"delta":{"content":"recovered"},"finish_reason":null}]`)))
+	}
+	ts, p := newTestServer(t, nil, mock)
+	chatURL := ts.URL + "/v1/chat/completions"
+
+	// First request: limited 409 (both retry attempts limited).
+	resp, data := doJSON(t, http.MethodPost, chatURL, chatBody(modelA), nil)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("first request status = %d, want 409: %s", resp.StatusCode, data)
+	}
+	if until, _ := p.ModelUnfit(modelA); until.IsZero() {
+		t.Fatal("unfit not marked after limited response")
+	}
+
+	// Simulate the unfit window lapsing so the second request is not
+	// fast-refused at the entry guard — it must reach chatAttempt, where
+	// the retry lands on the 200 and the success path clears the mark.
+	p.ClearModelUnfit(modelA)
+
+	resp2, data2 := doJSON(t, http.MethodPost, chatURL, chatBody(modelA), nil)
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("second request status = %d, want 200: %s", resp2.StatusCode, data2)
+	}
+	if !strings.Contains(string(data2), "recovered") {
+		t.Errorf("stream missing recovered content: %s", data2)
+	}
+	if until, _ := p.ModelUnfit(modelA); !until.IsZero() {
+		t.Errorf("unfit not cleared after successful chat (until = %v)", until)
+	}
+}
+
+// TestBridgeModelUnfitNotGated pins the bridge exemption: bridge clients
+// relay their own token (their account may serve the model on this egress
+// and their session slots are theirs to spend), so the registry never gates
+// them even when (egress, model) is marked unfit.
+func TestBridgeModelUnfitNotGated(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.ChatBody = testutil.SSEEvent(chunk("chatcmpl-bg1", 1, `"choices":[{"index":0,"delta":{"content":"bridged"},"finish_reason":null}]`))
+	ts, p := newBridgeTestServer(t, mock)
+	chatURL := ts.URL + "/v1/chat/completions"
+
+	p.MarkModelUnfit(modelA, &upstream.LimitedIpError{Body: "pre-marked unfit"})
+	if until, _ := p.ModelUnfit(modelA); until.IsZero() {
+		t.Fatal("pre-mark not set")
+	}
+
+	resp, data := doJSON(t, http.MethodPost, chatURL, chatBody(modelA), map[string]string{"Authorization": "Bearer client-tok-abc"})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("bridge status = %d, want 200 (bridge never gated): %s", resp.StatusCode, data)
+	}
+	if !strings.Contains(string(data), "bridged") {
+		t.Errorf("stream missing bridged content: %s", data)
+	}
+	if got := len(mock.RecordedChatHeaders); got != 1 {
+		t.Errorf("upstream chat calls = %d, want 1 (bridge ignored the unfit mark)", got)
+	}
+}
+
+// TestChatModelIPLimitedAdmissionPath covers the admission-path end-to-end:
+// the session create itself returns 409 limited, the pool marks (egress,
+// model) unfit and surfaces the LimitedIpError, and the chat surfaces 409
+// model_ip_limited. The session is never admitted, so no chat call fires.
+func TestChatModelIPLimitedAdmissionPath(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			writeRawJSON(w, http.StatusConflict, limitedChatBody())
+			return
+		}
+		writeRawJSON(w, http.StatusNotFound, `{"error":"not found"}`)
+	}
+	ts, p := newTestServer(t, nil, mock)
+	chatURL := ts.URL + "/v1/chat/completions"
+
+	resp, data := doJSON(t, http.MethodPost, chatURL, chatBody(modelA), nil)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, data)
+	}
+	if got := errorCode(t, data); got != "model_ip_limited" {
+		t.Errorf("code = %q, want model_ip_limited", got)
+	}
+	until, _ := p.ModelUnfit(modelA)
+	if until.IsZero() {
+		t.Error("pool unfit not set after admission-path limited refusal")
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -76,6 +76,19 @@ func newTestServerCfg(t *testing.T, apiKeys []string, mut func(*config.Config), 
 	return ts, p
 }
 
+// fallbackModelCount returns how many models the registry fallback table maps
+// — the count /v1/models and /healthz report in tests whose server never
+// refreshes the registry (newTestServerCfg only LoadFallbacks). Derived from
+// a fresh registry rather than a hardcoded number so the assertions follow
+// fallbackAgents changes automatically (e.g. issue #121 pruned five retired
+// rows: 15 → 10).
+func fallbackModelCount(t *testing.T) int {
+	t.Helper()
+	reg := registry.New(nil, nil)
+	reg.LoadFallback()
+	return reg.ModelCount()
+}
+
 func chatBody(model string) []byte {
 	return []byte(`{"model":"` + model + `","messages":[{"role":"user","content":"ping"}],"stream":true}`)
 }
@@ -424,8 +437,10 @@ func TestChatSessionInvalidBoundedRetry(t *testing.T) {
 	// Every chat returns a session-invalid error. Without a retry budget the
 	// recovery loop re-creates the session and re-chats forever, hanging the
 	// client; the budget must cap it at one retry (2 chat attempts total).
+	// session_expired is used (NOT session_superseded — that is terminal
+	// since #119, see TestChatSessionSupersededTerminal).
 	mock.ChatStatus = http.StatusBadRequest
-	mock.ChatErrorBody = `{"error":{"message":"session_superseded"}}`
+	mock.ChatErrorBody = `{"error":{"message":"session_expired"}}`
 	ts, _ := newTestServer(t, nil, mock)
 
 	// A client timeout makes a regression (unbounded loop) fail fast instead
@@ -449,6 +464,91 @@ func TestChatSessionInvalidBoundedRetry(t *testing.T) {
 	}
 	if got := mock.SessionCreates; got != 2 {
 		t.Errorf("upstream session creates = %d, want exactly 2 (bounded retry)", got)
+	}
+}
+
+// TestChatSessionSupersededTerminal pins #119: the 409 session_superseded
+// chat gate is TERMINAL — the CLI stops polling and never auto-rejoins
+// (another process owns the account row). chatAttempt must invalidate the
+// dead row but NOT auto-POST a takeover: exactly one upstream chat call and
+// exactly one admission (no recreate), surfaced as 409 session_superseded.
+func TestChatSessionSupersededTerminal(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.ChatStatus = http.StatusConflict
+	mock.ChatErrorBody = `{"error":{"message":"session_superseded"}}`
+	ts, _ := newTestServer(t, nil, mock)
+
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, data)
+	}
+	if !strings.Contains(string(data), "session_superseded") {
+		t.Errorf("body missing session_superseded code: %s", data)
+	}
+	if got := len(mock.RecordedChatHeaders); got != 1 {
+		t.Errorf("upstream chat attempts = %d, want 1 (no auto-POST)", got)
+	}
+	if got := mock.SessionCreates; got != 1 {
+		t.Errorf("upstream session creates = %d, want exactly 1 (initial admission only, no reacquire)", got)
+	}
+}
+
+// TestChatCreditsNotRetried pins #117: 402 must NOT be retried by
+// chatAttempt — the CLI throws immediately and 402 is outside its
+// retryable set. The mock must see exactly one chat call, and the client
+// sees 402 out_of_credits.
+func TestChatCreditsNotRetried(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	var chatCalls atomic.Int32
+	mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
+		chatCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusPaymentRequired)
+		_, _ = io.WriteString(w, `{"error":"out of credits"}`)
+	}
+	ts, _ := newTestServer(t, nil, mock)
+
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	if resp.StatusCode != http.StatusPaymentRequired {
+		t.Fatalf("status = %d, want 402: %s", resp.StatusCode, data)
+	}
+	if !strings.Contains(string(data), "out_of_credits") {
+		t.Errorf("body = %s, want out_of_credits code", data)
+	}
+	if got := chatCalls.Load(); got != 1 {
+		t.Errorf("upstream chat calls = %d, want 1 (402 must not be retried)", got)
+	}
+}
+
+// TestChatWaitingRoomRequiredSessionEnding pins #116 end-to-end: a 428
+// waiting_room_required (FREEBUFF_GATE_CODES endsTheSession:true) is
+// SESSION-ENDING — chatAttempt invalidates the ended row and reacquires
+// once (2 chat attempts, 2 admissions), then surfaces 503
+// waiting_room_required + Retry-After, never the generic 502.
+func TestChatWaitingRoomRequiredSessionEnding(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.ChatStatus = http.StatusTooEarly // 428
+	mock.ChatErrorBody = `{"error":{"message":"waiting_room_required"}}`
+	ts, _ := newTestServer(t, nil, mock)
+
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503: %s", resp.StatusCode, data)
+	}
+	if !strings.Contains(string(data), "waiting_room_required") {
+		t.Errorf("body missing waiting_room_required code: %s", data)
+	}
+	if strings.Contains(string(data), "upstream_unavailable") {
+		t.Errorf("body is the generic 502 shape, want 503 waiting_room_required: %s", data)
+	}
+	if got := len(mock.RecordedChatHeaders); got != 2 {
+		t.Errorf("upstream chat attempts = %d, want exactly 2 (session-ending retry once)", got)
+	}
+	if got := mock.SessionCreates; got != 2 {
+		t.Errorf("upstream session creates = %d, want exactly 2 (invalidate + reacquire once)", got)
 	}
 }
 
@@ -610,8 +710,8 @@ func TestModelsEndpoint(t *testing.T) {
 	if out.Object != "list" {
 		t.Errorf("object = %q, want list", out.Object)
 	}
-	if len(out.Data) < 15 {
-		t.Errorf("models = %d, want >= 15", len(out.Data))
+	if len(out.Data) < fallbackModelCount(t) {
+		t.Errorf("models = %d, want >= %d", len(out.Data), fallbackModelCount(t))
 	}
 	for i, m := range out.Data {
 		if m.ID == "" || m.Object != "model" || m.OwnedBy == "" {
@@ -656,8 +756,8 @@ func TestHealthz(t *testing.T) {
 	if out.UptimeSeconds < 0 {
 		t.Errorf("uptime_seconds = %v, want >= 0", out.UptimeSeconds)
 	}
-	if out.Models < 15 {
-		t.Errorf("models = %d, want >= 15", out.Models)
+	if out.Models < fallbackModelCount(t) {
+		t.Errorf("models = %d, want >= %d", out.Models, fallbackModelCount(t))
 	}
 	if len(out.Tokens) != 2 {
 		t.Errorf("tokens = %d, want 2", len(out.Tokens))
@@ -1768,10 +1868,12 @@ func TestMetricsTransientRetryCounters(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// The first upstream call (agent-runs START during lease acquisition)
-	// fails once at the transport level; TRANSIENT_RETRIES replays it.
-	client.SetTransport(&flakyFirstRT{base: http.DefaultTransport})
-
+	// #120: the session POST is bodyless (no GetBody), so a transport-level
+	// failure on it is NOT replayable by the transient retry (mirrors the
+	// CLI's bare bodyless fetch). Pre-admit the session on the healthy
+	// transport, then arm the flaky transport so its first victim is the
+	// agent-runs START during lease acquisition — a replayable request,
+	// which is what this test exercises.
 	sess := session.NewManager(client)
 	reg := registry.New(cfg, nil)
 	reg.LoadFallback()
@@ -1782,6 +1884,11 @@ func TestMetricsTransientRetryCounters(t *testing.T) {
 	srv := server.New(cfg, p, reg, nil, nil, "")
 	ts := httptest.NewServer(srv.Handler())
 	t.Cleanup(ts.Close)
+
+	if _, err := sess.EnsureSessionForModel(context.Background(), modelA); err != nil {
+		t.Fatal(err)
+	}
+	client.SetTransport(&flakyFirstRT{base: http.DefaultTransport})
 
 	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
 	if resp.StatusCode != http.StatusOK {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -541,6 +541,18 @@ func statusError(status string, st *upstream.SessionState) error {
 			RetryAfter:       retryAfter,
 			Body:             st.Message,
 		}
+	case "session_model_mismatch", "limited_ip":
+		// The egress IP cannot serve the requested model. The session row is
+		// fine (bound to its admitted model) — not session-invalid, so it
+		// must never be invalidated/refreshed (re-admitting burns a daily
+		// session slot). Non-limited messages keep today's exact error text.
+		if strings.Contains(strings.ToLower(st.Message), "limited") {
+			return &upstream.LimitedIpError{
+				RetryAfter: time.Duration(st.RetryAfterMs) * time.Millisecond,
+				Body:       st.Message,
+			}
+		}
+		return fmt.Errorf("session: unknown upstream status %q", status)
 	}
 	return nil
 }
@@ -654,7 +666,7 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string) error {
 			m.commit(nil)
 			m.mu.Unlock()
 			slog.Debug("session recreated", "reason", status, "instance_id", st.InstanceID)
-		case "banned", "country_blocked", "rate_limited", "ip_capped", "spend_limited":
+		case "banned", "country_blocked", "rate_limited", "ip_capped", "spend_limited", "session_model_mismatch", "limited_ip":
 			return statusError(status, st)
 		case "model_locked":
 			// Previous session is locked to a different model.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -856,7 +856,11 @@ func (m *Manager) EndSession(ctx context.Context) error {
 		return nil
 	}
 	slog.Debug("session ended", "instance_id", instanceID)
-	if err := m.client.EndSession(ctx, instanceID); err != nil && !errors.Is(err, upstream.ErrSessionInvalid) {
+	// session_invalid and session_superseded both mean "the slot is already
+	// gone / not ours" — nothing to do (#119 split superseded into its own
+	// terminal sentinel, so both must be swallowed here).
+	if err := m.client.EndSession(ctx, instanceID); err != nil &&
+		!errors.Is(err, upstream.ErrSessionInvalid) && !errors.Is(err, upstream.ErrSessionSuperseded) {
 		return err
 	}
 	return nil
@@ -896,13 +900,14 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 		return nil
 	}
 	// Release the upstream slot directly (not EndSession): EndSession's CAS
-	// commit(nil) would remove the store entry we just flushed, and the
-	// DELETE is keyed on the user, not the instance (reference/freebuff
-	// session wire: DELETE = Bearer only; the client still sends the
-	// instance header today — P2 #18 backlog). The cached state is kept
-	// in-memory so the store entry stays; the process is exiting.
+	// commit(nil) would remove the store entry we just flushed. The DELETE
+	// is keyed on the user, not the instance — Authorization-only, no
+	// x-freebuff-instance-id (reference/freebuff session wire: DELETE =
+	// Bearer only; fixed in #120). The cached state is kept in-memory so
+	// the store entry stays; the process is exiting.
 	slog.Debug("session ended on shutdown", "instance_id", shortInstance(instanceID))
-	if err := m.client.EndSession(ctx, instanceID); err != nil && !errors.Is(err, upstream.ErrSessionInvalid) {
+	if err := m.client.EndSession(ctx, instanceID); err != nil &&
+		!errors.Is(err, upstream.ErrSessionInvalid) && !errors.Is(err, upstream.ErrSessionSuperseded) {
 		return err
 	}
 	return nil

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -61,6 +61,29 @@ func TestCreateActive(t *testing.T) {
 	}
 }
 
+func TestStatusErrorModelIPLimited(t *testing.T) {
+	limited := &upstream.SessionState{Message: "model kimi/kimi-k2-0725 is limited on this IP", RetryAfterMs: 30000}
+	for _, status := range []string{"session_model_mismatch", "limited_ip"} {
+		err := statusError(status, limited)
+		var lie *upstream.LimitedIpError
+		if !errors.As(err, &lie) {
+			t.Fatalf("statusError(%q) = %v, want *upstream.LimitedIpError", status, err)
+		}
+		if !errors.Is(err, upstream.ErrModelIPLimited) {
+			t.Errorf("errors.Is(upstream.ErrModelIPLimited) = false, got %v", err)
+		}
+		if lie.RetryAfter != 30*time.Second {
+			t.Errorf("RetryAfter = %s, want 30s", lie.RetryAfter)
+		}
+	}
+
+	// Non-limited messages keep today's exact unknown-status error text.
+	err := statusError("session_model_mismatch", &upstream.SessionState{Message: "session model mismatch"})
+	if err == nil || err.Error() != `session: unknown upstream status "session_model_mismatch"` {
+		t.Errorf("non-limited statusError = %v, want unknown-status error", err)
+	}
+}
+
 func TestWaitingRoomThenActive(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1011,8 +1011,9 @@ func TestPollTransportErrorKeepsCachedState(t *testing.T) {
 }
 
 // TestEndSessionSwallowsSessionInvalid verifies EndSession returns nil when
-// the upstream DELETE fails with a 400 session_superseded (ErrSessionInvalid
-// — the slot is already gone, nothing to do).
+// the upstream DELETE fails with a 400 session_superseded (ErrSessionInvalid,
+// and ErrSessionSuperseded since #119 — the slot is already gone, nothing to
+// do).
 func TestEndSessionSwallowsSessionInvalid(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
@@ -1351,8 +1352,13 @@ func TestModelLockedFallbackInstance(t *testing.T) {
 	if len(deleteInstanceIDs) != 1 {
 		t.Fatalf("EndSession calls = %d, want 1", len(deleteInstanceIDs))
 	}
-	if deleteInstanceIDs[0] != "locked-inst-123" {
-		t.Errorf("EndSession instanceID = %q, want locked-inst-123", deleteInstanceIDs[0])
+	// #120: the DELETE is Authorization-only and user-keyed — the CLI never
+	// sends x-freebuff-instance-id on DELETE (callFreebuffSession sets the
+	// instance header only on GET; reference/freebuff/cli/src/utils/
+	// freebuff-session-api.ts). The old locked slot is still released: the
+	// upstream resolves the session from the Bearer token.
+	if deleteInstanceIDs[0] != "" {
+		t.Errorf("EndSession x-freebuff-instance-id = %q, want empty (Authorization-only DELETE)", deleteInstanceIDs[0])
 	}
 }
 

--- a/internal/upstream/auth_login.go
+++ b/internal/upstream/auth_login.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -39,17 +40,27 @@ import (
 )
 
 // freebuffLoginUserAgent is the official CLI login user agent (reference
-// account_login.go freebuffLoginUserAgent).
-const freebuffLoginUserAgent = "ai-sdk/openai-compatible/2.0.42/codebuff"
+// account_login.go freebuffLoginUserAgent). The CLI sends no UA override on
+// the login endpoints (bun default), and the only SDK-shaped UA the official
+// tree ever emits is the @codebuff/llm-providers package version — 1.0.0 in
+// the vendored tree (packages/llm-providers/package.json) — not the 2.0.x
+// third-party value this constant used to carry.
+const freebuffLoginUserAgent = "ai-sdk/openai-compatible/1.0.0/codebuff"
+
+// freebuffCLIUserAgent is the ads/streak request User-Agent the official CLI
+// sends on the waiting-room chain (reference use-gravity-ad.ts
+// getCliAdRequestUserAgent: "Freebuff-CLI/<CODEBUFF_CLI_VERSION>"; the
+// vendored release and the installed binary are 0.0.149).
+const freebuffCLIUserAgent = "Freebuff-CLI/0.0.149"
 
 // loginCallTimeout bounds each login HTTP call (code request, status poll,
 // protocol page walk).
 const loginCallTimeout = 30 * time.Second
 
 // loginPollInterval is how long between status polls (the upstream device
-// code takes a human to complete; 3s matches the reference
-// freebuffLoginPollSeconds).
-const loginPollInterval = 3 * time.Second
+// code takes a human to complete; 5s matches login-flow.ts pollLoginStatus
+// intervalMs=5000, timeout 5min).
+const loginPollInterval = 5 * time.Second
 
 // NewForAuth builds a token-less client for the headless OAuth login flow
 // (#62/#66). The transport/stealth/proxy wiring is identical to a pooled
@@ -369,8 +380,18 @@ func (c *Client) ProtocolGitHubLogin(ctx context.Context, username, password, to
 	return c.pollForCompletion(ctx, code, 0)
 }
 
-// pollForCompletion polls PollCLILogin until Done, up to pollTimeout.
-func (c *Client) pollForCompletion(ctx context.Context, code *CLILoginCode, _ time.Duration) (*CLILoginStatus, error) {
+// pollForCompletion polls PollCLILogin until Done, up to a 5-minute cap
+// (login-flow.ts pollLoginStatus timeoutMs). Transient PollCLILogin errors —
+// 5xx statuses and transport failures — are logged and the loop continues,
+// exactly like the official CLI: non-401 non-ok responses warn, network
+// errors log, 401 (pending) stays silent, and only the 5-minute deadline or
+// caller cancellation stops the loop. pollInterval overrides the default
+// cadence when non-zero (test seam; the protocol login passes 0).
+func (c *Client) pollForCompletion(ctx context.Context, code *CLILoginCode, pollInterval time.Duration) (*CLILoginStatus, error) {
+	interval := loginPollInterval
+	if pollInterval > 0 {
+		interval = pollInterval
+	}
 	deadline := time.Now().Add(5 * time.Minute)
 	for {
 		if ctx.Err() != nil {
@@ -381,15 +402,14 @@ func (c *Client) pollForCompletion(ctx context.Context, code *CLILoginCode, _ ti
 		}
 		status, err := c.PollCLILogin(ctx, code)
 		if err != nil {
-			return nil, err
-		}
-		if status.Done {
+			slog.Warn("login poll transient failure; continuing", "err", err)
+		} else if status.Done {
 			return status, nil
 		}
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case <-time.After(loginPollInterval):
+		case <-time.After(interval):
 		}
 	}
 }

--- a/internal/upstream/auth_login_test.go
+++ b/internal/upstream/auth_login_test.go
@@ -1,0 +1,115 @@
+package upstream
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"freebuff-proxy/internal/testutil"
+)
+
+// --- #125: login poll cadence + continue-on-error loop ----------------------
+
+// TestLoginPollIntervalIsFiveSeconds verifies #125: the status poll cadence
+// matches the official CLI's login-flow.ts pollLoginStatus intervalMs=5000.
+func TestLoginPollIntervalIsFiveSeconds(t *testing.T) {
+	if loginPollInterval != 5*time.Second {
+		t.Fatalf("loginPollInterval = %v, want 5s", loginPollInterval)
+	}
+}
+
+// TestLoginUserAgentIsOfficialLLMProvidersVersion verifies #125: the login UA
+// matches the vendored @codebuff/llm-providers package version (1.0.0) — the
+// only SDK-shaped UA the official tree emits — not a third-party 2.0.x value.
+func TestLoginUserAgentIsOfficialLLMProvidersVersion(t *testing.T) {
+	const want = "ai-sdk/openai-compatible/1.0.0/codebuff"
+	if freebuffLoginUserAgent != want {
+		t.Fatalf("freebuffLoginUserAgent = %q, want %q", freebuffLoginUserAgent, want)
+	}
+}
+
+// TestFreebuffCLIUserAgent verifies #124: the ads/streak request UA matches
+// the installed binary version (Freebuff-CLI/0.0.149, use-gravity-ad.ts
+// getCliAdRequestUserAgent).
+func TestFreebuffCLIUserAgent(t *testing.T) {
+	const want = "Freebuff-CLI/0.0.149"
+	if freebuffCLIUserAgent != want {
+		t.Fatalf("freebuffCLIUserAgent = %q, want %q", freebuffCLIUserAgent, want)
+	}
+}
+
+// TestPollForCompletionSurvivesTransientErrors verifies #125: pollForCompletion
+// keeps polling through a 5xx and a pending 401 instead of aborting, exactly
+// like login-flow.ts pollLoginStatus (non-401 non-ok → warn + sleep +
+// continue; 401 → silent + continue; only the 5-min cap / caller cancellation
+// stops the loop).
+func TestPollForCompletionSurvivesTransientErrors(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	client, err := NewForAuth(testConfig(mock.URL(), nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := client.StartCLILogin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var polls atomic.Int32
+	mock.AuthCLIHandler = func(w http.ResponseWriter, r *http.Request) {
+		switch polls.Add(1) {
+		case 1:
+			w.WriteHeader(http.StatusInternalServerError) // transient 5xx
+		case 2:
+			w.WriteHeader(http.StatusUnauthorized) // pending (silent)
+		default:
+			w.Write([]byte(`{"authToken":"cb_after_500","user":{"id":"gh-1","name":"Ada","email":"ada@example.com"}}`))
+		}
+	}
+
+	status, err := client.pollForCompletion(context.Background(), code, time.Millisecond)
+	if err != nil {
+		t.Fatalf("pollForCompletion aborted on transient errors: %v", err)
+	}
+	if !status.Done || status.AuthToken != "cb_after_500" {
+		t.Fatalf("status = %+v, want completed token cb_after_500", status)
+	}
+	if got := polls.Load(); got != 3 {
+		t.Errorf("status polls = %d, want 3 (500, 401, success)", got)
+	}
+}
+
+// TestPollForCompletionRespectsCancellation verifies the loop still stops on
+// caller cancellation even while a transient error would otherwise continue
+// (the CLI's aborted path).
+func TestPollForCompletionRespectsCancellation(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	client, err := NewForAuth(testConfig(mock.URL(), nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := client.StartCLILogin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mock.AuthCLIHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		cancel()
+	}()
+	_, err = client.pollForCompletion(ctx, code, time.Millisecond)
+	if err == nil {
+		t.Fatal("pollForCompletion succeeded despite cancellation, want context error")
+	}
+	if err != context.Canceled {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}

--- a/internal/upstream/auth_login_test.go
+++ b/internal/upstream/auth_login_test.go
@@ -65,7 +65,7 @@ func TestPollForCompletionSurvivesTransientErrors(t *testing.T) {
 		case 2:
 			w.WriteHeader(http.StatusUnauthorized) // pending (silent)
 		default:
-			w.Write([]byte(`{"authToken":"cb_after_500","user":{"id":"gh-1","name":"Ada","email":"ada@example.com"}}`))
+			_, _ = w.Write([]byte(`{"authToken":"cb_after_500","user":{"id":"gh-1","name":"Ada","email":"ada@example.com"}}`))
 		}
 	}
 

--- a/internal/upstream/auth_wave6_test.go
+++ b/internal/upstream/auth_wave6_test.go
@@ -108,8 +108,12 @@ func TestClassifyWaitingRoomRequired(t *testing.T) {
 	if !errors.Is(err, ErrWaitingRoomRequired) {
 		t.Fatalf("428 waiting_room_required: errors.Is = false, want ErrWaitingRoomRequired (got %v)", err)
 	}
-	if errors.Is(err, ErrSessionInvalid) {
-		t.Fatal("428 waiting_room_required must NOT be ErrSessionInvalid (#94)")
+	// Issue #116: FREEBUFF_GATE_CODES marks waiting_room_required
+	// endsTheSession:true — the refused session row is ENDED upstream, so
+	// the error must ALSO unwrap to ErrSessionInvalid (session-ending:
+	// chatAttempt invalidates + reacquires once).
+	if !errors.Is(err, ErrSessionInvalid) {
+		t.Fatal("428 waiting_room_required must be session-ending (unwrap to ErrSessionInvalid) since #116")
 	}
 	if errors.Is(err, ErrWaitingRoom) {
 		t.Fatal("428 waiting_room_required must NOT be ErrWaitingRoom (it is its own signal)")

--- a/internal/upstream/client.go
+++ b/internal/upstream/client.go
@@ -104,6 +104,13 @@ var (
 	// session must NOT be invalidated/refreshed (reference
 	// freebuff2api-optimized codebuff.py:1048-1074).
 	ErrWaitingRoomRequired = errors.New("upstream waiting room required")
+	// ErrModelIPLimited: the egress IP cannot serve the requested model
+	// (session_model_mismatch + "limited" marker, or the limited_ip session
+	// status). The session row is fine — it stays bound to its admitted
+	// model — but the request must be retried on a different (egress,
+	// model) pairing, so the session must NOT be invalidated/refreshed
+	// (that would burn a daily session slot re-admitting).
+	ErrModelIPLimited = errors.New("upstream: model limited on egress IP")
 )
 
 // WaitingRoomError is the concrete value behind ErrWaitingRoom; callers
@@ -305,6 +312,31 @@ func (e *IpCappedError) Error() string {
 }
 
 func (e *IpCappedError) Unwrap() error { return ErrIpCapped }
+
+// LimitedIpError is the concrete value behind ErrModelIPLimited: the egress
+// IP cannot serve the requested model (chat-level session_model_mismatch
+// with a "limited" marker, or the limited_ip session status). The session
+// row itself is fine — it stays bound to its admitted model — so this must
+// never invalidate the session (re-admitting burns a daily session slot).
+// RetryAfter comes from the Retry-After header (chat path) or the body's
+// retryAfterMs (admission path); it is surfaced to the client but does not
+// set the registry window. Unwrap makes errors.Is(err, ErrModelIPLimited)
+// work.
+type LimitedIpError struct {
+	Model      string
+	RetryAfter time.Duration
+	Body       string // truncated upstream body
+}
+
+func (e *LimitedIpError) Error() string {
+	msg := "model limited on this egress IP"
+	if e.Body != "" {
+		msg += ": " + e.Body
+	}
+	return msg
+}
+
+func (e *LimitedIpError) Unwrap() error { return ErrModelIPLimited }
 
 // SessionLimitError is a 409 session_limit_reached response: the ACCOUNT is
 // over its concurrent-tab budget, but this session's row is fine
@@ -1888,6 +1920,13 @@ func classifyError(status int, body string, hdr http.Header) error {
 		// Client.classify wrapper records the flag so the pool can fire the
 		// gated WAITING_ROOM_CHAIN before the next create.
 		return &WaitingRoomRequiredError{RetryAfter: retryAfter, Detail: truncate(body, 200)}
+	case containsAny(lower, "session_model_mismatch") && containsAny(lower, "limited"):
+		// The egress IP cannot serve the requested model. The session row is
+		// fine — it stays bound to its admitted model — so this is NOT
+		// session-invalid: invalidating would re-admit and burn a daily
+		// session slot. The server marks the refusal and the pool registry
+		// cools the (egress, model) pairing instead.
+		return &LimitedIpError{RetryAfter: retryAfter, Body: truncate(body, 200)}
 	case containsAny(lower, "freebuff_update_required", "session_superseded",
 		"session_expired", "session_model_mismatch", "model_locked"):
 		return fmt.Errorf("%w: %s%s", ErrSessionInvalid, truncate(body, 200), retryDetail(retryAfter))

--- a/internal/upstream/client.go
+++ b/internal/upstream/client.go
@@ -46,9 +46,20 @@ import (
 // Typed error sentinels. Callers use errors.Is against these; the concrete
 // error values wrap an UpstreamError where applicable.
 var (
-	// ErrSessionInvalid: the free session is stale/superseded/expired or a
-	// waiting room / update is required. Refresh the session and retry once.
+	// ErrSessionInvalid: the free session is stale/expired, or a waiting
+	// room / update is required. Refresh the session and retry once.
+	// (session_superseded is its own terminal sentinel — see below.)
 	ErrSessionInvalid = errors.New("upstream session invalid")
+	// ErrSessionSuperseded: 409 session_superseded chat gate — another
+	// process (or a later admission) owns the account row. TERMINAL: the
+	// CLI stops polling and never auto-rejoins, because an automatic
+	// takeover would ping-pong with the live second client
+	// (reference/freebuff common/src/types/freebuff-session.ts
+	// FREEBUFF_GATE_CODES {status:409, endsTheSession:true}; cli
+	// src/hooks/helpers/send-message.ts markFreebuffSessionSuperseded).
+	// Distinct from ErrSessionInvalid so chatAttempt invalidates the dead
+	// row but does NOT auto-POST a takeover (issue #119).
+	ErrSessionSuperseded = errors.New("upstream session superseded")
 	// ErrRunInvalid: the agent run is gone. Rotate the run and retry once.
 	ErrRunInvalid = errors.New("upstream run invalid")
 	// ErrAuthRejected: 401 — the token is rejected. Cool the token down.
@@ -98,11 +109,14 @@ var (
 	ErrSessionLimitReached = errors.New("upstream session limit reached")
 	// ErrWaitingRoomRequired: 428 waiting_room_required — the account must
 	// walk the reference pre-session flow (request_ad_chain + get_streak)
-	// before the next session create (issue #94). Retryable with Retry-After
-	// honored, NO token cooldown, and deliberately DISTINCT from
-	// ErrSessionInvalid: the cached session row is not stale, so the
-	// session must NOT be invalidated/refreshed (reference
-	// freebuff2api-optimized codebuff.py:1048-1074).
+	// before the next session create (issue #94). Since #116 it is
+	// SESSION-ENDING: FREEBUFF_GATE_CODES marks waiting_room_required
+	// endsTheSession:true (reference/freebuff common/src/types/
+	// freebuff-session.ts), so the concrete WaitingRoomRequiredError also
+	// unwraps to ErrSessionInvalid — chatAttempt invalidates the ended row
+	// and reacquires once. The sentinel is kept so the pool's
+	// WAITING_ROOM_CHAIN gate still fires before the next create; the
+	// Retry-After is honored with no token cooldown.
 	ErrWaitingRoomRequired = errors.New("upstream waiting room required")
 	// ErrModelIPLimited: the egress IP cannot serve the requested model
 	// (session_model_mismatch + "limited" marker, or the limited_ip session
@@ -137,8 +151,12 @@ func (e *WaitingRoomError) Unwrap() error { return ErrWaitingRoom }
 
 // WaitingRoomRequiredError is the concrete value behind
 // ErrWaitingRoomRequired (issue #94): a 428 waiting_room_required refusal.
-// It is retryable (RetryAfter honored) and carries no cooldown; callers
-// surface it as 503 + Retry-After.
+// Since #116 it is SESSION-ENDING: it unwraps to BOTH ErrWaitingRoomRequired
+// (kept so the pool's WAITING_ROOM_CHAIN gate fires before the next create)
+// and ErrSessionInvalid (FREEBUFF_GATE_CODES endsTheSession:true — the
+// refused session row is ended upstream, so chatAttempt invalidates it and
+// reacquires once). RetryAfter is honored; writeError surfaces it as
+// 503 + Retry-After.
 type WaitingRoomRequiredError struct {
 	RetryAfter time.Duration
 	Detail     string
@@ -155,7 +173,9 @@ func (e *WaitingRoomRequiredError) Error() string {
 	return msg
 }
 
-func (e *WaitingRoomRequiredError) Unwrap() error { return ErrWaitingRoomRequired }
+func (e *WaitingRoomRequiredError) Unwrap() []error {
+	return []error{ErrWaitingRoomRequired, ErrSessionInvalid}
+}
 
 // UpstreamError is a non-recoverable upstream failure surfaced verbatim.
 type UpstreamError struct {
@@ -499,7 +519,7 @@ type Client struct {
 	sessionCallTimeout time.Duration
 	requestJitter      time.Duration
 	costMode           string
-	userID             string // optional x-freebuff-acting-user-id (USER_ID; CLI parity)
+	userID             string // optional x-freebuff-acting-user-id (USER_ID; server-to-server header — the CLI never sends it; setting it is a ban risk)
 	debugDump          bool
 
 	// transientRetriesLimit is TRANSIENT_RETRIES: the maximum number of
@@ -771,9 +791,16 @@ func (c *Client) ChatCompletions(ctx context.Context, opts ChatOptions, body []b
 		// (reference/freebuff model-provider.ts:146-152); the model and
 		// instance id ride only in the body metadata (injectEnvelope).
 		if c.userID != "" {
-			// The official CLI sends the acting user id on every chat call and
-			// the free-mode gate expects it
-			// (reference/proxy-freebuff/server.js:131-134).
+			// x-freebuff-acting-user-id is a TRUSTED SERVER-TO-SERVER
+			// header: only the Codebuff API may honor it when the request
+			// authenticates as the Freebuff Web service account — the
+			// official CLI NEVER sends it in normal use (#126,
+			// reference/freebuff/common/src/constants/freebuff-models.ts
+			// FREEBUFF_ACTING_USER_HEADER:1180-1181). Enabling USER_ID
+			// impersonates that service identity on every chat call, a
+			// divergence the anti-ban docs flag as a BAN RISK. Default
+			// behavior (USER_ID unset) omits the header and is the
+			// CLI-parity shape.
 			req.Header.Set("x-freebuff-acting-user-id", c.userID)
 		}
 		resp, _, err := c.do(req, 0)
@@ -817,14 +844,20 @@ func (c *Client) ChatCompletions(ctx context.Context, opts ChatOptions, body []b
 	}
 }
 
-// CreateSession POSTs /api/v1/freebuff/session with an empty object.
+// CreateSession POSTs /api/v1/freebuff/session (no body, no Content-Type).
 func (c *Client) CreateSession(ctx context.Context) (*SessionState, error) {
 	return c.CreateSessionForModel(ctx, "")
 }
 
-// CreateSessionForModel POSTs /api/v1/freebuff/session with the requested model header.
+// CreateSessionForModel POSTs /api/v1/freebuff/session with the requested
+// model header. Mirrors the official CLI exactly: the session POST carries
+// NO body and NO Content-Type — only Authorization (+ x-freebuff-model on
+// create) — see callFreebuffSession
+// (reference/freebuff/cli/src/utils/freebuff-session-api.ts:105-119) and
+// the fetch helper's "Content-Type iff body present" rule
+// (reference/freebuff/packages/agent-runtime/src/codebuff-api.ts).
 func (c *Client) CreateSessionForModel(ctx context.Context, model string) (*SessionState, error) {
-	req, err := c.newRequest(ctx, http.MethodPost, "/api/v1/freebuff/session", []byte("{}"))
+	req, err := c.newRequest(ctx, http.MethodPost, "/api/v1/freebuff/session", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -906,13 +939,17 @@ func (c *Client) ProbeAccount(ctx context.Context) (*SessionState, error) {
 	return state, nil
 }
 
-// EndSession DELETE /api/v1/freebuff/session; 404 is tolerated.
+// EndSession DELETEs /api/v1/freebuff/session; 404 is tolerated. The
+// DELETE is Authorization-only and user-keyed — NO x-freebuff-instance-id,
+// exactly like the CLI (callFreebuffSession sets the instance header only
+// on GET; #120, reference/freebuff/cli/src/utils/freebuff-session-api.ts).
 func (c *Client) EndSession(ctx context.Context, instanceID string) error {
 	req, err := c.newRequest(ctx, http.MethodDelete, "/api/v1/freebuff/session", nil)
 	if err != nil {
 		return err
 	}
-	req.Header.Set("x-freebuff-instance-id", instanceID)
+	// instanceID is deliberately not sent: the upstream resolves the
+	// session from the Bearer token, not the instance (CLI parity).
 
 	resp, cancel, err := c.do(req, c.sessionCallTimeout)
 	if err != nil {
@@ -1270,7 +1307,14 @@ func (c *Client) newRequest(ctx context.Context, method, path string, body []byt
 		// User-Agent instead (see authLoginRequest).
 		req.Header.Del("Authorization")
 	}
-	req.Header.Set("Content-Type", "application/json")
+	// Content-Type is set only when a body exists: the CLI's session POST
+	// is bodyless and must not carry a Content-Type, and its fetch helper
+	// sets Content-Type iff a body is present (#120,
+	// reference/freebuff/cli/src/utils/freebuff-session-api.ts:105-119 and
+	// packages/agent-runtime/src/codebuff-api.ts:344-345).
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	// The official CLI sends the pinned llm-providers ai-sdk UA on chat and
 	// NO browser headers on any API path (bare Bun fetch) (#108/#109 fix
 	// option (a)): the utls ClientHello impersonation stays, the browser
@@ -1945,15 +1989,15 @@ func classifyError(status int, body string, hdr http.Header) error {
 		// (reference/freebuff freebuff-session.ts FREEBUFF_GATE_CODES).
 		return &WaitingRoomError{RetryAfter: retryAfter, Detail: truncate(body, 200)}
 	case containsAny(lower, "waiting_room_required"):
-		// 428 waiting_room_required (issue #94): the account must walk the
+		// 428 waiting_room_required (FREEBUFF_GATE_CODES {status:428,
+		// endsTheSession:true}, issue #116): the account must walk the
 		// reference pre-session ad-chain + streak flow before the next
-		// session create. Own retryable signal (Retry-After honored, no
-		// cooldown) — deliberately NOT ErrSessionInvalid: the session row is
-		// fine, so nothing must be invalidated (reference
-		// freebuff2api-optimized codebuff.py:1048-1074). The body marker is
-		// the discriminator (upstream can attach it to 428/429 alike); the
-		// Client.classify wrapper records the flag so the pool can fire the
-		// gated WAITING_ROOM_CHAIN before the next create.
+		// session create (issue #94). SESSION-ENDING: the concrete
+		// WaitingRoomRequiredError unwraps to ErrSessionInvalid as well as
+		// ErrWaitingRoomRequired, so chatAttempt invalidates the ended row
+		// and reacquires once, while the pool's WAITING_ROOM_CHAIN gate
+		// (flag below) still fires before the next create. Retry-After
+		// honored, no token cooldown.
 		return &WaitingRoomRequiredError{RetryAfter: retryAfter, Detail: truncate(body, 200)}
 	case containsAny(lower, "session_model_mismatch") && containsAny(lower, "limited"):
 		// The egress IP cannot serve the requested model. The session row is
@@ -1962,7 +2006,15 @@ func classifyError(status int, body string, hdr http.Header) error {
 		// session slot. The server marks the refusal and the pool registry
 		// cools the (egress, model) pairing instead.
 		return &LimitedIpError{RetryAfter: retryAfter, Body: truncate(body, 200)}
-	case containsAny(lower, "freebuff_update_required", "session_superseded",
+	case containsAny(lower, "session_superseded"):
+		// 409 session_superseded chat gate: another process owns the
+		// account row (FREEBUFF_GATE_CODES endsTheSession:true). TERMINAL —
+		// the CLI stops polling and never auto-rejoins
+		// (markFreebuffSessionSuperseded), so this is NOT ErrSessionInvalid:
+		// chatAttempt invalidates the dead row but must not auto-POST a
+		// takeover (issue #119).
+		return fmt.Errorf("%w: %s%s", ErrSessionSuperseded, truncate(body, 200), retryDetail(retryAfter))
+	case containsAny(lower, "freebuff_update_required",
 		"session_expired", "session_model_mismatch", "model_locked"):
 		return fmt.Errorf("%w: %s%s", ErrSessionInvalid, truncate(body, 200), retryDetail(retryAfter))
 	case status == http.StatusBadRequest && containsAny(lower, "runid not found", "runid not running"):

--- a/internal/upstream/client_test.go
+++ b/internal/upstream/client_test.go
@@ -2102,6 +2102,41 @@ func TestClassifyErrorMatrix(t *testing.T) {
 		}
 	})
 
+	t.Run("session_model_mismatch limited on egress IP", func(t *testing.T) {
+		cases := []struct {
+			name      string
+			body      string
+			hdr       http.Header
+			wantRetry time.Duration
+		}{
+			{
+				name: "limited marker",
+				body: `{"status":"session_model_mismatch","message":"model kimi/kimi-k2-0725 is limited on this IP"}`,
+			},
+			{
+				name:      "retry-after header honored",
+				body:      `{"status":"session_model_mismatch","message":"model kimi/kimi-k2-0725 is limited on this IP"}`,
+				hdr:       http.Header{"Retry-After": {"120"}},
+				wantRetry: 120 * time.Second,
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				err := classifyError(409, tc.body, tc.hdr)
+				var lie *LimitedIpError
+				if !errors.As(err, &lie) {
+					t.Fatalf("err = %v, want *LimitedIpError", err)
+				}
+				if !errors.Is(err, ErrModelIPLimited) {
+					t.Errorf("errors.Is(ErrModelIPLimited) = false, got %v", err)
+				}
+				if tc.wantRetry > 0 && lie.RetryAfter != tc.wantRetry {
+					t.Errorf("RetryAfter = %s, want %s", lie.RetryAfter, tc.wantRetry)
+				}
+			})
+		}
+	})
+
 	t.Run("500 with rate_limited body", func(t *testing.T) {
 		// Pin current behavior: the rate_limited body marker wins even on a
 		// 500, producing a RateLimitError.

--- a/internal/upstream/client_test.go
+++ b/internal/upstream/client_test.go
@@ -267,7 +267,7 @@ func TestErrorClassification(t *testing.T) {
 	}{
 		{"run invalid", 400, `{"error":"runId not found"}`, ErrRunInvalid},
 		{"run not running", 400, `{"error":"runId not running"}`, ErrRunInvalid},
-		{"session superseded", 400, `{"error":"session_superseded"}`, ErrSessionInvalid},
+		{"session superseded", 400, `{"error":"session_superseded"}`, ErrSessionSuperseded},
 		{"session expired", 400, `{"error":"session_expired"}`, ErrSessionInvalid},
 		{"update required", 400, `{"error":"freebuff_update_required"}`, ErrSessionInvalid},
 		{"auth", 401, `{"error":"unauthorized"}`, ErrAuthRejected},
@@ -380,6 +380,83 @@ func TestSessionControlCalls(t *testing.T) {
 	// end + tolerated 404
 	if err := client.EndSession(context.Background(), "inst-abc-123"); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestSessionCallWireShape pins issue #120: the session POST carries NO
+// body and NO Content-Type; the GET/DELETE likewise carry no Content-Type;
+// and the DELETE is Authorization-only (no x-freebuff-instance-id) —
+// exactly the official CLI's callFreebuffSession wire shape
+// (reference/freebuff/cli/src/utils/freebuff-session-api.ts:105-119).
+func TestSessionCallWireShape(t *testing.T) {
+	type seenReq struct {
+		method        string
+		bodyLen       int64
+		contentType   string
+		instanceHdr   string
+		authorization string
+	}
+	var mu sync.Mutex
+	var seen []seenReq
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		seen = append(seen, seenReq{
+			method:        r.Method,
+			bodyLen:       int64(len(body)),
+			contentType:   r.Header.Get("Content-Type"),
+			instanceHdr:   r.Header.Get("x-freebuff-instance-id"),
+			authorization: r.Header.Get("Authorization"),
+		})
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-abc-123"}`)
+	}
+
+	client, err := New("tok", testConfig(mock.URL(), nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.CreateSessionForModel(context.Background(), "deepseek/deepseek-v4-flash"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.GetSession(context.Background(), "inst-abc-123"); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.EndSession(context.Background(), "inst-abc-123"); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) != 3 {
+		t.Fatalf("mock saw %d session calls, want 3 (POST/GET/DELETE)", len(seen))
+	}
+	wantAuth := "Bearer tok"
+	for _, call := range seen {
+		switch call.method {
+		case http.MethodPost:
+			if call.bodyLen != 0 {
+				t.Errorf("session POST body = %d bytes, want 0 (no body)", call.bodyLen)
+			}
+		case http.MethodGet:
+			if call.instanceHdr == "" {
+				t.Error("session GET missing x-freebuff-instance-id")
+			}
+		case http.MethodDelete:
+			if call.instanceHdr != "" {
+				t.Errorf("session DELETE x-freebuff-instance-id = %q, want absent (Authorization-only)", call.instanceHdr)
+			}
+		}
+		if call.contentType != "" {
+			t.Errorf("session %s Content-Type = %q, want empty (set only when a body exists)", call.method, call.contentType)
+		}
+		if call.authorization != wantAuth {
+			t.Errorf("session %s Authorization = %q, want %q", call.method, call.authorization, wantAuth)
+		}
 	}
 }
 
@@ -1531,6 +1608,13 @@ type flakyRT struct {
 	seenHeaders []http.Header
 }
 
+// roundTripFunc adapts a bare function to http.RoundTripper for tests that
+// need a one-shot failing transport without body capture (bodyless requests
+// have a nil Body, which flakyRT's io.ReadAll cannot read).
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
 func (f *flakyRT) RoundTrip(req *http.Request) (*http.Response, error) {
 	f.calls.Add(1)
 	b, _ := io.ReadAll(req.Body)
@@ -1672,18 +1756,23 @@ func TestChatCompletionsRetriesTwiceWhenAllowed(t *testing.T) {
 	}
 }
 
-func TestCreateSessionRetriesConnectionReset(t *testing.T) {
+func TestCreateSessionNoRetryOnConnectionReset(t *testing.T) {
 	// A real abrupt connection close surfaces as context.Canceled on some
 	// platforms (Go cancels the request context when the server tears the
 	// connection down mid-request), which MUST NOT be retried. Inject the
 	// transport-level reset at the RoundTripper boundary instead: this is
 	// the same code path a live dial/TLS failure takes.
-	rt := &flakyRT{
-		failN:  1,
-		err:    errors.New("read tcp 127.0.0.1:443: connection reset by peer"),
-		header: http.Header{"Content-Type": []string{"application/json"}},
-		body:   []byte(`{"status":"active","instanceId":"inst-1","expiresAt":"2030-01-01T00:00:00Z"}`),
-	}
+	//
+	// #120: the session POST is bodyless (no GetBody), so a transport-level
+	// failure on it is NOT replayable by the transient retry — mirroring
+	// the CLI's bare bodyless fetch, which never retries the session POST
+	// (reference/freebuff/cli/src/utils/freebuff-session-api.ts
+	// callFreebuffSession). Exactly one upstream attempt, zero retries.
+	var calls atomic.Int32
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return nil, errors.New("read tcp 127.0.0.1:443: connection reset by peer")
+	})
 	client, err := New("tok-a", testConfig("", func(c *config.Config) { c.TransientRetries = 1 }))
 	if err != nil {
 		t.Fatal(err)
@@ -1691,22 +1780,14 @@ func TestCreateSessionRetriesConnectionReset(t *testing.T) {
 	client.retryBackoff = func() time.Duration { return time.Millisecond }
 	client.SetTransport(rt)
 
-	st, err := client.CreateSession(context.Background())
-	if err != nil {
-		t.Fatalf("CreateSession failed after retry: %v", err)
+	if _, err := client.CreateSession(context.Background()); err == nil {
+		t.Fatal("CreateSession succeeded despite the failed transport, want error (bodyless POST cannot replay)")
 	}
-	if st.Status != "active" || st.InstanceID != "inst-1" {
-		t.Errorf("session = %+v, want active inst-1", st)
+	if got := calls.Load(); got != 1 {
+		t.Errorf("upstream attempts = %d, want 1 (bodyless session POST must not be retried)", got)
 	}
-	if rt.calls.Load() != 2 {
-		t.Errorf("upstream attempts = %d, want 2 (1 failure + 1 retry)", rt.calls.Load())
-	}
-	if got := client.TransientRetries(); got != 1 {
-		t.Errorf("TransientRetries = %d, want 1", got)
-	}
-	// The session POST body was replayed identically.
-	if len(rt.seen) != 2 || string(rt.seen[0]) != string(rt.seen[1]) {
-		t.Errorf("replayed session body differs: %q vs %q", rt.seen[0], rt.seen[1])
+	if got := client.TransientRetries(); got != 0 {
+		t.Errorf("TransientRetries = %d, want 0", got)
 	}
 }
 


### PR DESCRIPTION
Stacked on PR #128 (P1). Merge #128 first, then this.

Fixes the 11 remaining open anti-ban issues from the CLI reverse-engineering study (docs/guides/anti-ban-gap-analysis.md, kept local/private). Every change was verified against the vendored official CLI source (reference/freebuff/) and cross-checked with the globally-installed Go skills (go-error-handling, go-testing, golang-code-style, go-code-review).

Closes #116 #117 #118 #119 #120 #121 #122 #123 #124 #125 #126

Commits:
- 8188f48 fix(registry): prune dead fallback model ids (#121)
- ee50275 fix(anti-ban): P2 wire identity, spend ledger, egress probe (#116-#120, #122-#126)

Verification: gofmt clean, go vet ./... clean, full go test ./... green (hermetic env).