### PR TITLE
feat(session): zero-downtime handover via grace-window async re-admission

### DIFF
--- a/internal/session/grace.go
+++ b/internal/session/grace.go
@@ -1,0 +1,54 @@
+package session
+
+import "time"
+
+// Grace-window handover helpers (issue #163): when a session is being
+// ridden through its 30-minute grace drain (gap #13) — a long stream that
+// crossed the expiresAt boundary — the next request should hand over to a
+// fresh session without paying a synchronous admission (waiting room) at
+// grace end. These helpers decide WHEN that background re-admit fires;
+// the riding/refusal semantics live in refresh (preemptive) and
+// EnsureSessionForModel (once-per-expiry guard).
+
+// graceEndsAt returns the cached session's grace-window end: the upstream
+// gracePeriodEndsAt when the response carried it, else expiresAt +
+// graceWindow (the 30-minute drain fallback, gap #13). Zero when neither
+// is known — the row has no computable grace window.
+func graceEndsAt(s *cachedState) time.Time {
+	if s == nil {
+		return time.Time{}
+	}
+	graceEnd := s.gracePeriodEndsAt
+	if graceEnd.IsZero() && !s.expiresAt.IsZero() {
+		graceEnd = s.expiresAt.Add(graceWindow)
+	}
+	return graceEnd
+}
+
+// reAdmitDue reports whether a pre-emptive re-admit should fire for the
+// cached session right now (issue #99/#163). It is the union of two
+// windows, each gated once-per-expiry by the caller:
+//
+//   - the pre-expiry lead window: an active session within lead of
+//     expiresAt-5s — the session is about to close, so a background
+//     admission lands a fresh instance for the next request;
+//   - the grace drain (issue #163): the session is usable ONLY through
+//     its grace window (the active window has closed, grace still open) —
+//     a long stream that crossed the expiry boundary must hand over to a
+//     fresh session without the next request paying a synchronous
+//     admission (waiting room) at grace end.
+//
+// The caller keeps the old row authoritative while the refresh runs
+// preemptively: a refusal or queue (the upstream still considers the old
+// session active) rides on without invalidating the cache.
+func reAdmitDue(s *cachedState, lead time.Duration, now time.Time) bool {
+	if s == nil || s.instanceID == "" {
+		return false
+	}
+	leadEnd := s.expiresAt.Add(-expiryMargin)
+	if s.status == "active" && lead > 0 && now.Before(leadEnd) && leadEnd.Sub(now) <= lead {
+		return true
+	}
+	graceEnd := graceEndsAt(s)
+	return !graceEnd.IsZero() && !now.Before(leadEnd) && now.Before(graceEnd)
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -400,10 +400,7 @@ func sessionUsable(s *cachedState) bool {
 	if s.status == "active" && time.Now().Before(s.expiresAt.Add(-expiryMargin)) {
 		return true
 	}
-	graceEnd := s.gracePeriodEndsAt
-	if graceEnd.IsZero() && !s.expiresAt.IsZero() {
-		graceEnd = s.expiresAt.Add(graceWindow)
-	}
+	graceEnd := graceEndsAt(s)
 	return !graceEnd.IsZero() && time.Now().Before(graceEnd)
 }
 
@@ -468,23 +465,26 @@ func (m *Manager) EnsureSessionForModel(ctx context.Context, model string) (stri
 				// stays alive and chat passes).
 				if (model == "" || s.model == "" || s.model == model) && sessionUsable(s) {
 					instance := s.instanceID
-					// Issue #99: pre-emptive re-admit. Only while the
-					// session is still pre-expiry (within reAdmitLead of
-					// expiresAt-5s): inside the grace drain the CLI rides
-					// the old row until grace ends, and a fresh admission
-					// would supersede it. The refresh runs on a background
-					// context so the caller's cancellation never strands a
-					// half-started admission.
-					if s.status == "active" && m.reAdmitLead > 0 &&
-						time.Now().Before(s.expiresAt.Add(-expiryMargin)) &&
-						time.Until(s.expiresAt.Add(-expiryMargin)) <= m.reAdmitLead &&
-						!m.reAdmitExpiry.Equal(s.expiresAt) {
+					// Issue #99/#163: pre-emptive re-admit — pre-expiry
+					// (within reAdmitLead of expiresAt-5s) or while the
+					// session is ridden through its grace drain (#163: a
+					// long stream crossing expiry must hand over to a
+					// fresh session without paying a synchronous
+					// admission at grace end). The refresh runs
+					// preemptively on a background context so a refusal
+					// or queue keeps the cache and rides on.
+					if m.reAdmitLead > 0 && !m.reAdmitExpiry.Equal(s.expiresAt) &&
+						reAdmitDue(s, m.reAdmitLead, time.Now()) {
 						// Issue #132: one attempt per expiry window. The
 						// upstream refuses a fresh create while the old
 						// instance is still authoritative, so a failed
 						// re-admit must ride the old session to expiry
 						// instead of re-triggering on every request (each
 						// trigger burns a session slot).
+						window := "lead"
+						if !time.Now().Before(s.expiresAt.Add(-expiryMargin)) {
+							window = "grace"
+						}
 						m.reAdmitExpiry = s.expiresAt
 						m.refreshing = true
 						m.refreshErr = nil
@@ -493,7 +493,7 @@ func (m *Manager) EnsureSessionForModel(ctx context.Context, model string) (stri
 						m.mu.Unlock()
 						go m.asyncReAdmit(model)
 						m.recordReAdmitTrigger()
-						slog.Debug("session: pre-emptive re-admit triggered", "instance_id", instance, "model", s.model)
+						slog.Debug("session: pre-emptive re-admit triggered", "instance_id", instance, "model", s.model, "window", window)
 						return instance, nil
 					}
 					m.mu.Unlock()
@@ -879,6 +879,17 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string, preemptive
 			slog.Debug("session created", "status", "disabled", "instance_id", "")
 			return nil
 		case "queued":
+			if preemptive {
+				// Issue #163: a pre-emptive re-admit that lands in the
+				// waiting room must not displace the ridden session —
+				// inside the grace drain the old row stays authoritative
+				// until grace closes, and committing the queue would
+				// surface waiting-room latency on the next request. Keep
+				// the cached session; the once-per-expiry guard stops a
+				// retry storm.
+				slog.Debug("session: pre-emptive re-admit queued, riding old session")
+				return nil
+			}
 			pollAt := st.PollAt
 			if pollAt.IsZero() {
 				wait := time.Duration(st.EstimatedWaitMs) * time.Millisecond

--- a/internal/session/wave3_test.go
+++ b/internal/session/wave3_test.go
@@ -149,6 +149,158 @@ func TestReAdmitDisabledByDefault(t *testing.T) {
 	}
 }
 
+// TestGraceWindowTriggersAsyncReAdmitAndHandsOver pins issue #163: when a
+// request arrives while the cached session is being ridden only through
+// its grace drain (a long stream crossed the expiresAt boundary), the
+// request rides the OLD instance while a background re-admit fires; once
+// the fresh admission lands, the next request gets the NEW instance — no
+// synchronous admission (waiting room) is paid at grace end, and the
+// handover consumes exactly one create.
+func TestGraceWindowTriggersAsyncReAdmitAndHandsOver(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	var creates atomic.Int32
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		creates.Add(1)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":     "active",
+			"instanceId": "inst-new",
+			"expiresAt":  time.Now().Add(30 * time.Minute).Format(time.RFC3339),
+		})
+	}
+	m := newTestSession(t, mock)
+	m.SetReAdmitLead(time.Minute)
+
+	// Seed an expired-but-in-grace cache: the shape left by a long stream
+	// that crossed expiresAt while chat was still being served (gap #13).
+	m.mu.Lock()
+	m.commit(&cachedState{
+		status:            "active",
+		instanceID:        "inst-grace",
+		model:             "deepseek/deepseek-v4-pro",
+		expiresAt:         time.Now().Add(-10 * time.Minute),
+		gracePeriodEndsAt: time.Now().Add(20 * time.Minute),
+	})
+	m.mu.Unlock()
+
+	// The first request rides the old instance and triggers the async
+	// re-admit.
+	instance, err := m.EnsureSessionForModel(context.Background(), "deepseek/deepseek-v4-pro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if instance != "inst-grace" {
+		t.Fatalf("first instance = %q, want inst-grace (ride old through grace)", instance)
+	}
+	// The background re-admit created the fresh session.
+	eventually(t, "grace re-admit create", func() bool { return creates.Load() >= 1 })
+	// Once the re-admit lands, the next request gets the new instance.
+	eventually(t, "fresh instance served after handover", func() bool {
+		id, err := m.EnsureSessionForModel(context.Background(), "deepseek/deepseek-v4-pro")
+		return err == nil && id == "inst-new"
+	})
+	// No storm: the handover consumed exactly one create.
+	time.Sleep(150 * time.Millisecond)
+	if got := creates.Load(); got != 1 {
+		t.Errorf("creates = %d, want 1 (once per expiry, no storm)", got)
+	}
+}
+
+// TestGraceWindowReAdmitRefusedRidesOldOnce pins the anti-supersede rule
+// (issue #163): a grace-window re-admit that the upstream refuses (the old
+// session is still authoritative — the create returns ended/superseded/
+// none) keeps the old row riding through the drain and fires at most ONCE
+// per expiry — no create storm.
+func TestGraceWindowReAdmitRefusedRidesOldOnce(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	var creates atomic.Int32
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		creates.Add(1)
+		writeJSON(w, http.StatusOK, map[string]any{"status": "ended"})
+	}
+	m := newTestSession(t, mock)
+	m.SetReAdmitLead(time.Minute)
+
+	m.mu.Lock()
+	m.commit(&cachedState{
+		status:            "active",
+		instanceID:        "inst-grace",
+		model:             "deepseek/deepseek-v4-pro",
+		expiresAt:         time.Now().Add(-10 * time.Minute),
+		gracePeriodEndsAt: time.Now().Add(20 * time.Minute),
+	})
+	m.mu.Unlock()
+
+	// First request triggers the re-admit (refused upstream) and rides.
+	if got, err := m.EnsureSessionForModel(context.Background(), "deepseek/deepseek-v4-pro"); err != nil || got != "inst-grace" {
+		t.Fatalf("first = %q/%v, want inst-grace ride", got, err)
+	}
+	eventually(t, "refused re-admit attempted", func() bool { return creates.Load() >= 1 })
+	// The refused re-admit left the old row authoritative: every later
+	// request keeps riding it with no re-trigger and no error.
+	for i := 0; i < 5; i++ {
+		if got, err := m.EnsureSessionForModel(context.Background(), "deepseek/deepseek-v4-pro"); err != nil || got != "inst-grace" {
+			t.Fatalf("ride %d = %q/%v, want inst-grace", i, got, err)
+		}
+	}
+	time.Sleep(150 * time.Millisecond)
+	if got := creates.Load(); got != 1 {
+		t.Errorf("creates = %d, want 1 (refused re-admit fires once)", got)
+	}
+}
+
+// TestGraceWindowReAdmitQueuedRidesOldOnce pins the queued side of the
+// anti-supersede rule (issue #163): a grace-window re-admit that lands in
+// the upstream waiting room must NOT displace the ridden session — the
+// next request keeps riding the old row through the drain instead of
+// surfacing waiting-room latency, and the re-admit fires only once.
+func TestGraceWindowReAdmitQueuedRidesOldOnce(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	var creates atomic.Int32
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		creates.Add(1)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":          "queued",
+			"instanceId":      "inst-q",
+			"position":        3,
+			"queueDepth":      7,
+			"estimatedWaitMs": 60000,
+			"pollAt":          time.Now().Add(time.Hour).Format(time.RFC3339),
+		})
+	}
+	m := newTestSession(t, mock)
+	m.SetReAdmitLead(time.Minute)
+
+	m.mu.Lock()
+	m.commit(&cachedState{
+		status:            "active",
+		instanceID:        "inst-grace",
+		model:             "deepseek/deepseek-v4-pro",
+		expiresAt:         time.Now().Add(-10 * time.Minute),
+		gracePeriodEndsAt: time.Now().Add(20 * time.Minute),
+	})
+	m.mu.Unlock()
+
+	// First request triggers the re-admit (lands queued) and rides.
+	if got, err := m.EnsureSessionForModel(context.Background(), "deepseek/deepseek-v4-pro"); err != nil || got != "inst-grace" {
+		t.Fatalf("first = %q/%v, want inst-grace ride", got, err)
+	}
+	eventually(t, "queued re-admit attempted", func() bool { return creates.Load() >= 1 })
+	// The queued admission was NOT cached: the next request keeps riding
+	// the old row — no WaitingRoomError, no re-trigger.
+	for i := 0; i < 5; i++ {
+		if got, err := m.EnsureSessionForModel(context.Background(), "deepseek/deepseek-v4-pro"); err != nil || got != "inst-grace" {
+			t.Fatalf("ride %d = %q/%v, want inst-grace (no waiting room)", i, got, err)
+		}
+	}
+	time.Sleep(150 * time.Millisecond)
+	if got := creates.Load(); got != 1 {
+		t.Errorf("creates = %d, want 1 (queued re-admit fires once)", got)
+	}
+}
+
 // TestPollSkipsWithinProbeTTL pins issue #60(a): session poll GETs within
 // the admission probe cache TTL of a successful session response are
 // skipped; after the TTL the GET happens.


### PR DESCRIPTION
Closes #163

## Problem
Long-running agentic tasks crossing the 60-min session boundary risk session_expired / waiting-room latency on follow-up turns: the pre-emptive re-admit only fired before expiry, not while riding the grace drain.

## Change
- EnsureSessionForModel now also triggers async re-admit while the cached session is ridden through its grace drain (expiry margin passed, grace still open). Triggering request rides the old instance; next request lands on the fresh session without synchronous admission latency.
- Gated by SESSION_RE_ADMIT_LEAD (opt-in) + once-per-expiry guard (reAdmitExpiry).
- Anti-supersede: refused (ended) or QUEUED pre-emptive re-admit keeps the cached session — next request keeps riding through the drain, no WaitingRoomError, no create storm.
- Shared grace computation extracted to internal/session/grace.go (session.go stays 1395 lines). Log line carries window=lead|grace.

## Evidence
- TestGraceWindowTriggersAsyncReAdmitAndHandsOver / RefusedRidesOldOnce / QueuedRidesOldOnce — PASS
- `env -u AUTH_TOKENS -u ADMIN_TOKEN go test ./...` — 21/21 packages ok
- gofmt clean