### PR TITLE
perf(pool): add model_locked_total{token,from,to} metric for switching cost

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -201,6 +201,11 @@ type TokenSnapshot struct {
 	// spend_limited, insufficient_quota, limit_burst_rate,
 	// free_mode_rate_limited, ...). Surfaced per-token in /metrics.
 	RateLimitEvents map[string]int64
+	// ModelLocked tallies model-lock session releases keyed by from → to
+	// model pair (issue #160): each model_locked admission releases the
+	// old slot and re-admits with the requested model. Surfaced per-token
+	// in /metrics as freebuff_proxy_model_locked_total.
+	ModelLocked map[string]map[string]int64
 }
 
 // Pool balances requests across the configured tokens.

--- a/internal/pool/snapshot.go
+++ b/internal/pool/snapshot.go
@@ -103,6 +103,7 @@ func (p *Pool) Snapshot() []TokenSnapshot {
 			TransientRetries:        tok.client.TransientRetries(),
 			FingerprintRotations:    tok.client.FingerprintRotations(),
 			RateLimitEvents:         tok.client.RateLimitEvents(),
+			ModelLocked:             tok.session.ModelLocked(),
 			Spend24h:                spend.Rolling24h,
 			SpendDay:                spend.Day,
 			SpendWeek:               spend.Week,

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -233,6 +233,20 @@ func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	}
 	sb.WriteString("\n")
 
