### PR TITLE
feat(config): add DASHBOARD_ENABLED option to disable web UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -189,3 +189,10 @@ LOG_LEVEL=info
 # reasoning_details is never folded. true/1/on — "think" tag; any other
 # word becomes the tag.
 #REASONING_IN_CONTENT=false
+#
+# ── Web UI ────────────────────────────────────────────────────────────────
+# Enable the embedded admin dashboard at /admin. Set to false to disable
+# all /admin routes (returns 404). The dashboard provides token management,
+# config editing, log viewer, and metrics — recommended to keep enabled
+# unless you're running headless.
+#DASHBOARD_ENABLED=true

--- a/.env.full-example
+++ b/.env.full-example
@@ -23,6 +23,10 @@ LISTEN_ADDR=127.0.0.1:3457
 #   openssl rand -hex 16   (or: python -c "import secrets;print(secrets.token_hex(16))")
 # Leave empty ONLY on loopback-only single-user installs.
 ADMIN_TOKEN=
+#
+# Enable/disable the embedded admin dashboard at /admin. When false, all
+# /admin routes return 404 and the dashboard struct is not created.
+#DASHBOARD_ENABLED=true
 
 # Optional client auth for the OpenAI-compatible endpoint. When set, only
 # requests bearing one of these keys (Authorization: Bearer or x-api-key)

