### PR TITLE
fix(server): keepalive must fire on client-write silence, not upstream-read activity

### DIFF
--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -794,7 +794,11 @@ func (s *Server) relayAnthropicStream(ctx context.Context, w http.ResponseWriter
 	defer keepalive.Stop()
 	lines := make(chan lineChunk)
 	go relayReadLoop(ctx, r, lines)
-	relayed := time.Now()
+	// lastWrite tracks the last frame actually written to the CLIENT; the
+	// keepalive condition keys on it so a liveness signal is emitted after
+	// any client-write silence, regardless of upstream comment/junk dribble
+	// (those are dropped and never relayed — #161).
+	lastWrite := time.Now()
 	first := true
 
 	for {
@@ -802,9 +806,9 @@ func (s *Server) relayAnthropicStream(ctx context.Context, w http.ResponseWriter
 		case <-ctx.Done():
 			return
 		case <-keepalive.C:
-			if time.Since(relayed) >= keepaliveInterval {
+			if time.Since(lastWrite) >= keepaliveInterval {
 				_, _ = io.WriteString(w, "event: ping\ndata: {\"type\": \"ping\"}\n\n")
-				relayed = time.Now()
+				lastWrite = time.Now()
 				flusher.Flush()
 			}
 		case lc := <-lines:
@@ -829,7 +833,9 @@ func (s *Server) relayAnthropicStream(ctx context.Context, w http.ResponseWriter
 			}
 			clean, drop := convert.SanitizeChunk(lc.line)
 			if drop {
-				relayed = time.Now()
+				// Dropped upstream lines are never relayed and must not
+				// advance the keepalive timer (client sees only real
+				// frames — #161).
 				continue
 			}
 			var chunk map[string]any
@@ -840,7 +846,7 @@ func (s *Server) relayAnthropicStream(ctx context.Context, w http.ResponseWriter
 				first = false
 				phasetiming.FromContext(ctx).Since(phasetiming.UpstreamTTFBMS, chatStart)
 			}
-			relayed = time.Now()
+			lastWrite = time.Now()
 			stats.chunks++
 			stats.bytes += len(clean)
 			if m, _ := chunk["model"].(string); m != "" {

--- a/internal/server/engine.go
+++ b/internal/server/engine.go
@@ -769,11 +769,13 @@ func usageTotalTokens(usage any) int64 {
 	return prompt + completion
 }
 
-// keepaliveInterval is how long the relay may sit without relaying a data
-// chunk before it emits an SSE comment frame to hold the connection open.
-// Long upstream reasoning pauses produce no chunks, and proxies/clients may
-// treat silence as a dead connection. A var (not const) so tests can shrink
-// it.
+// keepaliveInterval is how long the relay may go without writing a frame
+// to the client before it emits an SSE keepalive frame (comment on the
+// OpenAI-compatible wires, event: ping on the Anthropic wire) to hold the
+// connection open. Long upstream reasoning pauses produce no chunks, and
+// proxies/clients may treat silence as a dead connection. The timer keys
+// on client writes only: dropped upstream comment/junk lines never count
+// as liveness (#161). A var (not const) so tests can shrink it.
 var keepaliveInterval = 15 * time.Second
 
 // lineChunk is one upstream SSE line or the terminal send. done is set only

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -118,7 +118,12 @@ func (s *Server) relayStream(ctx context.Context, w http.ResponseWriter, r io.Re
 	lines := make(chan lineChunk)
 	go relayReadLoop(ctx, r, lines)
 
-	relayed := time.Now()
+	// lastWrite is when the relay last wrote a frame to the CLIENT. The
+	// keepalive condition keys on it so a liveness signal is emitted after
+	// any client-write silence, even when upstream comment/junk lines keep
+	// arriving (they are dropped, never relayed, and must not count as
+	// liveness — #161).
+	lastWrite := time.Now()
 	first := true
 	var reasoningParts []string
 	var contentParts []string
@@ -185,7 +190,7 @@ func (s *Server) relayStream(ctx context.Context, w http.ResponseWriter, r io.Re
 			}
 			stats.chunks++
 			stats.bytes += len(frame)
-			relayed = time.Now()
+			lastWrite = time.Now()
 			flusher.Flush()
 		}
 	}
@@ -195,9 +200,9 @@ func (s *Server) relayStream(ctx context.Context, w http.ResponseWriter, r io.Re
 		case <-ctx.Done():
 			return
 		case <-keepalive.C:
-			if time.Since(relayed) >= keepaliveInterval {
+			if time.Since(lastWrite) >= keepaliveInterval {
 				_, _ = io.WriteString(w, ": keepalive\n\n")
-				relayed = time.Now()
+				lastWrite = time.Now()
 				flusher.Flush()
 			}
 		case lc := <-lines:
@@ -222,8 +227,11 @@ func (s *Server) relayStream(ctx context.Context, w http.ResponseWriter, r io.Re
 			}
 			clean, drop := convert.SanitizeChunk(lc.line)
 			if drop {
-				// Non-chunk lines (upstream comments) still prove liveness.
-				relayed = time.Now()
+				// Non-chunk lines (upstream comments, junk frames) are never
+				// relayed and must NOT advance the keepalive timer: the
+				// client sees only real frames, so a steady dribble of
+				// upstream comments would starve it of liveness signals
+				// indefinitely (#161).
 				continue
 			}
 			// Track tool-call indexes BEFORE any strip: StripEndTurnToolCalls
@@ -414,7 +422,7 @@ func (s *Server) relayStream(ctx context.Context, w http.ResponseWriter, r io.Re
 			}
 			stats.chunks++
 			stats.bytes += len(frame)
-			relayed = time.Now()
+			lastWrite = time.Now()
 			flusher.Flush()
 		}
 	}

--- a/internal/server/relay_internal_test.go
+++ b/internal/server/relay_internal_test.go
@@ -73,6 +73,70 @@ func TestRelayStreamKeepalive(t *testing.T) {
 	}
 }
 
+// TestRelayStreamKeepaliveJunkUpstream pins the #161 root cause: upstream
+// comment/junk lines (gateway keepalives, blank frames) that arrive more
+// often than keepaliveInterval must NOT reset the client keepalive timer.
+// Pre-fix, each dropped line advanced "relayed", so the
+// time.Since(relayed) >= keepaliveInterval check never passed and NO
+// liveness frame was ever written — clients with stall detectors (e.g.
+// Next.js openai-compatible-chat) saw multi-minute silence. The client
+// must still receive keepalive frames within ~2x keepaliveInterval, the
+// junk must never be relayed, and [DONE] must stay intact.
+func TestRelayStreamKeepaliveJunkUpstream(t *testing.T) {
+	old := keepaliveInterval
+	keepaliveInterval = 20 * time.Millisecond
+	t.Cleanup(func() { keepaliveInterval = old })
+
+	s := testRelayServer()
+	rec := httptest.NewRecorder()
+	pr, pw := io.Pipe()
+	defer func() { _ = pr.Close() }()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.relayStream(context.Background(), rec, pr, &relayStats{}, time.Now())
+	}()
+
+	// One real chunk, then silence on data.
+	_, _ = pw.Write([]byte(testutilSSE(`{"id":"chatcmpl-j","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`)))
+
+	// Dribble upstream comment frames every 10ms (half keepaliveInterval).
+	// Pre-fix this starved the client of liveness frames indefinitely.
+	stopJunk := make(chan struct{})
+	go func() {
+		junk := time.NewTicker(10 * time.Millisecond)
+		defer junk.Stop()
+		for {
+			select {
+			case <-stopJunk:
+				return
+			case <-junk.C:
+				_, _ = io.WriteString(pw, ": ping\n\n")
+			}
+		}
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	close(stopJunk)
+	_ = pw.Close()
+	<-done
+
+	body := rec.Body.String()
+	if got := strings.Count(body, ": keepalive\n\n"); got < 2 {
+		t.Errorf("keepalive frames = %d, want >= 2 (junk dribble must not starve the client): %q", got, truncateStr(body, 400))
+	}
+	if strings.Contains(body, ": ping\n") {
+		t.Errorf("upstream comment junk leaked to the client: %q", truncateStr(body, 400))
+	}
+	if !strings.Contains(body, "hi") {
+		t.Error("body missing the relayed chunk")
+	}
+	if !strings.Contains(body, "data: [DONE]") {
+		t.Error("body missing [DONE] terminator")
+	}
+}
+
 // errAfterLineReader yields one SSE line then a transport-style error.
 type errAfterLineReader struct {
 	once bool

--- a/internal/server/responses.go
+++ b/internal/server/responses.go
@@ -423,7 +423,11 @@ func (s *Server) relayResponsesStream(ctx context.Context, w http.ResponseWriter
 	defer keepalive.Stop()
 	lines := make(chan lineChunk)
 	go relayReadLoop(ctx, r, lines)
-	relayed := time.Now()
+	// lastWrite tracks the last frame actually written to the CLIENT; the
+	// keepalive condition keys on it so a liveness signal is emitted after
+	// any client-write silence, regardless of upstream comment/junk dribble
+	// (those are dropped and never relayed — #161).
+	lastWrite := time.Now()
 	first := true
 	endTurnCallIndexes := make(map[int]bool)
 	// XML tool-call extractor: models such as MiMo/Hermes/Qwen emit tool
@@ -484,9 +488,9 @@ func (s *Server) relayResponsesStream(ctx context.Context, w http.ResponseWriter
 		case <-ctx.Done():
 			return
 		case <-keepalive.C:
-			if time.Since(relayed) >= keepaliveInterval {
+			if time.Since(lastWrite) >= keepaliveInterval {
 				_, _ = io.WriteString(w, ": keepalive\n\n")
-				relayed = time.Now()
+				lastWrite = time.Now()
 				flusher.Flush()
 			}
 		case lc := <-lines:
@@ -505,7 +509,9 @@ func (s *Server) relayResponsesStream(ctx context.Context, w http.ResponseWriter
 			}
 			clean, drop := convert.SanitizeChunk(lc.line)
 			if drop {
-				relayed = time.Now()
+				// Dropped upstream lines are never relayed and must not
+				// advance the keepalive timer (client sees only real
+				// frames — #161).
 				continue
 			}
 			var chunk map[string]any
@@ -652,7 +658,8 @@ func (s *Server) relayResponsesStream(ctx context.Context, w http.ResponseWriter
 				}
 			}
 			if drop {
-				relayed = time.Now()
+				// Chunk emptied by end_turn stripping: nothing was written
+				// to the client, so the keepalive timer must not advance.
 				continue
 			}
 			if first {
@@ -678,7 +685,7 @@ func (s *Server) relayResponsesStream(ctx context.Context, w http.ResponseWriter
 				s.endResponsesStream(w, send, st, model, respID, createdAt, true, map[string]any{"message": msg, "type": typ})
 				return
 			}
-			relayed = time.Now()
+			lastWrite = time.Now()
 			stats.chunks++
 			stats.bytes += len(clean)
 			if m, _ := chunk["model"].(string); m != "" {


### PR DESCRIPTION
Closes #161

## Problem
Next.js openai-compatible-chat stall detector aborted streams at 367-435s (6-7 min) for deepseek-v4-pro. Root cause: relay keepalive timer ('relayed') was advanced by the drop branch on every upstream comment/junk line (gateway ': ping', blank frames, non-standard JSON) even though nothing was written to the client. When junk arrives more often than keepaliveInterval (15s), the time.Since(relayed) >= keepaliveInterval check never passes — no keepalive frame is ever emitted.

## Change
Renamed relayed -> lastWrite in all three relays (openai.go, anthropic.go, responses.go); updated ONLY at actual client-write sites (relayed chunks, XML-flush frames, keepalive frames). Drop branches no longer advance the timer. Keepalive frames: ': keepalive\n\n' (OpenAI/Responses), 'event: ping' (Anthropic). [DONE] terminator untouched. Worst-case client silence now ~2x keepaliveInterval.

## Evidence
- TestRelayStreamKeepaliveJunkUpstream: 10ms comment dribble (< interval) against relayStream; asserts >=2 keepalive frames reach client, junk never leaks, chunk + [DONE] intact. Red-checked pre-fix ('keepalive frames = 0'), passes post-fix.
- `env -u AUTH_TOKENS -u ADMIN_TOKEN go test ./...` — 20/20 packages ok
- gofmt clean