+	sb.WriteString("# HELP freebuff_proxy_model_locked_total Session releases on model lock, by model switch (from to)\n")
+	sb.WriteString("# TYPE freebuff_proxy_model_locked_total counter\n")
+	for _, snap := range snaps {
+		for from, tos := range snap.ModelLocked {
+			for to, n := range tos {
+				if n > 0 {
+					fmt.Fprintf(&sb, "freebuff_proxy_model_locked_total{token=\"%d\",from=\"%s\",to=\"%s\"} %d\n",
+						snap.Token+1, escapeLabelValue(from), escapeLabelValue(to), n)
+				}
+			}
+		}
+	}
+	sb.WriteString("\n")
+
 	if s.logs != nil {
 		// T20: handled-record counters from the dashboard log ring. The key
 		// is logring's "level|msg" (level lowercased). msg is a free-form

--- a/internal/server/server_edge_test.go
+++ b/internal/server/server_edge_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -659,4 +660,63 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return fmt.Sprintf("%s…(%d bytes)", s[:n], len(s))
+}
+
+// TestMetricsModelLockedTotal pins issue #160's metrics surface: a chat
+// that forces a model_locked admission (old slot released, desired model
+// re-admitted) renders freebuff_proxy_model_locked_total with the from→to
+// model pair, per token.
+func TestMetricsModelLockedTotal(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	const lockModel = "deepseek/deepseek-v4-flash"
+	var mu sync.Mutex
+	bAttempts := 0
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			model := r.Header.Get("x-freebuff-model")
+			w.Header().Set("Content-Type", "application/json")
+			if model == modelA {
+				_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-A","model":"`+modelA+`","expiresAt":"2030-01-01T00:00:00Z"}`)
+				return
+			}
+			// The locked model: the first admission is locked to modelA,
+			// the in-loop retry (same refresh) succeeds.
+			mu.Lock()
+			bAttempts++
+			attempt := bAttempts
+			mu.Unlock()
+			if attempt == 1 {
+				_, _ = io.WriteString(w, `{"status":"model_locked","currentModel":"`+modelA+`","requestedModel":"`+lockModel+`"}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-B","model":"`+lockModel+`","expiresAt":"2030-01-01T00:00:00Z"}`)
+		case http.MethodDelete:
+			w.WriteHeader(200)
+			_, _ = io.WriteString(w, `{"status":"ended"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}
+	ts, _ := newTestServer(t, nil, mock)
+
+	// First chat binds the session to modelA; the second switches to
+	// lockModel and trips one model_locked release.
+	for _, model := range []string{modelA, lockModel} {
+		resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(model), nil)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("chat %s status = %d, want 200: %s", model, resp.StatusCode, truncate(string(data), 200))
+		}
+	}
+
+	resp, data := doJSON(t, http.MethodGet, ts.URL+"/metrics", nil, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("metrics status = %d, want 200: %s", resp.StatusCode, truncate(string(data), 200))
+	}
+	body := string(data)
+	want := `freebuff_proxy_model_locked_total{token="1",from="z-ai/glm-5.2",to="deepseek/deepseek-v4-flash"} 1`
+	if !strings.Contains(body, want) {
+		t.Errorf("metrics missing %s in:\n%s", want, body)
+	}
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -155,6 +155,14 @@ type Manager struct {
 	invalidationEvents []invalidationEvent
 	reAdmitTriggers    []time.Time
 	lastStormAt        time.Time
+
+	// modelLocked tallies model-lock release events keyed by from → to
+	// model pair (issue #160): every model_locked admission releases the
+	// old slot and re-admits with the requested model, so the pair counts
+	// the model-switch cost. Guarded by modelLockedMu (refresh holds no
+	// other lock while recording).
+	modelLockedMu sync.Mutex
+	modelLocked   map[string]map[string]int64
 }
 
 // invalidationEvent is one terminal session event in the re-admit storm
@@ -946,6 +954,7 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string, preemptive
 			m.commit(nil)
 			m.mu.Unlock()
 			m.recordInvalidation(reasonModelLock)
+			m.recordModelLock(st.CurrentModel, targetModel)
 			_ = m.client.EndSession(ctx)
 			slog.Debug("session released on model lock, retrying", "reason", reasonModelLock, "current", st.CurrentModel, "target", targetModel)
 		case "model_unavailable":

--- a/internal/session/session_model_locked.go
+++ b/internal/session/session_model_locked.go
@@ -1,0 +1,45 @@
+// session_model_locked.go — issue #160 model-lock release metering.
+//
+// Split from session.go (CI line cap): the model_locked admission branch in
+// Manager.refresh releases the old slot and re-admits with the requested
+// model, and this counter tracks the switching cost per from → to pair so
+// /metrics can surface freebuff_proxy_model_locked_total.
+package session
+
+// recordModelLock tallies one model-lock release for the (from, to) model
+// pair (issue #160): called from the refresh model_locked branch right where
+// the old slot is released and the desired model re-admitted. Own mutex —
+// refresh holds no other lock here.
+func (m *Manager) recordModelLock(from, to string) {
+	m.modelLockedMu.Lock()
+	defer m.modelLockedMu.Unlock()
+	if m.modelLocked == nil {
+		m.modelLocked = make(map[string]map[string]int64)
+	}
+	tos := m.modelLocked[from]
+	if tos == nil {
+		tos = make(map[string]int64)
+		m.modelLocked[from] = tos
+	}
+	tos[to]++
+}
+
+// ModelLocked returns a copy of the model-lock release counter keyed by
+// from → to model pair (empty map when no releases). Fed to /metrics as
+// freebuff_proxy_model_locked_total (issue #160).
+func (m *Manager) ModelLocked() map[string]map[string]int64 {
+	m.modelLockedMu.Lock()
+	defer m.modelLockedMu.Unlock()
+	if m.modelLocked == nil {
+		return map[string]map[string]int64{}
+	}
+	out := make(map[string]map[string]int64, len(m.modelLocked))
+	for from, tos := range m.modelLocked {
+		toCopy := make(map[string]int64, len(tos))
+		for to, n := range tos {
+			toCopy[to] = n
+		}
+		out[from] = toCopy
+	}
+	return out
+}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1040,6 +1040,73 @@ func TestModelLockedReleasesOldSlot(t *testing.T) {
 	if snap := mgr.Snapshot(); snap.InstanceID != "inst-B" {
 		t.Errorf("final instance = %q, want inst-B", snap.InstanceID)
 	}
+	// Issue #160: the release is metered. One model_locked admission for
+	// (model/A → model/B) must land exactly one counter event.
+	if got := mgr.ModelLocked()["model/A"]["model/B"]; got != 1 {
+		t.Errorf("ModelLocked[model/A][model/B] = %d, want 1 (all: %v)", got, mgr.ModelLocked())
+	}
+}
+
+// TestModelLockedCounter pins the issue #160 counter's accumulation
+// semantics: every model_locked admission releases the old slot and
+// re-admits with the desired model, and the from → to pair counts each
+// release — two switches A→B (each locked once upstream) must read 2, not
+// a set/overwrite.
+func TestModelLockedCounter(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mgr := newTestManager(t, mock)
+
+	var mu sync.Mutex
+	bAttempts := 0
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			model := r.Header.Get("x-freebuff-model")
+			w.Header().Set("Content-Type", "application/json")
+			if model == "model/A" {
+				_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-A","model":"model/A","expiresAt":"2030-01-01T00:00:00Z"}`)
+				return
+			}
+			// model/B: alternate locked → active so each A→B switch
+			// hits exactly one model_locked admission (the retry in the
+			// same refresh loop succeeds on the next iteration).
+			mu.Lock()
+			bAttempts++
+			attempt := bAttempts
+			mu.Unlock()
+			if attempt%2 == 1 {
+				_, _ = io.WriteString(w, `{"status":"model_locked","currentModel":"model/A","requestedModel":"model/B"}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-B","model":"model/B","expiresAt":"2030-01-01T00:00:00Z"}`)
+		case http.MethodDelete:
+			w.WriteHeader(200)
+			_, _ = io.WriteString(w, `{"status":"ended"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	// Switch A→B (locked), back to A (no lock), then A→B again (locked).
+	for _, model := range []string{"model/A", "model/B", "model/A", "model/B"} {
+		if _, err := mgr.EnsureSessionForModel(context.Background(), model); err != nil {
+			t.Fatalf("EnsureSessionForModel(%s): %v", model, err)
+		}
+	}
+
+	locked := mgr.ModelLocked()
+	if got := locked["model/A"]["model/B"]; got != 2 {
+		t.Errorf("ModelLocked[model/A][model/B] = %d, want 2 (two locked switches; all: %v)", got, locked)
+	}
+	if len(locked) != 1 {
+		t.Errorf("ModelLocked = %v, want exactly one from→to pair", locked)
+	}
+	// Sanity: the upstream really saw the four model/B creates and two
+	// releases (locked + retry per switch).
+	if bAttempts != 4 {
+		t.Errorf("model/B creates = %d, want 4 (2 locked + 2 retries)", bAttempts)
+	}
 }
 
 // TestRefreshBudgetExhaustedAlwaysNone verifies the create/poll loop is


### PR DESCRIPTION
Closes #160

## Problem
Model stickiness landed (#162) but the switching cost is unobservable. Rapid model switch (v4-pro -> luna -> flash, driven by the v4-pro availability window) still costs a release+recreate (~500-900ms) that should be trackable.

## Change
New metric freebuff_proxy_model_locked_total{token,from,to}: counter lives in session.Manager at the actual reason=model_lock handling site (from=st.CurrentModel, to=targetModel already in scope), flows through the pool snapshot -> /metrics pipeline like RateLimitEvents, preserving per-token labels. Release/retry logic untouched.

## Implementation
- internal/session/session_model_locked.go (new, keeps session.go under 1400)
- pool snapshot + health.go emit

## Evidence
- TestModelLockedCounter (2 switches => count 2), TestModelLockedReleasesOldSlot (+1), TestMetricsModelLockedTotal — PASS
- `env -u AUTH_TOKENS -u ADMIN_TOKEN go test ./...` — 20/20 packages ok
- gofmt clean; session.go 1393 lines