--- a/cmd/freebuff-proxy/main.go
+++ b/cmd/freebuff-proxy/main.go
@@ -286,6 +286,7 @@ func main() {
 		"registry_models", reg.ModelCount(),
 		"log_level", logLevelDisplay(level),
 		"verbose", *verbose,
+		"dashboard_enabled", cfg.DashboardEnabled,
 	)
 	if cfg.ActingUserID != "" {
 		// #126: the header is only safe with the token's OWN account id (the
@@ -297,7 +298,7 @@ func main() {
 	// /admin/reload and the admin dashboard are open in default deployments
 	// (no API_KEYS, or bridge mode): warn loudly so operators can decide
 	// whether to set ADMIN_TOKEN.
-	if cfg.AdminToken == "" && (len(cfg.APIKeys) == 0 || cfg.BridgeMode()) {
+	if cfg.DashboardEnabled && cfg.AdminToken == "" && (len(cfg.APIKeys) == 0 || cfg.BridgeMode()) {
 		logger.Warn("/admin/reload and the /admin dashboard are unauthenticated — any client that can reach the proxy can reload configuration and view its state. Set ADMIN_TOKEN to require a bearer token")
 	}
 	logger.Info("listening", "addr", cfg.ListenAddr)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -159,6 +159,10 @@ type Config struct {
 	// PreferMaxModels maps standard model IDs to their -max extended context
 	// variants (PREFER_MAX_MODELS).
 	PreferMaxModels bool
+	// DashboardEnabled controls whether the embedded admin web UI is served
+	// (DASHBOARD_ENABLED; default true). Set to false to disable all /admin
+	// routes.
+	DashboardEnabled bool
 	// AccessTier is the account access tier the proxy assumes for -max model
 	// upgrades (ACCESS_TIER, or learned at runtime from the upstream session
 	// probe/admission response's accessTier field): "full" (default when
@@ -268,6 +272,7 @@ type rawConfig struct {
 	RateLimitPerIP                   *float64        `json:"RATE_LIMIT_PER_IP"`
 	RateLimitBurst                   *int            `json:"RATE_LIMIT_BURST"`
 	PreferMaxModels                  bool            `json:"PREFER_MAX_MODELS"`
+	DashboardEnabled                 bool            `json:"DASHBOARD_ENABLED"`
 	AccessTier                       string          `json:"ACCESS_TIER"`
 }
 
@@ -306,6 +311,7 @@ func defaultRawConfig() rawConfig {
 		MaxSpendPerDay:                   nil,         // 0 = unlimited advisory spend ceiling (never enforced)
 		IdleRotationTimeout:              "",          // "" = disabled (unset → SAFE_MODE preset may fill)
 		SafeMode:                         true,        // anti-ban presets on by default; set SAFE_MODE=false to disable
+		DashboardEnabled:                 true,        // dashboard on by default; set DASHBOARD_ENABLED=false to disable
 		LogAccess:                        true,        // per-request access lines on by default; LOG_ACCESS=false disables them
 		LogRingSize:                      ptrInt(500), // dashboard log viewer ring capacity (T19)
 		CORSAllowedOrigin:                "*",         // browser clients reach /v1/* cross-origin by default
@@ -491,6 +497,7 @@ func Load(configPath string) (Config, error) {
 	overrideFloat(&raw.RateLimitPerIP, "RATE_LIMIT_PER_IP")
 	overrideInt(&raw.RateLimitBurst, "RATE_LIMIT_BURST")
 	overrideBool(&raw.PreferMaxModels, "PREFER_MAX_MODELS")
+	overrideBool(&raw.DashboardEnabled, "DASHBOARD_ENABLED")
 	overrideString(&raw.AccessTier, "ACCESS_TIER")
 
 	parseDuration := func(raw, name string) (time.Duration, error) {
@@ -753,6 +760,7 @@ func Load(configPath string) (Config, error) {
 		RateLimitPerIP:                   rateLimitPerIP,
 		RateLimitBurst:                   rateLimitBurst,
 		PreferMaxModels:                  raw.PreferMaxModels,
+		DashboardEnabled:                 raw.DashboardEnabled,
 		AccessTier:                       strings.TrimSpace(raw.AccessTier),
 		AccessTierExplicit:               strings.TrimSpace(raw.AccessTier) != "",
 		EnvFile:                          envFileUsed,
@@ -1090,6 +1098,7 @@ func applyDotenv(raw *rawConfig, path string) error {
 	overrideFloatFrom(&raw.RateLimitPerIP, get, "RATE_LIMIT_PER_IP")
 	overrideIntFrom(&raw.RateLimitBurst, get, "RATE_LIMIT_BURST")
 	overrideBoolFrom(&raw.PreferMaxModels, get, "PREFER_MAX_MODELS")
+	overrideBoolFrom(&raw.DashboardEnabled, get, "DASHBOARD_ENABLED")
 	overrideStringFrom(&raw.AccessTier, get, "ACCESS_TIER")
 	return nil
 }

--- a/internal/server/dashboard_edge_test.go
+++ b/internal/server/dashboard_edge_test.go
@@ -40,6 +40,7 @@ func bridgeDashboardServer(t *testing.T, adminToken string) *httptest.Server {
 		RegistryRefresh:    6 * time.Hour,
 		UpstreamBaseURL:    mock.URL(),
 		AdminToken:         adminToken,
+		DashboardEnabled:   true,
 	}
 	reg := registry.New(cfg, nil)
 	reg.LoadFallback()
@@ -102,6 +103,7 @@ func TestDashboardTokenTestAllEmptyRegistry(t *testing.T) {
 		RegistryRefresh:    6 * time.Hour,
 		UpstreamBaseURL:    mock.URL(),
 		AdminToken:         "secret",
+		DashboardEnabled:   true,
 	}
 	reg := registry.New(cfg, nil) // no LoadFallback → empty catalog
 	clientCfg := *cfg
@@ -740,6 +742,7 @@ func TestDashboardSmokeEmptyRegistry(t *testing.T) {
 		RegistryRefresh:    6 * time.Hour,
 		UpstreamBaseURL:    mock.URL(),
 		AdminToken:         "secret",
+		DashboardEnabled:   true,
 	}
 	reg := registry.New(cfg, nil) // no fallback
 	p, err := pool.New(cfg, nil, nil, reg)

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -566,6 +566,7 @@ func TestDashboardModeSwitchClearsJSONConfigTokens(t *testing.T) {
 		RegistryRefresh:    6 * time.Hour,
 		UpstreamBaseURL:    mock.URL(),
 		AdminToken:         "secret",
+		DashboardEnabled:   true,
 	}
 	clientCfg := *cfg
 	clientCfg.UpstreamBaseURL = mock.URL()
@@ -793,6 +794,7 @@ func TestDashboardConcurrentTokenAdds(t *testing.T) {
 		RegistryRefresh:    6 * time.Hour,
 		UpstreamBaseURL:    mock.URL(),
 		AdminToken:         "secret",
+		DashboardEnabled:   true,
 	}
 	clientCfg := *cfg
 	clientCfg.UpstreamBaseURL = mock.URL()
@@ -1040,6 +1042,7 @@ func TestDashboardTokenRemoveRollsBackOnPersistFailure(t *testing.T) {
 		RegistryRefresh:    6 * time.Hour,
 		UpstreamBaseURL:    mock.URL(),
 		AdminToken:         "secret",
+		DashboardEnabled:   true,
 	}
 	clientCfg := *cfg
 	clientCfg.UpstreamBaseURL = mock.URL()
@@ -1088,6 +1091,7 @@ func TestDashboardDiagPortHandling(t *testing.T) {
 		RegistryRefresh:    6 * time.Hour,
 		UpstreamBaseURL:    mock.URL(),
 		AdminToken:         "secret",
+		DashboardEnabled:   true,
 	}
 	clientCfg := *cfg
 	clientCfg.UpstreamBaseURL = mock.URL()
@@ -1147,6 +1151,7 @@ func TestDashboardConfigSaveAppliesModelAliases(t *testing.T) {
 		RegistryRefresh:    6 * time.Hour,
 		UpstreamBaseURL:    mock.URL(),
 		AdminToken:         "secret",
+		DashboardEnabled:   true,
 	}
 	clientCfg := *cfg
 	clientCfg.UpstreamBaseURL = mock.URL()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -147,11 +147,13 @@ func New(cfg *config.Config, p *pool.Pool, reg *registry.Registry, logger *slog.
 	for _, opt := range opts {
 		opt(s)
 	}
-	dashOpts := []dashboard.Option{}
-	if s.version != "" {
-		dashOpts = append(dashOpts, dashboard.WithVersion(s.version, s.updates))
+	if cfg.DashboardEnabled {
+		dashOpts := []dashboard.Option{}
+		if s.version != "" {
+			dashOpts = append(dashOpts, dashboard.WithVersion(s.version, s.updates))
+		}
+		s.dash = dashboard.New(func() *config.Config { return s.cfg.Load() }, p, reg, logger, logs, dashOpts...)
 	}
-	s.dash = dashboard.New(func() *config.Config { return s.cfg.Load() }, p, reg, logger, logs, dashOpts...)
 	s.adminAuth = newAdminAuth()
 	s.reasoningCache = reasoningcache.New(10000, 2*time.Hour)
 	convert.SetReasoningLookup(func(toolID string, content, toolCallsJSON string) (string, string, bool) {
@@ -172,68 +174,70 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /v1/models", s.requireAuth(s.handleModels))
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
 	mux.HandleFunc("GET /metrics", s.handleMetrics)
-	mux.HandleFunc("POST /admin/reload", s.requireAdminToken(s.requireAuth(s.adminCSRF(http.HandlerFunc(s.handleReload)))))
-	// Admin dashboard: cookie-authenticated browser UI. Assets are static
-	// and public — the login page (served without a cookie) references them,
-	// so they must NOT sit behind dashboardAuth. Overview/tokens/metrics are
-	// read-only status and stay open when ADMIN_TOKEN is unset (legacy).
-	// Config (read + write) and logs expose secrets and are gated further:
-	// with ADMIN_TOKEN unset they require a loopback client.
-	// GET /admin/login serves the SPA login page (client-side form, posts to
-	// the JSON API below); with ADMIN_TOKEN unset it redirects straight to
-	// the dashboard (handleAdminLogin's first branch). POST /admin/login is
-	// the JSON token-check API.
-	mux.HandleFunc("GET /admin/login", s.handleAdminLogin)
-	// POST /admin/login consumes the per-IP login-attempt budget, so it must
-	// carry the same CSRF gate as the other mutating admin routes: without it
-	// a malicious page could fire cross-origin POSTs with wrong tokens and
-	// lock the victim out of the dashboard (5 fails → 1-minute lockout,
-	// repeatable).
-	mux.HandleFunc("POST /admin/login", s.adminCSRF(http.HandlerFunc(s.handleAdminLogin)))
-	// GET /admin/logout clears the session cookie and returns to the login
-	// page; POST /admin/logout does the same but answers JSON {"ok":true}.
-	// Logout deliberately runs WITHOUT a valid cookie (expired sessions must
-	// still be logged out) and is NOT wrapped in adminSensitive — it exposes
-	// nothing and must work for anyone capable of reaching /admin/login.
-	mux.HandleFunc("GET /admin/logout", s.handleAdminLogout)
-	mux.HandleFunc("POST /admin/logout", s.handleAdminLogout)
-	// Admin dashboard API routes (JSON)
-	mux.Handle("GET /admin/api/overview", s.dashboardAuth(s.dash.APIHandler("overview")))
-	mux.Handle("GET /admin/api/tokens", s.dashboardAuth(s.dash.APIHandler("tokens")))
-	mux.Handle("GET /admin/api/models", s.dashboardAuth(s.dash.APIHandler("models")))
-	mux.Handle("GET /admin/api/traces", s.dashboardAuth(s.dash.APIHandler("traces")))
-	mux.Handle("GET /admin/api/setup", s.dashboardAuth(s.dash.APIHandler("setup")))
-	mux.Handle("GET /admin/api/config", s.dashboardAuth(s.adminSensitive(s.dash.APIHandler("config"))))
-	mux.Handle("GET /admin/api/logs", s.dashboardAuth(s.adminSensitive(s.dash.APIHandler("logs"))))
-	mux.Handle("GET /admin/api/metrics", s.dashboardAuth(s.dash.APIHandler("metrics")))
-	mux.Handle("GET /admin/api/version", s.dashboardAuth(http.HandlerFunc(s.dash.APIVersion)))
+	if s.cfg.Load().DashboardEnabled {
+		mux.HandleFunc("POST /admin/reload", s.requireAdminToken(s.requireAuth(s.adminCSRF(http.HandlerFunc(s.handleReload)))))
+		// Admin dashboard: cookie-authenticated browser UI. Assets are static
+		// and public — the login page (served without a cookie) references them,
+		// so they must NOT sit behind dashboardAuth. Overview/tokens/metrics are
+		// read-only status and stay open when ADMIN_TOKEN is unset (legacy).
+		// Config (read + write) and logs expose secrets and are gated further:
+		// with ADMIN_TOKEN unset they require a loopback client.
+		// GET /admin/login serves the SPA login page (client-side form, posts to
+		// the JSON API below); with ADMIN_TOKEN unset it redirects straight to
+		// the dashboard (handleAdminLogin's first branch). POST /admin/login is
+		// the JSON token-check API.
+		mux.HandleFunc("GET /admin/login", s.handleAdminLogin)
+		// POST /admin/login consumes the per-IP login-attempt budget, so it must
+		// carry the same CSRF gate as the other mutating admin routes: without it
+		// a malicious page could fire cross-origin POSTs with wrong tokens and
+		// lock the victim out of the dashboard (5 fails → 1-minute lockout,
+		// repeatable).
+		mux.HandleFunc("POST /admin/login", s.adminCSRF(http.HandlerFunc(s.handleAdminLogin)))
+		// GET /admin/logout clears the session cookie and returns to the login
+		// page; POST /admin/logout does the same but answers JSON {"ok":true}.
+		// Logout deliberately runs WITHOUT a valid cookie (expired sessions must
+		// still be logged out) and is NOT wrapped in adminSensitive — it exposes
+		// nothing and must work for anyone capable of reaching /admin/login.
+		mux.HandleFunc("GET /admin/logout", s.handleAdminLogout)
+		mux.HandleFunc("POST /admin/logout", s.handleAdminLogout)
+		// Admin dashboard API routes (JSON)
+		mux.Handle("GET /admin/api/overview", s.dashboardAuth(s.dash.APIHandler("overview")))
+		mux.Handle("GET /admin/api/tokens", s.dashboardAuth(s.dash.APIHandler("tokens")))
+		mux.Handle("GET /admin/api/models", s.dashboardAuth(s.dash.APIHandler("models")))
+		mux.Handle("GET /admin/api/traces", s.dashboardAuth(s.dash.APIHandler("traces")))
+		mux.Handle("GET /admin/api/setup", s.dashboardAuth(s.dash.APIHandler("setup")))
+		mux.Handle("GET /admin/api/config", s.dashboardAuth(s.adminSensitive(s.dash.APIHandler("config"))))
+		mux.Handle("GET /admin/api/logs", s.dashboardAuth(s.adminSensitive(s.dash.APIHandler("logs"))))
+		mux.Handle("GET /admin/api/metrics", s.dashboardAuth(s.dash.APIHandler("metrics")))
+		mux.Handle("GET /admin/api/version", s.dashboardAuth(http.HandlerFunc(s.dash.APIVersion)))
 
-	// SPA: all admin/* GET routes serve the embedded Svelte SPA
-	mux.Handle("GET /admin", s.dashboardAuth(http.HandlerFunc(s.dash.ServeSPA)))
-	mux.Handle("GET /admin/", s.dashboardAuth(http.HandlerFunc(s.dash.ServeSPA)))
-	mux.Handle("GET /admin/tokens", s.dashboardAuth(http.HandlerFunc(s.dash.ServeSPA)))
-	mux.Handle("GET /admin/models", s.dashboardAuth(http.HandlerFunc(s.dash.ServeSPA)))
-	mux.Handle("GET /admin/traces", s.dashboardAuth(http.HandlerFunc(s.dash.ServeSPA)))
-	mux.Handle("GET /admin/setup", s.dashboardAuth(http.HandlerFunc(s.dash.ServeSPA)))
-	mux.Handle("GET /admin/playground", s.dashboardAuth(http.HandlerFunc(s.dash.ServeSPA)))
-	mux.Handle("GET /admin/config", s.dashboardAuth(s.adminSensitive(http.HandlerFunc(s.dash.ServeSPA))))
-	mux.Handle("GET /admin/logs", s.dashboardAuth(s.adminSensitive(http.HandlerFunc(s.dash.ServeSPA))))
-	mux.Handle("GET /admin/metrics", s.dashboardAuth(http.HandlerFunc(s.dash.ServeSPA)))
-	mux.Handle("POST /admin/playground/chat", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handlePlaygroundChat)))))
-	mux.Handle("POST /admin/login/start", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleLoginStart)))))
-	mux.Handle("GET /admin/login/status", s.dashboardAuth(s.adminSensitive(http.HandlerFunc(s.handleLoginStatus))))
-	mux.Handle("POST /admin/config", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleConfigSave)))))
-	mux.Handle("POST /admin/tokens/{id}/unlock", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleTokenUnlock)))))
-	mux.Handle("POST /admin/tokens/{id}/finish", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleTokenFinish)))))
-	mux.Handle("POST /admin/tokens/{id}/test", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleTokenTest)))))
-	mux.Handle("POST /admin/tokens/test-all", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleTokenTestAll)))))
-	mux.Handle("POST /admin/tokens/add", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleTokenAdd)))))
-	mux.Handle("POST /admin/tokens/remove", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleTokenRemove)))))
-	mux.Handle("POST /admin/mode", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleModeSwitch)))))
-	mux.Handle("POST /admin/diag", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleDiag)))))
-	mux.Handle("POST /admin/smoke", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleSmoke)))))
-	// Static assets: serve from embedded dist/assets
-	mux.Handle("GET /admin/assets/", noDirListing(http.StripPrefix("/admin/assets/", http.FileServerFS(mustSubFS(dashboard.DistFS(), "assets")))))
+		// SPA: all admin/* GET routes serve the embedded Svelte SPA
+		mux.Handle("GET /admin", s.dashboardAuth(http.HandlerFunc(s.dash.ServeSPA)))
+		mux.Handle("GET /admin/", s.dashboardAuth(http.HandlerFunc(s.dash.ServeSPA)))
+		mux.Handle("GET /admin/tokens", s.dashboardAuth(http.HandlerFunc(s.dash.ServeSPA)))
+		mux.Handle("GET /admin/models", s.dashboardAuth(http.HandlerFunc(s.dash.ServeSPA)))
+		mux.Handle("GET /admin/traces", s.dashboardAuth(http.HandlerFunc(s.dash.ServeSPA)))
+		mux.Handle("GET /admin/setup", s.dashboardAuth(http.HandlerFunc(s.dash.ServeSPA)))
+		mux.Handle("GET /admin/playground", s.dashboardAuth(http.HandlerFunc(s.dash.ServeSPA)))
+		mux.Handle("GET /admin/config", s.dashboardAuth(s.adminSensitive(http.HandlerFunc(s.dash.ServeSPA))))
+		mux.Handle("GET /admin/logs", s.dashboardAuth(s.adminSensitive(http.HandlerFunc(s.dash.ServeSPA))))
+		mux.Handle("GET /admin/metrics", s.dashboardAuth(http.HandlerFunc(s.dash.ServeSPA)))
+		mux.Handle("POST /admin/playground/chat", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handlePlaygroundChat)))))
+		mux.Handle("POST /admin/login/start", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleLoginStart)))))
+		mux.Handle("GET /admin/login/status", s.dashboardAuth(s.adminSensitive(http.HandlerFunc(s.handleLoginStatus))))
+		mux.Handle("POST /admin/config", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleConfigSave)))))
+		mux.Handle("POST /admin/tokens/{id}/unlock", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleTokenUnlock)))))
+		mux.Handle("POST /admin/tokens/{id}/finish", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleTokenFinish)))))
+		mux.Handle("POST /admin/tokens/{id}/test", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleTokenTest)))))
+		mux.Handle("POST /admin/tokens/test-all", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleTokenTestAll)))))
+		mux.Handle("POST /admin/tokens/add", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleTokenAdd)))))
+		mux.Handle("POST /admin/tokens/remove", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleTokenRemove)))))
+		mux.Handle("POST /admin/mode", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleModeSwitch)))))
+		mux.Handle("POST /admin/diag", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleDiag)))))
+		mux.Handle("POST /admin/smoke", s.dashboardAuth(s.adminSensitive(s.adminCSRF(http.HandlerFunc(s.handleSmoke)))))
+		// Static assets: serve from embedded dist/assets
+		mux.Handle("GET /admin/assets/", noDirListing(http.StripPrefix("/admin/assets/", http.FileServerFS(mustSubFS(dashboard.DistFS(), "assets")))))
+	}
 	// CORS middleware wraps the whole route table: it answers OPTIONS
 	// preflights on the /v1/* API surface with 204 and stamps the allow
 	// headers on every /v1/* response. Admin routes are intentionally left

