### PR TITLE
fix(logring): inline empty-key groups

### DIFF
--- a/internal/logring/logring.go
+++ b/internal/logring/logring.go
@@ -168,16 +168,18 @@ func (h *Handler) WithGroup(name string) slog.Handler {
 }
 
 // flatten renders an attr subtree into "key=value" strings; group keys are
-// dotted (group.subkey=value).
+// dotted (group.subkey=value) and empty-key groups are inlined.
 func flatten(prefix string, a slog.Attr) []string {
 	if a.Value.Kind() == slog.KindGroup {
-		// Recurse with the GROUP's own key as the new prefix so
-		// slog.Group("http", slog.Int("status", 200)) renders
-		// "http.status=200" — the child keys extend the group, they do not
-		// replace it.
-		key := a.Key
-		if prefix != "" {
-			key = prefix + "." + key
+		// The group's own key extends the prefix ("http.status=200"); an
+		// empty key inlines the group, so children keep the current prefix
+		// with no extra separator.
+		key := prefix
+		if a.Key != "" {
+			key = a.Key
+			if prefix != "" {
+				key = prefix + "." + a.Key
+			}
 		}
 		var out []string
 		for _, child := range a.Value.Group() {

--- a/internal/logring/logring_test.go
+++ b/internal/logring/logring_test.go
@@ -323,3 +323,55 @@ func TestCountsConcurrent(t *testing.T) {
 		t.Errorf("Counts()[warn|retry] = %d, want %d", got, goroutines*per)
 	}
 }
+
+// TestRingEmptyGroupInlined is the empty-key group regression: a group with
+// an empty key must be inlined (slog contract: "If a group's key is empty,
+// inline the group's Attrs"), so its children keep the current prefix with
+// no extra separator — "svc.status=200", never "svc..status=200".
+func TestRingEmptyGroupInlined(t *testing.T) {
+	cases := []struct {
+		name      string
+		withGroup string
+		group     slog.Attr
+		want      string
+	}{
+		{
+			name:      "empty group under named prefix",
+			withGroup: "svc",
+			group:     slog.Group("", slog.Int("status", 200)),
+			want:      "svc.status=200",
+		},
+		{
+			name:      "nested empty group",
+			withGroup: "svc",
+			group:     slog.Group("", slog.Group("inner", slog.Int("status", 200))),
+			want:      "svc.inner.status=200",
+		},
+		{
+			name:      "consecutive empty groups",
+			withGroup: "svc",
+			group:     slog.Group("", slog.Group("", slog.Int("status", 200))),
+			want:      "svc.status=200",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewHandler(discarding{}, 10)
+			logger := slog.New(h)
+			if tc.withGroup != "" {
+				logger = logger.WithGroup(tc.withGroup)
+			}
+			logger.Info("msg", tc.group)
+			recent := h.Recent(1)
+			if len(recent) != 1 {
+				t.Fatalf("Recent(1) = %d entries, want 1", len(recent))
+			}
+			// One record with one attr: Fields must equal the expected
+			// single field exactly, so any malformed "svc..status=200"
+			// shape fails the equality implicitly.
+			if got := recent[0].Fields; len(got) != 1 || got[0] != tc.want {
+				t.Errorf("fields = %v, want [%s]", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

`logring` currently adds a separator when flattening an empty-key `slog.Group` under an existing group prefix. This can produce malformed retained fields such as:

```text
svc..status=200
```

instead of:

```text
svc.status=200
```

The `slog.Handler` contract specifies that groups with an empty key should have their attributes inlined.

This change keeps the existing prefix unchanged for empty-key groups while preserving the current behavior for named groups.

Regression coverage includes empty groups under a named prefix, nested empty groups, and consecutive empty groups.

No related issue; this was found while reviewing the structured log flattening path.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor / internal
* [ ] Docs only
* [ ] Dependency update

## Checklist

* [x] Code builds: `go build ./...`
* [x] `go vet ./...` clean
* [x] Tests pass: `go test ./...` (CI also runs `-race`)
* [x] Tests added/updated for the change
* [x] Public docs updated if behavior or config changed (`README.md`, `docs/guides/`) — not applicable; no public config or documentation changes
* [x] No secrets: no real tokens, `.env`, or `config.json` content

## Notes

Targeted `logring` tests pass with the race detector, and the full local race suite passes sequentially with `go test -race -p 1 ./...`.
