### PR TITLE
feat(server): quota-fallback transparency — served-model headers + accurate model field

### DIFF
--- a/internal/pool/acquire.go
+++ b/internal/pool/acquire.go
@@ -440,7 +440,18 @@ func (p *Pool) Acquire(ctx context.Context, model string) (*Lease, error) {
 		if allQuotaCapped {
 			if fb := cfg.QuotaFallbackModels[model]; fb != "" && fb != model {
 				p.logger.Info("pool: quota exhausted, falling back to unlimited model", "requested", model, "fallback", fb)
-				return p.Acquire(ctx, fb)
+				// Issue #164: the fallback lease reports why it serves a
+				// different model so the server surfaces the switch to the
+				// client (X-FreeBuff-Fallback: quota_exhausted). By the time
+				// this branch is reached every token with positive quota for
+				// `model` has already been tried and failed (see acquireOrder:
+				// quota-capped tokens are excluded from the order, all others
+				// are visited by the failover loop before the fallback fires).
+				fbLease, fbErr := p.Acquire(ctx, fb)
+				if fbLease != nil {
+					fbLease.FallbackReason = "quota_exhausted"
+				}
+				return fbLease, fbErr
 			}
 		}
 
@@ -496,6 +507,18 @@ func (p *Pool) Acquire(ctx context.Context, model string) (*Lease, error) {
 // whose quota is exhausted for the model (RecentCount >= Limit with a future
 // ResetAt) are excluded from this pass entirely; their rate-limit reasons
 // are returned so the caller surfaces a real 429 when every token is capped.
+//
+// Issue #164 (fallback ordering): the order returned here exhausts EVERY
+// token with positive quota for the requested model before the caller's
+// QUOTA_FALLBACK_MODELS fallback can fire. Non-capped tokens (matching hot,
+// cold, mismatched hot) are all in the order and the failover loop in
+// Acquire visits each of them in turn — a token only fails the pass with a
+// quota-exhausted error after it was actually attempted. Quota-capped
+// tokens are excluded (they have nothing left to serve), and when every
+// token is capped or cooling down the order degrades to full round-robin so
+// the loop still records every reason. The fallback branch in Acquire only
+// runs after that loop completed without a lease and every rate-limited
+// error it recorded is a quota exhaustion.
 func (p *Pool) acquireOrder(toks *[]*tokenEntry, start int, model string) ([]int, []*upstream.RateLimitError) {
 	// eligible mirrors the per-token checks the failover loop applies:
 	// not cooling down, under the daily message cap, and not quota-capped

--- a/internal/pool/bridge.go
+++ b/internal/pool/bridge.go
@@ -104,6 +104,7 @@ func (p *Pool) AcquireBridge(ctx context.Context, clientToken, model string) (*L
 	}
 
 	// Issue #155: quota-exhaustion fallback in bridge mode.
+	fellBack := false
 	if bridgeQuotaCapped(entry, model) {
 		if fb := cfg.QuotaFallbackModels[model]; fb != "" && fb != model {
 			p.logger.Info("pool: bridge token quota exhausted, falling back", "token", bridgeTokenLabel(entry), "requested", model, "fallback", fb)
@@ -113,6 +114,7 @@ func (p *Pool) AcquireBridge(ctx context.Context, clientToken, model string) (*L
 			}
 			model = fb
 			agentID = fbAgent
+			fellBack = true // issue #164: report the switch to the client
 		} else {
 			return nil, bridgeQuotaLimitError(entry, model)
 		}
@@ -147,7 +149,13 @@ func (p *Pool) AcquireBridge(ctx context.Context, clientToken, model string) (*L
 			if isQuotaExhaustedError(rle) {
 				if fb := cfg.QuotaFallbackModels[model]; fb != "" && fb != model {
 					p.logger.Info("pool: bridge token quota exhausted on admission, falling back", "token", bridgeTokenLabel(entry), "requested", model, "fallback", fb)
-					return p.AcquireBridge(ctx, clientToken, fb)
+					// Issue #164: report the switch (X-FreeBuff-Fallback:
+					// quota_exhausted) on the fallback lease.
+					fbLease, fbErr := p.AcquireBridge(ctx, clientToken, fb)
+					if fbLease != nil {
+						fbLease.FallbackReason = "quota_exhausted"
+					}
+					return fbLease, fbErr
 				}
 			}
 		}
@@ -219,8 +227,12 @@ func (p *Pool) AcquireBridge(ctx context.Context, clientToken, model string) (*L
 	p.lastActive = time.Now()
 	p.idleFinished = false
 	p.lastActiveMu.Unlock()
+	fallbackReason := ""
+	if fellBack {
+		fallbackReason = "quota_exhausted"
+	}
 	return &Lease{Token: -1, Model: effectiveModel, AgentID: effectiveAgentID, Run: run, SessionInstanceID: instanceID,
-		Bridge: entry, AcquiredAt: time.Now()}, nil
+		Bridge: entry, FallbackReason: fallbackReason, AcquiredAt: time.Now()}, nil
 }
 
 // ProbeNewToken validates a NOT-yet-added token against upstream with a

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -99,6 +99,14 @@ type Lease struct {
 	Run               *runs.Run
 	SessionInstanceID string       // "" when the session is disabled
 	Bridge            *bridgeEntry // nil for pooled (fixed-token) leases
+	// FallbackReason names WHY this lease serves a different model than the
+	// requested one (issue #164): "quota_exhausted" when the QUOTA_FALLBACK_MODELS
+	// path re-routed the request after every quota-positive token was
+	// exhausted; "queue_timeout" when the server's FALLBACK_AFTER_MS
+	// waiting-room path re-routed. Empty when the lease serves the requested
+	// model directly. Surfaced to clients as the X-FreeBuff-Fallback
+	// response header.
+	FallbackReason string
 	// entry is the fixed-token entry backing this lease. Set by Acquire so
 	// LeaseRelease always releases through the right run manager: after a
 	// concurrent RemoveLastToken, the Token index may be out of range (or

--- a/internal/pool/scarce_test.go
+++ b/internal/pool/scarce_test.go
@@ -156,6 +156,11 @@ func TestAcquireQuotaExhaustionFallback(t *testing.T) {
 	if lease.Model != "mimo/mimo-v2.5" {
 		t.Errorf("lease.Model = %q, want mimo/mimo-v2.5 (fallback)", lease.Model)
 	}
+	// Issue #164: the fallback lease must report why it serves a different
+	// model so the server surfaces X-FreeBuff-Fallback: quota_exhausted.
+	if lease.FallbackReason != "quota_exhausted" {
+		t.Errorf("lease.FallbackReason = %q, want quota_exhausted", lease.FallbackReason)
+	}
 }
 
 func TestAcquireBridgeScarceAndFallback(t *testing.T) {

--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -765,9 +765,17 @@ func (s *Server) relayAnthropicStream(ctx context.Context, w http.ResponseWriter
 	_, _ = io.WriteString(w, ": connecting\n\n")
 	flusher.Flush()
 
+	// Issue #164: the message_start event names the proxy's served model
+	// (lease.Model, fallbacks included), not the raw requested id — clients
+	// must see what actually served the request. Falls back to the requested
+	// model when the relay is driven without a lease (direct unit tests).
+	servedModel := stats.servedModel
+	if servedModel == "" {
+		servedModel = requestedModel
+	}
 	st := &anthropicStreamState{
 		messageID:          "msg_" + randHexString(10),
-		model:              requestedModel,
+		model:              servedModel,
 		inputTokens:        inputTokens,
 		toolCalls:          make(map[int]*anthropicToolState),
 		endTurnCallIndexes: make(map[int]bool),
@@ -1277,7 +1285,14 @@ func (s *Server) relayAnthropicJSON(ctx context.Context, w http.ResponseWriter, 
 			"failed to decode upstream stream: "+err.Error(), "upstream_error", 0)
 		return
 	}
-	msgObj := anthropicMessageFromCompletion(completion, requestedModel)
+	// Issue #164: the message object names the proxy's served model (lease.Model,
+	// fallbacks included), not the raw requested id — fall back to the
+	// requested model only when the relay ran without a lease.
+	servedModel := stats.servedModel
+	if servedModel == "" {
+		servedModel = requestedModel
+	}
+	msgObj := anthropicMessageFromCompletion(completion, servedModel)
 	out, err := json.Marshal(msgObj)
 	if err != nil {
 		s.writeAnthropicError(w, r, http.StatusBadGateway,
@@ -1354,15 +1369,18 @@ func (s *Server) relayAnthropicJSON(ctx context.Context, w http.ResponseWriter, 
 }
 
 // anthropicMessageFromCompletion builds the Anthropic message object from
-// an accumulated chat.completion.
-func anthropicMessageFromCompletion(completion map[string]any, requestedModel string) map[string]any {
+// an accumulated chat.completion. servedModel is the authoritative model the
+// proxy's lease was bound to (issue #164) and wins over the upstream echo;
+// the echo only fills the field when no served model is known (direct unit
+// calls) — the response must name what actually served the request.
+func anthropicMessageFromCompletion(completion map[string]any, servedModel string) map[string]any {
 	id, _ := completion["id"].(string)
 	if id == "" {
 		id = "msg_" + randHexString(10)
 	}
-	model, _ := completion["model"].(string)
+	model := servedModel
 	if model == "" {
-		model = requestedModel
+		model, _ = completion["model"].(string)
 	}
 	message := map[string]any{
 		"id":            id,

--- a/internal/server/engine.go
+++ b/internal/server/engine.go
@@ -278,17 +278,38 @@ func (s *Server) chatCore(w http.ResponseWriter, r *http.Request, model string, 
 	if reasoningEffort != "" {
 		routingAttrs = append(routingAttrs, "reasoning_effort", reasoningEffort)
 	}
+	// Issue #164: fallback transparency. x-freebuff-served-model names the
+	// model this lease's session/run is actually bound to — requested model
+	// when served directly, the re-routed model after any fallback — and is
+	// set on every successful response so clients can always tell what
+	// served them. x-freebuff-fallback is set ONLY when a fallback fired,
+	// with the reason: "quota_exhausted" (pool QUOTA_FALLBACK_MODELS path,
+	// after every quota-positive token for the requested model was
+	// exhausted) or "queue_timeout" (FALLBACK_AFTER_MS waiting-room
+	// re-route, issue #100). The legacy X-FreeBuff-Fallback-Model header
+	// (issue #100) is kept for the queue-time path.
+	servedModel := lease.Model
+	if servedModel == "" {
+		servedModel = model
+	}
+	w.Header().Set("X-FreeBuff-Served-Model", servedModel)
+	fallbackReason := lease.FallbackReason
 	if fallbackUsed {
+		fallbackReason = "queue_timeout"
 		// Surface the transparent model switch to the client (issue #100):
 		// the streamed response itself is indistinguishable, so the header
 		// is the notice.
 		w.Header().Set("X-FreeBuff-Fallback-Model", cfg.FallbackModels[model])
 		routingAttrs = append(routingAttrs, "fallback", cfg.FallbackModels[model])
 	}
+	if fallbackReason != "" {
+		w.Header().Set("X-FreeBuff-Fallback", fallbackReason)
+		routingAttrs = append(routingAttrs, "served_model", servedModel)
+	}
 	s.logger.Info(kind+" routing", routingAttrs...)
 
 	chatStart := time.Now()
-	stats := &relayStats{}
+	stats := &relayStats{servedModel: servedModel}
 	relay(ctx, w, up, stats, chatStart)
 	// Issue #114: record the completed chat as a run step — steps are
 	// batched in memory and sent WITH FINISH (the CLI has no /steps
@@ -774,6 +795,12 @@ type relayStats struct {
 	// final usage block), fed to the pool spend ledger once per successful
 	// completion (#122). 0 when the stream carried no usage.
 	usageTokens int64
+	// servedModel is the model this lease's session/run is actually bound to
+	// (lease.Model, resolved fallbacks included). Set by chatCore before the
+	// relay runs so wire relays can stamp it onto the response body's model
+	// field and message_start events (issue #164). Empty when a relay is
+	// driven directly by a test with no lease.
+	servedModel string
 }
 
 // usageTotalTokens extracts the token total from a chat usage object

--- a/internal/server/fallback_transparency_test.go
+++ b/internal/server/fallback_transparency_test.go
@@ -1,0 +1,384 @@
+// fallback_transparency_test.go — issue #164: fallback transparency.
+//
+// The gateway must tell clients what model actually served a request:
+//   - x-freebuff-served-model on every successful response (requested model
+//     when served directly, the re-routed model after a fallback);
+//   - x-freebuff-fallback ONLY when a fallback fired, naming the reason
+//     (quota_exhausted | queue_timeout);
+//   - the response body's model field (chat.completion chunks/body and the
+//     Anthropic message_start/message object) reflecting the served model.
+package server_test
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"freebuff-proxy/internal/config"
+	"freebuff-proxy/internal/testutil"
+)
+
+// chunkModel renders one OpenAI-style SSE chat chunk with a custom model id
+// (the shared chunk() helper bakes modelA; these tests need chunks that echo
+// a DIFFERENT model to prove the relay rewrites them).
+func chunkModel(id string, model string, payload string) string {
+	return `{"id":"` + id + `","object":"chat.completion.chunk","created":1,"model":"` + model + `",` + payload + `}`
+}
+
+// chatSSE returns a minimal two-chunk streaming chat body (content + stop)
+// whose chunks echo the given model id.
+func chatSSE(model string) string {
+	return testutil.SSEEvent(chunkModel("chatcmpl-t1", model,
+		`"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]`)) +
+		testutil.SSEEvent(chunkModel("chatcmpl-t1", model,
+			`"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]`))
+}
+
+// parseChunkModels extracts the "model" field of every data line in an SSE
+// body (assumes chat.completion.chunk objects).
+func parseChunkModels(t *testing.T, body string) []string {
+	t.Helper()
+	var models []string
+	sc := bufio.NewScanner(strings.NewReader(body))
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			continue
+		}
+		var chunk struct {
+			Model string `json:"model"`
+		}
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			t.Fatalf("unmarshal chunk: %v: %s", err, data)
+		}
+		models = append(models, chunk.Model)
+	}
+	return models
+}
+
+// TestFallbackTransparencyDirectOpenAI pins the direct-serving contract: no
+// fallback config, the requested model serves, so x-freebuff-served-model
+// equals the requested model, x-freebuff-fallback is ABSENT, and the body
+// model field — streaming chunks and the non-streaming body — reflects the
+// served model even when the upstream echo lies.
+func TestFallbackTransparencyDirectOpenAI(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	// The upstream echoes a DIFFERENT model id than the one it was asked to
+	// serve: the relay must stamp the proxy's served model regardless.
+	mock.ChatBody = chatSSE("upstream/echo-model")
+	srv, _ := newTestServer(t, nil, mock)
+
+	// Streaming path.
+	resp, data := doJSON(t, http.MethodPost, srv.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stream status = %d, want 200: %s", resp.StatusCode, data)
+	}
+	if got := resp.Header.Get("x-freebuff-served-model"); got != modelA {
+		t.Errorf("x-freebuff-served-model = %q, want %q (direct serving)", got, modelA)
+	}
+	if got := resp.Header.Get("x-freebuff-fallback"); got != "" {
+		t.Errorf("x-freebuff-fallback = %q, want absent (direct serving)", got)
+	}
+	for i, m := range parseChunkModels(t, string(data)) {
+		if m != modelA {
+			t.Errorf("stream chunk %d model = %q, want %q (served model stamped)", i, m, modelA)
+		}
+	}
+
+	// Non-streaming path.
+	resp2, data2 := doJSON(t, http.MethodPost, srv.URL+"/v1/chat/completions",
+		[]byte(`{"model":"`+modelA+`","messages":[{"role":"user","content":"ping"}],"stream":false}`), nil)
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("non-stream status = %d, want 200: %s", resp2.StatusCode, data2)
+	}
+	var comp struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(data2, &comp); err != nil {
+		t.Fatalf("unmarshal body: %v: %s", err, data2)
+	}
+	if comp.Model != modelA {
+		t.Errorf("non-stream body model = %q, want %q (served model stamped)", comp.Model, modelA)
+	}
+	if got := resp2.Header.Get("x-freebuff-served-model"); got != modelA {
+		t.Errorf("non-stream x-freebuff-served-model = %q, want %q", got, modelA)
+	}
+	if got := resp2.Header.Get("x-freebuff-fallback"); got != "" {
+		t.Errorf("non-stream x-freebuff-fallback = %q, want absent", got)
+	}
+}
+
+// TestFallbackTransparencyQueueTimeout pins the queue-time fallback (issue
+// #100): with FALLBACK_AFTER_MS + FALLBACK_MODEL configured and a waiting
+// room beyond the threshold, x-freebuff-served-model names the fallback
+// model, x-freebuff-fallback = queue_timeout, the legacy
+// X-FreeBuff-Fallback-Model header stays, and streamed chunks carry the
+// fallback model.
+func TestFallbackTransparencyQueueTimeout(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.SessionMode = "queued"
+	mock.SessionSequence = []string{"queued", "active"} // first create queues; the fallback model's create succeeds
+	mock.EstimatedWaitMs = 20000                        // > FALLBACK_AFTER_MS (10s)
+	// The fallback model's upstream chat echoes the REQUESTED model: the
+	// relay must stamp the actually-served fallback model onto the chunks.
+	mock.ChatBody = chatSSE("z-ai/glm-5.2")
+	srv, _ := newTestServerCfg(t, nil, func(c *config.Config) {
+		c.FallbackAfter = 10 * time.Second
+		c.FallbackModels = map[string]string{"z-ai/glm-5.2": "deepseek/deepseek-v4-flash"}
+	}, mock)
+	body := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	resp, data := doJSON(t, http.MethodPost, srv.URL+"/v1/chat/completions", []byte(body), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (fallback served): %s", resp.StatusCode, data)
+	}
+	if got := resp.Header.Get("x-freebuff-served-model"); got != "deepseek/deepseek-v4-flash" {
+		t.Errorf("x-freebuff-served-model = %q, want deepseek/deepseek-v4-flash", got)
+	}
+	if got := resp.Header.Get("x-freebuff-fallback"); got != "queue_timeout" {
+		t.Errorf("x-freebuff-fallback = %q, want queue_timeout", got)
+	}
+	// Legacy #100 header remains for existing clients.
+	if got := resp.Header.Get("X-FreeBuff-Fallback-Model"); got != "deepseek/deepseek-v4-flash" {
+		t.Errorf("X-FreeBuff-Fallback-Model = %q, want deepseek/deepseek-v4-flash", got)
+	}
+	for i, m := range parseChunkModels(t, string(data)) {
+		if m != "deepseek/deepseek-v4-flash" {
+			t.Errorf("stream chunk %d model = %q, want deepseek/deepseek-v4-flash (served fallback stamped)", i, m)
+		}
+	}
+}
+
+// quotaExhaustionMock wires a mock whose session create 429s with a
+// quota-exhausted body for the requested model and succeeds for the
+// QUOTA_FALLBACK_MODELS target (mirrors scarce_test.go's pool-level setup,
+// exercised end-to-end through the HTTP surface here).
+func quotaExhaustionMock(t *testing.T) *testutil.MockUpstream {
+	t.Helper()
+	mock := testutil.NewMock()
+	t.Cleanup(mock.Close)
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			switch r.Header.Get("x-freebuff-model") {
+			case modelA:
+				// Session quota exhausted for the requested model.
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = io.WriteString(w, fmt.Sprintf(`{
+					"status": "rate_limited",
+					"model": %q,
+					"limit": 5,
+					"recentCount": 5,
+					"period": "pacific_day",
+					"resetAt": %q,
+					"retryAfterMs": 3600000
+				}`, modelA, time.Now().Add(time.Hour).Format(time.RFC3339)))
+			default:
+				// The fallback model admits fine.
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, fmt.Sprintf(`{
+					"status": "active",
+					"instanceId": "inst-fallback",
+					"model": %q,
+					"expiresAt": %q
+				}`, r.Header.Get("x-freebuff-model"), time.Now().Add(time.Hour).Format(time.RFC3339)))
+			}
+			return
+		}
+		http.NotFound(w, r)
+	}
+	// Upstream chat for the fallback model echoes the REQUESTED model: the
+	// relay must stamp the served fallback model.
+	mock.ChatBody = chatSSE("z-ai/glm-5.2")
+	return mock
+}
+
+// TestFallbackTransparencyQuotaExhaustedOpenAI pins the quota-exhaustion
+// fallback (issue #155): when the requested model's session quota is
+// exhausted on every token, the pool re-routes to QUOTA_FALLBACK_MODELS and
+// the response reports served-model + x-freebuff-fallback: quota_exhausted.
+func TestFallbackTransparencyQuotaExhaustedOpenAI(t *testing.T) {
+	mock := quotaExhaustionMock(t)
+	srv, _ := newTestServerCfg(t, nil, func(c *config.Config) {
+		c.QuotaFallbackModels = map[string]string{"z-ai/glm-5.2": "deepseek/deepseek-v4-flash"}
+	}, mock)
+
+	// Streaming: the fallback model serves; headers + chunks must agree.
+	body := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	resp, data := doJSON(t, http.MethodPost, srv.URL+"/v1/chat/completions", []byte(body), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stream status = %d, want 200 (fallback served): %s", resp.StatusCode, data)
+	}
+	if got := resp.Header.Get("x-freebuff-served-model"); got != "deepseek/deepseek-v4-flash" {
+		t.Errorf("x-freebuff-served-model = %q, want deepseek/deepseek-v4-flash", got)
+	}
+	if got := resp.Header.Get("x-freebuff-fallback"); got != "quota_exhausted" {
+		t.Errorf("x-freebuff-fallback = %q, want quota_exhausted", got)
+	}
+	for i, m := range parseChunkModels(t, string(data)) {
+		if m != "deepseek/deepseek-v4-flash" {
+			t.Errorf("stream chunk %d model = %q, want deepseek/deepseek-v4-flash (served fallback stamped)", i, m)
+		}
+	}
+
+	// Non-streaming: body model must also name the served fallback model.
+	bodyNS := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":false}`
+	resp2, data2 := doJSON(t, http.MethodPost, srv.URL+"/v1/chat/completions", []byte(bodyNS), nil)
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("non-stream status = %d, want 200: %s", resp2.StatusCode, data2)
+	}
+	var comp struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(data2, &comp); err != nil {
+		t.Fatalf("unmarshal body: %v: %s", err, data2)
+	}
+	if comp.Model != "deepseek/deepseek-v4-flash" {
+		t.Errorf("non-stream body model = %q, want deepseek/deepseek-v4-flash", comp.Model)
+	}
+	if got := resp2.Header.Get("x-freebuff-served-model"); got != "deepseek/deepseek-v4-flash" {
+		t.Errorf("non-stream x-freebuff-served-model = %q, want deepseek/deepseek-v4-flash", got)
+	}
+	if got := resp2.Header.Get("x-freebuff-fallback"); got != "quota_exhausted" {
+		t.Errorf("non-stream x-freebuff-fallback = %q, want quota_exhausted", got)
+	}
+}
+
+// anthropicHeaders sends one /v1/messages request with the given headers and
+// returns the response, the raw body, and the parsed SSE events when stream.
+type anthropicMessageEvent struct {
+	Type    string `json:"type"`
+	Message *struct {
+		Model string `json:"model"`
+	} `json:"message"`
+}
+
+func parseAnthropicEvents(t *testing.T, body string) []anthropicMessageEvent {
+	t.Helper()
+	var events []anthropicMessageEvent
+	sc := bufio.NewScanner(strings.NewReader(body))
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var ev anthropicMessageEvent
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &ev); err != nil {
+			t.Fatalf("unmarshal anthropic event: %v: %s", err, line)
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+// TestFallbackTransparencyAnthropic pins the Anthropic surface: message_start
+// (streaming) and the message object (non-streaming) name the served model,
+// and the fallback headers fire on both when a quota fallback serves.
+func TestFallbackTransparencyAnthropic(t *testing.T) {
+	direct := testutil.NewMock()
+	defer direct.Close()
+	direct.ChatBody = chatSSE("upstream/echo-model")
+	srvDirect, _ := newTestServer(t, []string{"anthropic-key"}, direct)
+
+	// Direct streaming: message_start names the requested model.
+	reqBody := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	resp, data := doJSON(t, http.MethodPost, srvDirect.URL+"/v1/messages", []byte(reqBody),
+		map[string]string{"anthropic-api-key": "anthropic-key", "anthropic-version": "2023-06-01"})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("direct stream status = %d, want 200: %s", resp.StatusCode, data)
+	}
+	if got := resp.Header.Get("x-freebuff-served-model"); got != modelA {
+		t.Errorf("direct x-freebuff-served-model = %q, want %q", got, modelA)
+	}
+	if got := resp.Header.Get("x-freebuff-fallback"); got != "" {
+		t.Errorf("direct x-freebuff-fallback = %q, want absent", got)
+	}
+	foundStart := false
+	for _, ev := range parseAnthropicEvents(t, string(data)) {
+		if ev.Type == "message_start" && ev.Message != nil {
+			foundStart = true
+			if ev.Message.Model != modelA {
+				t.Errorf("message_start model = %q, want %q (served model)", ev.Message.Model, modelA)
+			}
+		}
+	}
+	if !foundStart {
+		t.Error("message_start event not found in direct stream")
+	}
+
+	// Direct non-streaming: message object model names the served model.
+	reqBodyNS := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":false}`
+	respNS, dataNS := doJSON(t, http.MethodPost, srvDirect.URL+"/v1/messages", []byte(reqBodyNS),
+		map[string]string{"anthropic-api-key": "anthropic-key", "anthropic-version": "2023-06-01"})
+	if respNS.StatusCode != http.StatusOK {
+		t.Fatalf("direct non-stream status = %d, want 200: %s", respNS.StatusCode, dataNS)
+	}
+	var msg struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(dataNS, &msg); err != nil {
+		t.Fatalf("unmarshal message: %v: %s", err, dataNS)
+	}
+	if msg.Model != modelA {
+		t.Errorf("non-stream message model = %q, want %q", msg.Model, modelA)
+	}
+
+	// Quota fallback on the Anthropic surface.
+	fb := quotaExhaustionMock(t)
+	srvFB, _ := newTestServerCfg(t, []string{"anthropic-key"}, func(c *config.Config) {
+		c.QuotaFallbackModels = map[string]string{"z-ai/glm-5.2": "deepseek/deepseek-v4-flash"}
+	}, fb)
+
+	respFB, dataFB := doJSON(t, http.MethodPost, srvFB.URL+"/v1/messages", []byte(reqBody),
+		map[string]string{"anthropic-api-key": "anthropic-key", "anthropic-version": "2023-06-01"})
+	if respFB.StatusCode != http.StatusOK {
+		t.Fatalf("fallback stream status = %d, want 200: %s", respFB.StatusCode, dataFB)
+	}
+	if got := respFB.Header.Get("x-freebuff-served-model"); got != "deepseek/deepseek-v4-flash" {
+		t.Errorf("fallback x-freebuff-served-model = %q, want deepseek/deepseek-v4-flash", got)
+	}
+	if got := respFB.Header.Get("x-freebuff-fallback"); got != "quota_exhausted" {
+		t.Errorf("fallback x-freebuff-fallback = %q, want quota_exhausted", got)
+	}
+	foundFbStart := false
+	for _, ev := range parseAnthropicEvents(t, string(dataFB)) {
+		if ev.Type == "message_start" && ev.Message != nil {
+			foundFbStart = true
+			if ev.Message.Model != "deepseek/deepseek-v4-flash" {
+				t.Errorf("fallback message_start model = %q, want deepseek/deepseek-v4-flash", ev.Message.Model)
+			}
+		}
+	}
+	if !foundFbStart {
+		t.Error("message_start event not found in fallback stream")
+	}
+
+	// Non-streaming fallback: message object model names the served model.
+	respFBNS, dataFBNS := doJSON(t, http.MethodPost, srvFB.URL+"/v1/messages", []byte(reqBodyNS),
+		map[string]string{"anthropic-api-key": "anthropic-key", "anthropic-version": "2023-06-01"})
+	if respFBNS.StatusCode != http.StatusOK {
+		t.Fatalf("fallback non-stream status = %d, want 200: %s", respFBNS.StatusCode, dataFBNS)
+	}
+	var msgFB struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(dataFBNS, &msgFB); err != nil {
+		t.Fatalf("unmarshal fallback message: %v: %s", err, dataFBNS)
+	}
+	if msgFB.Model != "deepseek/deepseek-v4-flash" {
+		t.Errorf("fallback non-stream message model = %q, want deepseek/deepseek-v4-flash", msgFB.Model)
+	}
+	if got := respFBNS.Header.Get("x-freebuff-fallback"); got != "quota_exhausted" {
+		t.Errorf("fallback non-stream x-freebuff-fallback = %q, want quota_exhausted", got)
+	}
+}

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -127,7 +127,11 @@ func (s *Server) relayStream(ctx context.Context, w http.ResponseWriter, r io.Re
 	first := true
 	var reasoningParts []string
 	var contentParts []string
-	var streamModel string
+	// Issue #164: the stream's model identity is the proxy's served model
+	// (lease.Model, fallbacks included) — synthetic XML-flush chunks and the
+	// reasoning cache key on it. The upstream chunk echo only fills the
+	// field when no lease drove the relay (direct unit-test calls).
+	streamModel := stats.servedModel
 	toolIDsMap := make(map[string]bool)
 	var toolIDs []string
 	endTurnCallIndexes := make(map[int]bool)
@@ -384,7 +388,7 @@ func (s *Server) relayStream(ctx context.Context, w http.ResponseWriter, r io.Re
 					} `json:"choices"`
 				}
 				if json.Unmarshal(clean, &chunk) == nil {
-					if chunk.Model != "" {
+					if chunk.Model != "" && streamModel == "" {
 						streamModel = chunk.Model
 					}
 					if chunk.ID != "" {
@@ -411,6 +415,11 @@ func (s *Server) relayStream(ctx context.Context, w http.ResponseWriter, r io.Re
 					}
 				}
 			}
+			// Issue #164: stamp the served model onto every relayed chunk so
+			// the streamed response identifies the model that actually
+			// served it (fallbacks included). No-op when the chunk already
+			// carries the served model or no lease drove the relay.
+			clean = rewriteChatChunkModel(clean, stats.servedModel)
 			if first {
 				first = false
 				phasetiming.FromContext(ctx).Since(phasetiming.UpstreamTTFBMS, chatStart)
@@ -426,6 +435,30 @@ func (s *Server) relayStream(ctx context.Context, w http.ResponseWriter, r io.Re
 			flusher.Flush()
 		}
 	}
+}
+
+// rewriteChatChunkModel returns clean unchanged unless the chunk's model
+// field differs from the served model, in which case it re-marshals the
+// chunk with the served model. A chunk carrying no model field is left
+// untouched (the upstream OpenAI-compatible surface always includes it;
+// injecting into arbitrary frames would re-marshal every chunk). served ""
+// (relay driven directly without a lease) disables the rewrite entirely.
+func rewriteChatChunkModel(clean []byte, served string) []byte {
+	if served == "" || !bytes.Contains(clean, []byte(`"model":`)) {
+		return clean
+	}
+	var chunk map[string]any
+	if json.Unmarshal(clean, &chunk) != nil {
+		return clean
+	}
+	if cur, _ := chunk["model"].(string); cur == served {
+		return clean
+	}
+	chunk["model"] = served
+	if b, err := json.Marshal(chunk); err == nil {
+		return b
+	}
+	return clean
 }
 
 // trackToolCallIndexes records per-stream tool-call state on every chunk
@@ -582,6 +615,21 @@ func (s *Server) relayJSON(ctx context.Context, w http.ResponseWriter, r io.Read
 				}
 			}
 			if changed {
+				if b, err := json.Marshal(comp); err == nil {
+					out = b
+				}
+			}
+		}
+	}
+	// Issue #164: stamp the served model onto the non-streaming response
+	// body so clients see the model that actually served the request
+	// (fallbacks included). Runs before the reasoning-cache block below so
+	// the cache also keys on the served model, matching the streaming path.
+	if stats.servedModel != "" {
+		var comp map[string]any
+		if json.Unmarshal(out, &comp) == nil {
+			if cur, _ := comp["model"].(string); cur != stats.servedModel {
+				comp["model"] = stats.servedModel
 				if b, err := json.Marshal(comp); err == nil {
 					out = b
 				}


### PR DESCRIPTION
Closes #164

## Problem
Quota fallback (e.g. flash -> mimo) returned 200 with no indication of rerouting; clients saw the requested model, not the served one.

## Change
- Rotation priority VERIFIED already correct: acquireOrder exhausts every quota-positive token for the requested model before QUOTA_FALLBACK_MODELS fires (documented in acquire.go).
- Headers on both wire protocols: X-FreeBuff-Served-Model (always), X-FreeBuff-Fallback (quota_exhausted | queue_timeout, omitted on direct serving).
- Served model propagated into response bodies: OpenAI chat.completion model field + streaming chunks, Anthropic message_start + message object.
- Lease.FallbackReason stamped at quota-fallback points (pool.go, acquire.go, bridge.go both paths).

## Evidence
- fallback_transparency_test.go (4 e2e tests) + scarce_test lease.FallbackReason assertion — PASS
- `env -u AUTH_TOKENS -u ADMIN_TOKEN go test ./...` — 20/20 packages ok; go build ./... clean
- gofmt clean