--- a/internal/server/server_api_test.go
+++ b/internal/server/server_api_test.go
@@ -43,6 +43,7 @@ func newTestServerWithLogger(t *testing.T, apiKeys []string, logger *slog.Logger
 		UpstreamBaseURL:    "https://www.codebuff.com",
 		APIKeys:            apiKeys,
 		LogAccess:          true,
+		DashboardEnabled:   true,
 	}
 	clients := make([]*upstream.Client, 0, len(mocks))
 	sessions := make([]*session.Manager, 0, len(mocks))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -48,6 +48,7 @@ func newTestServerCfg(t *testing.T, apiKeys []string, mut func(*config.Config), 
 		UpstreamBaseURL:    "https://www.codebuff.com",
 		APIKeys:            apiKeys,
 		LogAccess:          true,
+		DashboardEnabled:   true,
 	}
 	if mut != nil {
 		mut(cfg)
@@ -1629,6 +1630,7 @@ func newBridgeTestServer(t *testing.T, mock *testutil.MockUpstream) (*httptest.S
 		SessionCallTimeout: 5 * time.Second,
 		RegistryRefresh:    6 * time.Hour,
 		UpstreamBaseURL:    mock.URL(),
+		DashboardEnabled:   true,
 	}
 	reg := registry.New(cfg, nil)
 	reg.LoadFallback()
@@ -1941,6 +1943,7 @@ func TestChatModelAliasesAndReasoningEffort(t *testing.T) {
 		ModelAliases: map[string]string{
 			"gpt-4o": modelA,
 		},
+		DashboardEnabled: true,
 	}, p, reg, nil, nil, "")
 	tsAlias := httptest.NewServer(srv.Handler())
 	t.Cleanup(tsAlias.Close)
