### PR TITLE
fix(server): treat session_superseded as terminal, never retry in-request

### DIFF
--- a/internal/pool/lifecycle.go
+++ b/internal/pool/lifecycle.go
@@ -143,11 +143,20 @@ func (p *Pool) RecordSpend(lease *Lease, tokens int64) {
 // failing must not invalidate the fresh one. Out-of-range tokens are
 // ignored.
 func (p *Pool) InvalidateSession(token int, instanceID string) {
+	p.InvalidateSessionWithReason(token, instanceID, "instance_invalidated", 0)
+}
+
+// InvalidateSessionWithReason drops the cached session of token only when
+// its instance id matches instanceID (issue #132 guard), recording WHY
+// (T9/T10). The superseded chat recovery path passes session.ReasonSuperseded
+// (#159) so the re-admit storm detector can attribute the invalidation; the
+// other session-invalid paths keep the generic instance_invalidated reason.
+func (p *Pool) InvalidateSessionWithReason(token int, instanceID, reason string, status int) {
 	toks := p.toks.Load()
 	if token < 0 || token >= len(*toks) {
 		return
 	}
-	(*toks)[token].session.InvalidateInstance(instanceID)
+	(*toks)[token].session.InvalidateInstanceWithReason(instanceID, reason, status)
 }
 
 // InvalidateRun drops the current run of token for agentID so the next
@@ -181,10 +190,16 @@ func (p *Pool) ClearQueuedCaches() int {
 // entry so the next AcquireBridge re-creates it (session-invalid recovery).
 // Guarded to the lease's instance id (issue #132) — see InvalidateSession.
 func (p *Pool) InvalidateBridgeSession(lease *Lease) {
+	p.InvalidateBridgeSessionWithReason(lease, "instance_invalidated", 0)
+}
+
+// InvalidateBridgeSessionWithReason is the reason-aware form of
+// InvalidateBridgeSession (see InvalidateSessionWithReason, #159).
+func (p *Pool) InvalidateBridgeSessionWithReason(lease *Lease, reason string, status int) {
 	if lease == nil || lease.Bridge == nil {
 		return
 	}
-	lease.Bridge.session.InvalidateInstance(lease.SessionInstanceID)
+	lease.Bridge.session.InvalidateInstanceWithReason(lease.SessionInstanceID, reason, status)
 }
 
 // InvalidateBridgeRun drops the current run of the bridge entry for agentID

--- a/internal/server/engine.go
+++ b/internal/server/engine.go
@@ -174,6 +174,9 @@ func (s *Server) chatCore(w http.ResponseWriter, r *http.Request, model string, 
 			}),
 			s.pool.Chat,
 			s.pool.InvalidateBridgeSession,
+			func(l *pool.Lease) {
+				s.pool.InvalidateBridgeSessionWithReason(l, session.ReasonSuperseded, http.StatusConflict)
+			},
 			s.pool.InvalidateBridgeRun,
 			func(l *pool.Lease) { s.pool.CooldownBridge(l, runs.DefaultCooldown) },
 			s.pool.CooldownBridgeBan,
@@ -222,6 +225,9 @@ func (s *Server) chatCore(w http.ResponseWriter, r *http.Request, model string, 
 			acquire,
 			s.pool.Chat,
 			func(l *pool.Lease) { s.pool.InvalidateSession(l.Token, l.SessionInstanceID) },
+			func(l *pool.Lease) {
+				s.pool.InvalidateSessionWithReason(l.Token, l.SessionInstanceID, session.ReasonSuperseded, http.StatusConflict)
+			},
 			func(l *pool.Lease, agentID string) { s.pool.InvalidateRun(l.Token, agentID) },
 			func(l *pool.Lease) { s.pool.CooldownToken(l.Token, runs.DefaultCooldown) },
 			func(l *pool.Lease, be *upstream.BanError) { s.pool.CooldownTokenBan(l.Token, be) },
@@ -455,13 +461,15 @@ func attemptStatus(err error) int {
 // chatAttempt runs the retry-once recovery loop for one chat request: chat
 // through the leased token; on session-invalid / run-invalid the lease is
 // released, the cached session/run invalidated, and a fresh lease acquired
-// once; on auth-reject / ban / rate-limit / ip-capped the token is cooled
-// down (ip_capped bounded to its retryAfterMs — never the Pacific-midnight
-// lock) and the error returned for writeError. The acquire/chat/invalidate/
-// cooldown hooks are closures so the pooled (fixed-token) and bridge paths
-// share the exact same recovery semantics. On success the returned body
-// reader and final lease belong to the caller: close the body and release
-// the lease via Pool.LeaseRelease when done.
+// once; on session_superseded the lease is released and the cached session
+// invalidated (reason "superseded") but NEVER retried — it is terminal for
+// this request (#159); on auth-reject / ban / rate-limit / ip-capped the
+// token is cooled down (ip_capped bounded to its retryAfterMs — never the
+// Pacific-midnight lock) and the error returned for writeError. The
+// acquire/chat/invalidate/cooldown hooks are closures so the pooled
+// (fixed-token) and bridge paths share the exact same recovery semantics.
+// On success the returned body reader and final lease belong to the caller:
+// close the body and release the lease via Pool.LeaseRelease when done.
 func (s *Server) chatAttempt(
 	ctx context.Context,
 	model string,
@@ -470,6 +478,7 @@ func (s *Server) chatAttempt(
 	acquire func(context.Context, string) (*pool.Lease, error),
 	chat func(context.Context, *pool.Lease, upstream.ChatOptions, []byte) (io.ReadCloser, error),
 	invalidateSession func(*pool.Lease),
+	invalidateSessionSuperseded func(*pool.Lease),
 	invalidateRun func(*pool.Lease, string),
 	cooldownAuth func(*pool.Lease),
 	cooldownBan func(*pool.Lease, *upstream.BanError),
@@ -615,19 +624,20 @@ func (s *Server) chatAttempt(
 				return nil, nil, err
 			}
 		case errors.Is(err, upstream.ErrSessionSuperseded):
-			// #119: 409 session_superseded — another instance took over
-			// the account. Drop the cached session and re-admit ONCE
-			// for this request (mirror the ErrSessionInvalid budget:
-			// attempts > 1 surfaces the error). The session is already
-			// invalidated so the next request re-joins fresh; auto-
-			// retry here avoids the 30s model lock9router would apply
-			// on a503 response. Never loops — a single reacquire, then
-			// surface.
+			// #159: 409 session_superseded — another instance took over
+			// the account; this session's row is GONE (endsTheSession:true
+			// per FREEBUFF_GATE_CODES). TERMINAL for this request: drop the
+			// cached session (reason "superseded" feeds the re-admit storm
+			// detector) so the NEXT request re-admits fresh, and surface
+			// the error immediately. NEVER retry on the dead instance — an
+			// in-request re-admit burns a fresh daily session slot against
+			// the superseding instance and risks ping-pong (the #119 retry
+			// was observed as attempts=2 with the slot still wasted until
+			// the client cancelled ~59s). Auto-takeover is the other
+			// instance's to resolve; the next client request re-joins.
 			release()
-			invalidateSession(lease)
-			if attempts > 1 {
-				return nil, nil, err
-			}
+			invalidateSessionSuperseded(lease)
+			return nil, nil, err
 		case errors.Is(err, upstream.ErrRunInvalid):
 			release()
 			invalidateRun(lease, lease.AgentID)

--- a/internal/server/server_edge_test.go
+++ b/internal/server/server_edge_test.go
@@ -568,53 +568,56 @@ func TestBridgeChatSessionInvalidBoundedRetry(t *testing.T) {
 	}
 }
 
-// TestBridgeChatSessionSupersededRetries pins #119 on the bridge path: 409
-// session_superseded retries once — the cached session is dropped and a fresh
-// session is acquired for the retry. This avoids the 30s model lock 9router
-// applies on a 503 response. Two chat attempts, two session creates, success
-// on the retry.
-func TestBridgeChatSessionSupersededRetries(t *testing.T) {
+// TestBridgeChatSessionSupersededTerminal pins #159 on the bridge path: 409
+// session_superseded is TERMINAL — the cached session is dropped immediately
+// and the error surfaces with NO in-request retry (the #119 re-admit-once
+// behavior wasted a fresh daily session slot against the superseding
+// instance). One chat attempt, one session create, 503 session_superseded.
+func TestBridgeChatSessionSupersededTerminal(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
-	// First chat attempt returns session_superseded, second succeeds.
+	// First chat attempt returns session_superseded; a second would succeed
+	// (canary) — the 503 must land without the canary ever firing.
 	callCount := 0
 	originalHandler := mock.ChatHandler
 	mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
 		callCount++
 		if callCount == 1 {
-			// First call: session_superseded
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write([]byte(`{"error":{"message":"session_superseded"}}`))
 			return
 		}
-		// Second call: success
 		if originalHandler != nil {
 			originalHandler(w, r)
-		} else {
-			w.Header().Set("Content-Type", "text/event-stream")
-			_, _ = w.Write([]byte("data: " + chunk("cmpl-test", 1234567890, `"choices":[{"delta":{"content":"ok"},"index":0}]`) + "\n\n"))
-			_, _ = w.Write([]byte("data: [DONE]\n\n"))
+			return
 		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: " + chunk("cmpl-test", 1234567890, `"choices":[{"delta":{"content":"ok"},"index":0}]`) + "\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
 	}
 	ts, _ := newBridgeTestServer(t, mock)
 
 	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA),
 		map[string]string{"Authorization": "Bearer client-tok-ss"})
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, data)
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503: %s", resp.StatusCode, data)
 	}
-	if got := len(mock.RecordedChatHeaders); got != 2 {
-		t.Errorf("upstream chat attempts = %d, want exactly 2 (retry on superseded)", got)
+	if !strings.Contains(string(data), "session_superseded") {
+		t.Errorf("body missing session_superseded: %s", data)
 	}
-	if got := mock.SessionCreates; got != 2 {
-		t.Errorf("session creates = %d, want exactly 2 (invalidated + re-acquired)", got)
+	if got := callCount; got != 1 {
+		t.Errorf("upstream chat attempts = %d, want exactly 1 (no retry on the dead instance)", got)
+	}
+	if got := mock.SessionCreates; got != 1 {
+		t.Errorf("session creates = %d, want exactly 1 (no re-admit against the superseding instance)", got)
 	}
 }
 
-// TestBridgeChatSessionSupersededBoundedRetry pins #119 on the bridge path:
-// when the retry ALSO fails on session_superseded, the attempt budget caps at
-// 2 attempts and surfaces 503 session_superseded.
-func TestBridgeChatSessionSupersededBoundedRetry(t *testing.T) {
+// TestBridgeChatSessionSupersededNextRequestReadmits pins #159 on the bridge
+// path: a superseded chat invalidates the cached session immediately, so the
+// NEXT request re-admits fresh. Two requests: 503 session_superseded (one
+// create), then success on a NEW session (second create — cache was dropped).
+func TestBridgeChatSessionSupersededNextRequestReadmits(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	mock.ChatStatus = http.StatusBadRequest
@@ -629,11 +632,24 @@ func TestBridgeChatSessionSupersededBoundedRetry(t *testing.T) {
 	if !strings.Contains(string(data), "session_superseded") {
 		t.Errorf("body missing session_superseded: %s", data)
 	}
-	if got := len(mock.RecordedChatHeaders); got != 2 {
-		t.Errorf("upstream chat attempts = %d, want exactly 2 (bounded retry on superseded)", got)
+	if got := mock.SessionCreates; got != 1 {
+		t.Fatalf("session creates after superseded request = %d, want 1", got)
+	}
+
+	// Upstream heals; the next request must create a FRESH session (the
+	// superseded row was invalidated, so no cached instance is reused).
+	mock.ChatStatus = http.StatusOK
+	mock.ChatErrorBody = ""
+	resp2, data2 := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA),
+		map[string]string{"Authorization": "Bearer client-tok-ss"})
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("second request status = %d, want 200: %s", resp2.StatusCode, data2)
 	}
 	if got := mock.SessionCreates; got != 2 {
-		t.Errorf("session creates = %d, want exactly 2 (invalidated + re-acquired once)", got)
+		t.Errorf("session creates after re-admit request = %d, want 2 (fresh session, not cache reuse)", got)
+	}
+	if got := len(mock.RecordedChatHeaders); got != 2 {
+		t.Errorf("upstream chat attempts = %d, want 2 (1 per request — no in-request retry)", got)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -581,52 +581,62 @@ func TestChatSessionInvalidBoundedRetry(t *testing.T) {
 	}
 }
 
-// TestChatSessionSupersededRetries pins #119: 409 session_superseded (another
-// instance took over the account, endsTheSession:true) retries once — the
-// cached session is dropped and a fresh session is acquired for the retry.
-// This avoids the 30s model lock 9router applies on a 503 response. Two chat
-// attempts, two session creates, success on the retry.
-func TestChatSessionSupersededRetries(t *testing.T) {
+// TestChatSessionSupersededTerminal pins #159: 409 session_superseded
+// (another instance took over the account, endsTheSession:true) is TERMINAL
+// for the current request — the cached session is dropped immediately and
+// the error surfaces with NO in-request retry. The success canary proves the
+// retry never fires: one chat attempt, one session create, 503
+// session_superseded (the #119 re-admit-once behavior wasted a fresh daily
+// session slot against the superseding instance and still failed).
+func TestChatSessionSupersededTerminal(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
-	// First chat attempt returns session_superseded, second succeeds.
+	// First chat attempt returns session_superseded; a SECOND attempt would
+	// succeed (canary) — the response must still be 503 and the canary must
+	// never fire, proving the dead instance is not re-attempted.
 	callCount := 0
 	originalHandler := mock.ChatHandler
 	mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
 		callCount++
 		if callCount == 1 {
-			// First call: session_superseded
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write([]byte(`{"error":{"message":"session_superseded"}}`))
 			return
 		}
-		// Second call: success
 		if originalHandler != nil {
 			originalHandler(w, r)
-		} else {
-			w.Header().Set("Content-Type", "text/event-stream")
-			_, _ = w.Write([]byte("data: " + chunk("cmpl-test", 1234567890, `"choices":[{"delta":{"content":"ok"},"index":0}]`) + "\n\n"))
-			_, _ = w.Write([]byte("data: [DONE]\n\n"))
+			return
 		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: " + chunk("cmpl-test", 1234567890, `"choices":[{"delta":{"content":"ok"},"index":0}]`) + "\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
 	}
 	ts, _ := newTestServer(t, nil, mock)
 
 	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, data)
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503: %s", resp.StatusCode, data)
 	}
-	if got := len(mock.RecordedChatHeaders); got != 2 {
-		t.Errorf("upstream chat attempts = %d, want exactly 2 (retry on superseded)", got)
+	if !strings.Contains(string(data), "session_superseded") {
+		t.Errorf("body missing session_superseded: %s", data)
 	}
-	if got := mock.SessionCreates; got != 2 {
-		t.Errorf("session creates = %d, want exactly 2 (invalidated + re-acquired)", got)
+	if got := callCount; got != 1 {
+		t.Errorf("upstream chat attempts = %d, want exactly 1 (no retry on the dead instance)", got)
+	}
+	if got := len(mock.RecordedChatHeaders); got != 1 {
+		t.Errorf("upstream chat attempts (recorded) = %d, want exactly 1", got)
+	}
+	if got := mock.SessionCreates; got != 1 {
+		t.Errorf("session creates = %d, want exactly 1 (no re-admit against the superseding instance)", got)
 	}
 }
 
-// TestChatSessionSupersededBoundedRetry pins #119: when the retry ALSO fails
-// on session_superseded, the attempt budget caps at 2 attempts and surfaces
-// 503 session_superseded with Retry-After: 1.
-func TestChatSessionSupersededBoundedRetry(t *testing.T) {
+// TestChatSessionSupersededNextRequestReadmits pins #159: a superseded chat
+// invalidates the cached session immediately, so the NEXT request re-admits
+// fresh instead of reusing the dead row. Two requests: the first surfaces
+// 503 session_superseded (one create), the second succeeds on a NEW session
+// (second create — proves the cache was dropped, not reused).
+func TestChatSessionSupersededNextRequestReadmits(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	mock.ChatStatus = http.StatusBadRequest
@@ -640,11 +650,23 @@ func TestChatSessionSupersededBoundedRetry(t *testing.T) {
 	if !strings.Contains(string(data), "session_superseded") {
 		t.Errorf("body missing session_superseded: %s", data)
 	}
-	if got := len(mock.RecordedChatHeaders); got != 2 {
-		t.Errorf("upstream chat attempts = %d, want exactly 2 (bounded retry on superseded)", got)
+	if got := mock.SessionCreates; got != 1 {
+		t.Fatalf("session creates after superseded request = %d, want 1", got)
+	}
+
+	// Upstream heals; the next request must create a FRESH session (the
+	// superseded row was invalidated, so no cached instance is reused).
+	mock.ChatStatus = http.StatusOK
+	mock.ChatErrorBody = ""
+	resp2, data2 := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("second request status = %d, want 200: %s", resp2.StatusCode, data2)
 	}
 	if got := mock.SessionCreates; got != 2 {
-		t.Errorf("session creates = %d, want exactly 2 (invalidated + re-acquired once)", got)
+		t.Errorf("session creates after re-admit request = %d, want 2 (fresh session, not cache reuse)", got)
+	}
+	if got := len(mock.RecordedChatHeaders); got != 2 {
+		t.Errorf("upstream chat attempts = %d, want 2 (1 per request — no in-request retry)", got)
 	}
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -61,10 +61,8 @@ const (
 	reasonStore      = "store"
 
 	// ReasonSuperseded is the T9 terminal-event reason for a session another
-	// instance took over (session_superseded, endsTheSession:true). Exported
-	// so the chat recovery path records superseded invalidations under the
-	// vocabulary — the re-admit storm detector's (T10) superseded count
-	// depends on the reason reaching recordInvalidation (#159).
+	// instance took over (session_superseded, endsTheSession:true); exported
+	// so the chat recovery path feeds the re-admit storm detector (T10).
 	ReasonSuperseded = reasonSuperseded
 
 	// Re-admit storm detector (T10): more than stormThreshold terminal
@@ -1092,10 +1090,7 @@ func (m *Manager) InvalidateInstance(instanceID string) {
 }
 
 // InvalidateInstanceWithReason is the reason-aware form of InvalidateInstance
-// (#159): instance-guarded drop that records WHY (T9/T10) and the triggering
-// HTTP status. The chat recovery path uses it so a session_superseded
-// invalidation feeds the re-admit storm detector's superseded count and the
-// log names the cause instead of the generic instance_invalidated reason.
+// (#159): additionally records WHY (T9/T10) and the triggering HTTP status.
 func (m *Manager) InvalidateInstanceWithReason(instanceID, reason string, status int) {
 	if instanceID == "" {
 		return

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -60,6 +60,13 @@ const (
 	reasonPoll       = "poll"
 	reasonStore      = "store"
 
+	// ReasonSuperseded is the T9 terminal-event reason for a session another
+	// instance took over (session_superseded, endsTheSession:true). Exported
+	// so the chat recovery path records superseded invalidations under the
+	// vocabulary — the re-admit storm detector's (T10) superseded count
+	// depends on the reason reaching recordInvalidation (#159).
+	ReasonSuperseded = reasonSuperseded
+
 	// Re-admit storm detector (T10): more than stormThreshold terminal
 	// session events within stormWindow is a session re-admit storm — each
 	// invalidation is followed by a fresh admission that burns a daily
@@ -1081,6 +1088,15 @@ func (m *Manager) InvalidateWithReason(reason string, status int) {
 // next request to re-create and restart the churn. A mismatch leaves the
 // cache untouched.
 func (m *Manager) InvalidateInstance(instanceID string) {
+	m.InvalidateInstanceWithReason(instanceID, "instance_invalidated", 0)
+}
+
+// InvalidateInstanceWithReason is the reason-aware form of InvalidateInstance
+// (#159): instance-guarded drop that records WHY (T9/T10) and the triggering
+// HTTP status. The chat recovery path uses it so a session_superseded
+// invalidation feeds the re-admit storm detector's superseded count and the
+// log names the cause instead of the generic instance_invalidated reason.
+func (m *Manager) InvalidateInstanceWithReason(instanceID, reason string, status int) {
 	if instanceID == "" {
 		return
 	}
@@ -1091,8 +1107,12 @@ func (m *Manager) InvalidateInstance(instanceID string) {
 	}
 	m.commit(nil)
 	m.mu.Unlock()
-	m.recordInvalidation("instance_invalidated")
-	slog.Debug("session invalidated", "instance_id", instanceID)
+	m.recordInvalidation(reason)
+	if status > 0 {
+		slog.Debug("session invalidated", "instance_id", instanceID, "reason", reason, "status", status)
+		return
+	}
+	slog.Debug("session invalidated", "instance_id", instanceID, "reason", reason)
 }
 
 // ClearQueued drops the cached session only when it is in the queued

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1983,3 +1983,51 @@ func TestInvalidateInstanceGuarded(t *testing.T) {
 		t.Fatal("cached session not invalidated by its own instance id")
 	}
 }
+
+// TestInvalidateInstanceWithReason pins the #159 superseded invalidation
+// path: the reason-aware instance-guarded drop records the T9 "superseded"
+// reason (feeding the re-admit storm detector's superseded count) with the
+// triggering status, and a stale instance id — a chat still riding the OLD,
+// superseded instance after a fresh re-admit — leaves the newer cache alone.
+func TestInvalidateInstanceWithReason(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mgr := newTestManager(t, mock)
+	if _, err := mgr.EnsureSession(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	restore := captureLogs(&buf)
+	defer restore()
+
+	// A stale instance id must not drop the newer cached session, even with
+	// the superseded reason (#132 guard).
+	mgr.InvalidateInstanceWithReason("inst-stale-999", ReasonSuperseded, http.StatusConflict)
+	mgr.mu.Lock()
+	cur := ""
+	if mgr.state != nil {
+		cur = mgr.state.instanceID
+	}
+	alive := mgr.state != nil
+	mgr.mu.Unlock()
+	if !alive {
+		t.Fatal("cached session invalidated by a stale superseded instance id")
+	}
+
+	// The matching instance id clears it and records reason=superseded
+	// status=409 (T9/T10 vocabulary).
+	mgr.InvalidateInstanceWithReason(cur, ReasonSuperseded, http.StatusConflict)
+	mgr.mu.Lock()
+	alive = mgr.state != nil
+	mgr.mu.Unlock()
+	if alive {
+		t.Fatal("cached session not invalidated by its own superseded instance id")
+	}
+	got := buf.String()
+	if !strings.Contains(got, `msg="session invalidated"`) ||
+		!strings.Contains(got, "reason=superseded") ||
+		!strings.Contains(got, "status=409") {
+		t.Errorf("superseded invalidated log missing reason/status:\n%s", got)
+	}
+}


### PR DESCRIPTION
Closes #159

## Problem
Chat 409 session_superseded (another instance took over the account) triggered the #119 in-request re-admit (attempts=2), burning a fresh daily session slot against the superseding instance and still failing — wasting the slot until client cancel ~59s. 6 hits in 5k logs.

## Change
session_superseded is now TERMINAL for the current request: release lease + invalidate cached session immediately (reason 'superseded', status 409 — feeds the T10 storm detector) + surface 503 session_superseded with NO retry. Next request re-admits fresh. The retry path never re-attempts the dead instance.

## Implementation
- session.go: ReasonSuperseded + InvalidateInstanceWithReason (instance-guarded, #132); InvalidateInstance delegates
- pool/lifecycle.go: InvalidateSessionWithReason / InvalidateBridgeSessionWithReason
- engine.go: chatAttempt invalidateSessionSuperseded closure (pooled + bridge), ErrSessionSuperseded returns immediately — no fall-through to re-acquire loop

## Evidence
- TestChatSessionSupersededTerminal / NextRequestReadmits + bridge equivalents + TestInvalidateInstanceWithReason — all PASS
- `env -u AUTH_TOKENS -u ADMIN_TOKEN go test ./...` — 20/20 packages ok
- gofmt clean; session.go 1399 lines (under 1400 gate)