### PR TITLE
fix(updatecheck): honor backoff after failed refresh

### DIFF
--- a/internal/updatecheck/updatecheck.go
+++ b/internal/updatecheck/updatecheck.go
@@ -2,8 +2,10 @@
 // (issue #50b): a cached lookup of the latest GitHub release tag for the
 // repo, plus a semver-ish comparison against the running version. The
 // lookup is deliberately non-blocking for the dashboard — the first render
-// after a 6h cache expiry performs one bounded HTTP GET (3s timeout); a
-// failure degrades to "no update" and is retried on the next render.
+// after a 6h cache expiry (or after a failed attempt's backoff window)
+// performs one bounded HTTP GET (3s timeout); a failure degrades to
+// "no update" and backs off for the same 6h window instead of retrying on
+// every render.
 package updatecheck
 
 import (
@@ -51,12 +53,14 @@ func New(repo string, client *http.Client) *Checker {
 }
 
 // Latest returns the latest release tag (e.g. "v0.9.3") from the in-memory
-// cache, fetching it when the cache is empty or older than CacheTTL. A
-// fetch failure returns the previously cached tag (or "") with the error.
-// The cache is refreshed single-flight so concurrent renders share one GET.
+// cache, fetching it when the last attempt — successful or failed — is
+// older than CacheTTL. A fetch failure returns the previously cached tag
+// (or "") with the error and still records the attempt, so subsequent
+// calls back off for CacheTTL instead of re-fetching. The cache is
+// refreshed single-flight so concurrent renders share one GET.
 func (c *Checker) Latest(ctx context.Context) (string, error) {
 	c.mu.Lock()
-	if c.latest != "" && time.Since(c.fetched) < CacheTTL {
+	if time.Since(c.fetched) < CacheTTL {
 		tag := c.latest
 		c.mu.Unlock()
 		return tag, nil
@@ -92,10 +96,10 @@ func (c *Checker) Latest(ctx context.Context) (string, error) {
 		c.latest = tag
 		c.fetched = time.Now()
 	} else {
-		// Keep the previous value (retry on the next render). A first-ever
-		// failure also stamps fetched so the dashboard's frequent polls back
-		// off for CacheTTL instead of hammering api.github.com on every
-		// render (review P2).
+		// Keep the previous value and stamp the attempt: the CacheTTL window
+		// now also covers failed lookups (first-ever failure included), so
+		// the dashboard's frequent polls back off instead of hammering
+		// api.github.com on every render (review P2).
 		c.fetched = time.Now()
 	}
 	got := c.latest

--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -104,6 +104,39 @@ func TestLatestFetchFailureReturnsprev(t *testing.T) {
 	}
 }
 
+// TestLatestFirstFetchFailureBacksOffForTTL verifies that a failed first
+// fetch still starts the CacheTTL backoff window: the attempt is stamped
+// fetched (see the review-P2 comment in Latest), so a second call well
+// inside CacheTTL must reuse the recorded failure window instead of
+// hitting the network again.
+func TestLatestFirstFetchFailureBacksOffForTTL(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+	tr := &rewriteTransport{target: srv.URL}
+	c := New(DefaultRepo, &http.Client{Transport: tr, Timeout: fetchTimeout})
+
+	if latest, err := c.Latest(context.Background()); latest != "" || err == nil {
+		t.Fatalf("first Latest = %q, %v; want empty + error", latest, err)
+	}
+	if hits != 1 {
+		t.Fatalf("network hits after first call = %d, want 1", hits)
+	}
+
+	// Second call, immediately (well inside CacheTTL): must NOT re-fetch,
+	// and the backoff hit surfaces as an empty tag with no error.
+	latest2, err2 := c.Latest(context.Background())
+	if latest2 != "" || err2 != nil {
+		t.Errorf("second Latest = %q, %v; want empty tag + nil error (backoff hit)", latest2, err2)
+	}
+	if hits != 1 {
+		t.Errorf("network hits after second call = %d, want 1 (first-ever failure must back off for CacheTTL)", hits)
+	}
+}
+
 // rewriteTransport sends every request to target (a test seam: the checker
 // hardcodes the github.com URL, which tests must not contact).
 type rewriteTransport struct {


### PR DESCRIPTION
## Description

A failed first update check records `fetched`, but the cache path also required `latest` to be non-empty. As a result, when GitHub was unavailable before any successful fetch, each subsequent dashboard render could trigger another request instead of respecting `CacheTTL`.

This change makes the cache window depend on the last fetch attempt, whether successful or failed. A fresh checker still performs its initial request, while a failed attempt now backs off for the existing `CacheTTL` window as intended.

Adds a regression test covering the first-fetch failure case and updates stale comments to match the backoff behavior.

No related issue; this was found while reviewing the update-check caching path.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Docs only
- [ ] Dependency update

## Checklist

- [x] Code builds: `go build ./...`
- [x] `go vet ./...` clean
- [x] Tests pass: `go test ./...` (CI also runs `-race`)
- [x] Tests added/updated for the change
- [x] Public docs updated if behavior or config changed (`README.md`, `docs/guides/`) — not applicable; no public config or user-facing documentation changed
- [x] No secrets: no real tokens, `.env`, or `config.json` content

## Notes

The regression test verifies that after a first-ever failed update check, a second `Latest()` call within `CacheTTL` does not issue another HTTP request.

The change intentionally reuses the existing `fetched` timestamp and does not introduce additional retry state or alter the update-check concurrency path.