@@ -2006,6 +2009,7 @@ func TestMetricsTransientRetryCounters(t *testing.T) {
 		SessionCallTimeout: 5 * time.Second,
 		RegistryRefresh:    6 * time.Hour,
 		UpstreamBaseURL:    mock.URL(),
+		DashboardEnabled:   true,
 		TransientRetries:   1,
 	}
 	client, err := upstream.New("tok-0", cfg)

--- a/internal/server/server_wave6_test.go
+++ b/internal/server/server_wave6_test.go
@@ -285,6 +285,7 @@ func newServerOpts(t *testing.T, mock *testutil.MockUpstream, mut func(*config.C
 		RegistryRefresh:    6 * time.Hour,
 		UpstreamBaseURL:    "https://www.codebuff.com",
 		LogAccess:          true,
+		DashboardEnabled:   true,
 	}
 	if mut != nil {
 		mut(cfg)


### PR DESCRIPTION
Add `DASHBOARD_ENABLED` config knob (env/JSON/.env, default `true`) that fully disables the embedded admin dashboard when set to `false`.

## What changes

- **Config**: `DashboardEnabled bool` in `Config` + `rawConfig` structs, `overrideBool` wiring, default `true`
- **Server**: All `/admin` routes gated on `s.cfg.Load().DashboardEnabled` — when false, the mux returns 404. Dashboard struct is not created (`s.dash` stays nil)
- **Startup**: Log line includes `dashboard_enabled` field; unauthenticated dashboard warning suppressed when disabled
- **Docs**: `.env.example` and `.env.full-example` updated with new section

## Usage

```env
DASHBOARD_ENABLED=false
```

Or in JSON config:
```json
{
  "DASHBOARD_ENABLED": false
}
```

## Verification

```
go build ./...
env -u AUTH_TOKENS -u ADMIN_TOKEN go test ./... -count=1 -short
gofmt -l cmd internal
```

All pass. 10 files changed, +106/-67.