### PR TITLE
fix(upstream): silence stdlib 'protocol https already registered' log on stealth h2 clients

### DIFF
--- a/internal/upstream/client.go
+++ b/internal/upstream/client.go
@@ -228,6 +228,17 @@ func NewWithIndex(token string, tokenIndex int, cfg *config.Config) (*Client, er
 				MaxHeaderListSize:         262_144, // Chrome SETTINGS_MAX_HEADER_LIST_SIZE
 			}
 			transport.RegisterProtocol("https", h2t)
+			// The stdlib runs onceSetNextProtoDefaults on the
+			// transport's first use; its bundled h2 configure would
+			// call RegisterProtocol("https") again and panic — the
+			// recovered error is logged as "protocol https already
+			// registered" on every stealth client's first request.
+			// The documented empty-TLSNextProto kill switch makes
+			// protocols().HTTP2() false so that configure is skipped;
+			// https dispatch to our custom h2t goes through
+			// altProto (alternateRoundTripper) and is independent of
+			// the bundled configure.
+			transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
 		} else {
 			// Plain Go transport: the stdlib already negotiates HTTP/2 by
 			// default (the DefaultTransport clone carries

--- a/internal/upstream/egress_stealth_test.go
+++ b/internal/upstream/egress_stealth_test.go
@@ -8,8 +8,10 @@ package upstream
 // concurrent work on client_test.go does not collide.
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 	"testing"
@@ -114,6 +116,41 @@ func TestHTTP2UpstreamWiring(t *testing.T) {
 			t.Errorf("h1 stealth dial error = %q, want the tcp dial wrapper", msg)
 		}
 	})
+}
+
+// TestStealthH2NoBundledConfigureLog guards the "protocol https already
+// registered" log: the stdlib's onceSetNextProtoDefaults runs the bundled
+// http2 configure on the transport's first use, which panics (recovered
+// into a logged error) because our stealth h2 transport already owns
+// "https" via RegisterProtocol. The empty TLSNextProto kill switch skips
+// that configure; the warning must never hit the log.
+func TestStealthH2NoBundledConfigureLog(t *testing.T) {
+	c, err := New("tok", testConfig("", func(cfg *config.Config) {
+		cfg.HTTP2Upstream = true
+		cfg.TLSFingerprint = "chrome126"
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture the default logger, which is where net/http emits the
+	// bundled-h2 configure error.
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(prev)
+
+	// First use of the transport is what triggers onceSetNextProtoDefaults.
+	req, err := http.NewRequest(http.MethodGet, "https://127.0.0.1:1/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.http.Transport.RoundTrip(req); err == nil {
+		t.Fatal("RoundTrip to a refused port succeeded")
+	}
+	if got := buf.String(); strings.Contains(got, "protocol https already registered") {
+		t.Errorf("bundled h2 configure warning leaked to the log:\n%s", got)
+	}
 }
 
 // TestSessionResponseFeedsRiskEngine guards the passive risk feed (issue


### PR DESCRIPTION
## Problem
`-doctor` (and every stealth HTTP/2 client) logs a spurious warning on first request:

```
Error enabling Transport HTTP/2 support: protocol https already registered
```

Root cause: the stdlib's `Transport.onceSetNextProtoDefaults` runs the bundled h2 configure (`http2configureTransports` → `http2registerHTTPSProtocol` → `t.RegisterProtocol("https", ...)`) on a transport's first use. The stealth+h2 path registers a custom `http2.Transport` for `https` first, so the bundled configure panics; the recovered error becomes a `log.Printf` on **every** stealth client's first request, not just doctor.

## Fix
Set the documented empty-`TLSNextProto` kill switch after `RegisterProtocol` in the stealth+h2 branch. This makes `protocols().HTTP2()` false, so `onceSetNextProtoDefaults` returns at the protocols gate **before** the bundled configure ever runs. https dispatch to the custom h2t goes through `altProto` (`alternateRoundTripper`) and is independent of the bundled configure — untouched.

Plain paths and the h1 kill-switch path are unchanged (they already used this exact pattern).

## Evidence
- `TestStealthH2NoBundledConfigureLog`: **red pre-fix** (captures the exact warning), **green post-fix**.
- `TestHTTP2UpstreamWiring` (all 4 subtests): green — dispatch to the utls dialer preserved.
- `-doctor`: `already registered` count 0; probe succeeds.
- `env -u AUTH_TOKENS -u ADMIN_TOKEN go test -count=1 ./cmd/... ./internal/...`: all packages ok.