### PR TITLE
fix(pool): isolate per-model quota cooldowns and surface GLM promo quota (#178)

### DIFF
--- a/internal/dashboard/dashboard_data.go
+++ b/internal/dashboard/dashboard_data.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -303,6 +304,38 @@ func (d *Dashboard) tokensData() tokensData {
 				row.HasEntitlement = true
 			}
 			detail.Quota = append(detail.Quota, row)
+		}
+		// Scarcity/promo isolation (issue #178): the upstream glmPromo block
+		// ({dailySessions, endsAt}) grants a referral quota on scarce models
+		// like GLM/Luna/Pro. Synthesize a dashboard row for z-ai/glm-5.2 so
+		// the promo is visible even though no per-model quota was admitted;
+		// a real rateLimitsByModel entry for the model wins over the promo.
+		if _, exists := t.QuotaByModel["z-ai/glm-5.2"]; !exists && t.GlmPromo != "" {
+			var gp struct {
+				DailySessions float64 `json:"dailySessions"`
+				EndsAt        string  `json:"endsAt"`
+			}
+			if err := json.Unmarshal([]byte(t.GlmPromo), &gp); err == nil && gp.DailySessions > 0 {
+				var resetAt time.Time
+				if ts, err := time.Parse(time.RFC3339, gp.EndsAt); err == nil {
+					resetAt = ts
+				}
+				glmRow := quotaRow{
+					Model:          "z-ai/glm-5.2",
+					Limit:          formatQuota(gp.DailySessions),
+					Recent:         "0",
+					Remaining:      gp.DailySessions,
+					Period:         "promo",
+					ResetAt:        shortTime(resetAt),
+					ResetAtUTC:     utcAttr(resetAt),
+					ResetsIn:       humanDuration(time.Until(resetAt)),
+					Entitled:       "referral",
+					HasEntitlement: true,
+					UsagePct:       0,
+					HasBar:         true,
+				}
+				detail.Quota = append(detail.Quota, glmRow)
+			}
 		}
 		sort.Slice(detail.Quota, func(i, j int) bool { return detail.Quota[i].Model < detail.Quota[j].Model })
 		detail.HasQuota = len(detail.Quota) > 0

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -418,13 +418,14 @@ func pageServer(t *testing.T, tokens int, page string, mut func(*config.Config),
 const dashModel = "z-ai/glm-5.2"
 
 // quotaPageServer builds a tokens page whose session admission carries the
-// given rateLimitsByModel entries, driven through a real pool chat so the
-// token snapshot gains QuotaByModel (the only way the quota table renders).
-func quotaPageServer(t *testing.T, limits map[string]any) *httptest.Server {
+// mock-configured quota state (rateLimitsByModel entries, glmPromo block),
+// driven through a real pool chat so the token snapshot gains QuotaByModel/
+// GlmPromo (the only way the quota table renders).
+func quotaPageServer(t *testing.T, mut func(*testutil.MockUpstream)) *httptest.Server {
 	t.Helper()
 	mock := testutil.NewMock()
 	t.Cleanup(mock.Close)
-	mock.RateLimitsByModel = limits
+	mut(mock)
 	mock.ChatBody = testutil.SSEEvent(`{"id":"c1","object":"chat.completion.chunk","created":1,"model":"`+dashModel+`","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`) +
 		testutil.SSEEvent(`{"id":"c1","object":"chat.completion.chunk","created":1,"model":"`+dashModel+`","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`)
 	cfg := &config.Config{
@@ -472,26 +473,28 @@ func quotaPageServer(t *testing.T, limits map[string]any) *httptest.Server {
 // TestTokensPageQuotaRows pins the quota table JSON fields.
 func TestTokensPageQuotaRows(t *testing.T) {
 	reset := time.Now().Add(4*time.Hour + 12*time.Minute).UTC().Format(time.RFC3339)
-	ts := quotaPageServer(t, map[string]any{
-		dashModel: map[string]any{
-			"model":       dashModel,
-			"limit":       100,
-			"recentCount": 120, // > limit → UsagePct clamps to 100
-			"period":      "pacific_day",
-			"resetAt":     reset,
-			"entitlementBreakdown": map[string]any{
-				"base":     1,
-				"referral": 1,
-				"streak":   3,
+	ts := quotaPageServer(t, func(m *testutil.MockUpstream) {
+		m.RateLimitsByModel = map[string]any{
+			dashModel: map[string]any{
+				"model":       dashModel,
+				"limit":       100,
+				"recentCount": 120, // > limit → UsagePct clamps to 100
+				"period":      "pacific_day",
+				"resetAt":     reset,
+				"entitlementBreakdown": map[string]any{
+					"base":     1,
+					"referral": 1,
+					"streak":   3,
+				},
 			},
-		},
-		"deepseek/deepseek-v4-flash": map[string]any{
-			"model":       "deepseek/deepseek-v4-flash",
-			"limit":       100,
-			"recentCount": 80, // exactly at NearLimit threshold
-			"period":      "pacific_day",
-			"resetAt":     reset,
-		},
+			"deepseek/deepseek-v4-flash": map[string]any{
+				"model":       "deepseek/deepseek-v4-flash",
+				"limit":       100,
+				"recentCount": 80, // exactly at NearLimit threshold
+				"period":      "pacific_day",
+				"resetAt":     reset,
+			},
+		}
 	})
 	resp, err := http.Get(ts.URL + "/tokens")
 	if err != nil {
@@ -528,7 +531,65 @@ func TestTokensPageQuotaRows(t *testing.T) {
 	}
 }
 
-// TestTokensPagePureBridgeInBridgeCard pins the pure-bridge tokens page JSON.
+// TestTokensDataGlmPromoSynthesis pins the synthesized z-ai/glm-5.2 promo
+// quota row (issue #178): the upstream glmPromo block ({dailySessions,
+// endsAt}) grants a referral quota on scarce models like GLM, so the
+// dashboard renders it even when no rateLimitsByModel entry was admitted.
+func TestTokensDataGlmPromoSynthesis(t *testing.T) {
+	ts := quotaPageServer(t, func(m *testutil.MockUpstream) {
+		m.GlmPromo = map[string]any{
+			"dailySessions": 2,
+			"endsAt":        "2026-08-22T07:00:00Z",
+		}
+	})
+	resp, err := http.Get(ts.URL + "/tokens")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var data map[string]any
+	if err := json.Unmarshal(mustReadAll(t, resp), &data); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	tokens, _ := data["tokens"].([]any)
+	if len(tokens) == 0 {
+		t.Fatal("no tokens in response")
+	}
+	token, _ := tokens[0].(map[string]any)
+	quota, _ := token["quota"].([]any)
+	if len(quota) == 0 {
+		t.Fatal("no quota entries")
+	}
+	var glm map[string]any
+	for _, q := range quota {
+		qm := q.(map[string]any)
+		if qm["model"] == "z-ai/glm-5.2" {
+			glm = qm
+			break
+		}
+	}
+	if glm == nil {
+		t.Fatal("no z-ai/glm-5.2 quota row")
+	}
+	if glm["limit"] != "2" {
+		t.Errorf("limit = %v, want 2", glm["limit"])
+	}
+	if glm["period"] != "promo" {
+		t.Errorf("period = %v, want promo", glm["period"])
+	}
+	if glm["entitled"] != "referral" {
+		t.Errorf("entitled = %v, want referral", glm["entitled"])
+	}
+	if glm["has_bar"] != true {
+		t.Error("has_bar should be true for promo row")
+	}
+	if glm["has_entitlement"] != true {
+		t.Error("has_entitlement should be true for promo row")
+	}
+	if glm["recent"] != "0" {
+		t.Errorf("recent = %v, want 0", glm["recent"])
+	}
+}
 func TestTokensPagePureBridgeInBridgeCard(t *testing.T) {
 	ts, _ := pageServer(t, 0, "tokens", nil, nil)
 	resp, err := http.Get(ts.URL + "/tokens")

--- a/internal/pool/acquire.go
+++ b/internal/pool/acquire.go
@@ -212,6 +212,13 @@ func (p *Pool) Acquire(ctx context.Context, model string) (*Lease, error) {
 				waiting = append(waiting, wr)
 			}
 			if rle := asRateLimit(err); rle != nil {
+				// Issue #178: tag the refusal with the requested model when
+				// the upstream body omits it, so the remembered cooldown can
+				// be isolated per model — a quota cap on one model (glm-5.2,
+				// gpt-5.6-luna) must not block the same token's other models.
+				if rle.Model == "" {
+					rle.Model = model
+				}
 				tok.runs.CooldownRateLimit(rle)
 				dup := false
 				for _, existing := range rateLimited {
@@ -331,6 +338,13 @@ func (p *Pool) Acquire(ctx context.Context, model string) (*Lease, error) {
 				p.logger.Debug("pool: token cooling down", "token", idx+1, "duration", runs.DefaultCooldown.String())
 			}
 			if rle := asRateLimit(err); rle != nil {
+				// Issue #178: tag the refusal with the requested model when
+				// the upstream body omits it, so the remembered cooldown can
+				// be isolated per model — a quota cap on one model (glm-5.2,
+				// gpt-5.6-luna) must not block the same token's other models.
+				if rle.Model == "" {
+					rle.Model = model
+				}
 				tok.runs.CooldownRateLimit(rle)
 				dup := false
 				for _, existing := range rateLimited {

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -153,6 +153,10 @@ type TokenSnapshot struct {
 	// nests entitlement inside each rate-limit entry).
 	QuotaByModel map[string]session.QuotaSnapshot
 	Entitlement  map[string]float64
+	// GlmPromo is the raw upstream glmPromo block ({dailySessions, endsAt})
+	// from the token's last admission (issue #178); "" when absent. The
+	// dashboard synthesizes the z-ai/glm-5.2 promo quota row from it.
+	GlmPromo string
 	// Standing is the upstream account standing block (issue #96); nil until
 	// the session reports it.
 	Standing *upstream.SessionStanding

--- a/internal/pool/pool_scarce_test.go
+++ b/internal/pool/pool_scarce_test.go
@@ -1,0 +1,109 @@
+// pool_scarce_test.go — issue #178: quota-exhaustion cooldowns are isolated
+// per model, so a token quota-capped for one scarce/promo model
+// (z-ai/glm-5.2, gpt-5.6-luna) keeps serving its other models
+// (deepseek/deepseek-v4-flash) instead of being locked token-wide.
+package pool
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"freebuff-proxy/internal/testutil"
+	"freebuff-proxy/internal/upstream"
+)
+
+// TestQuotaCooldownIsolationAcrossModels pins issue #178 at the pool level:
+// a token whose remembered cooldown is a quota exhaustion for one model is
+// still eligible for a DIFFERENT model — the glm-5.2 daily cap must not
+// block flash on the same token — while the capped model itself keeps
+// surfacing the remembered 429.
+func TestQuotaCooldownIsolationAcrossModels(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	p := newTestPool(t, mock)
+
+	// Seed token 1's cooldown exactly as an upstream quota-exhaustion 429
+	// for glm-5.2 lands: quota fields at/over the limit with a future reset.
+	rle := &upstream.RateLimitError{
+		Model:       "z-ai/glm-5.2",
+		Status:      "rate_limited",
+		RetryAfter:  time.Hour,
+		Limit:       2,
+		RecentCount: 2,
+		Period:      "pacific_day",
+		ResetAt:     time.Now().Add(time.Hour),
+		Body:        "session quota exhausted for model",
+	}
+	p.CooldownTokenRateLimit(0, rle)
+
+	// The capped model itself is refused: the token is cooling down for it.
+	_, err := p.Acquire(context.Background(), "z-ai/glm-5.2")
+	var got *upstream.RateLimitError
+	if !errors.As(err, &got) {
+		t.Fatalf("Acquire(z-ai/glm-5.2) on quota-capped token = %v, want 429", err)
+	}
+
+	// A different model on the SAME token is not blocked by that cooldown.
+	lease, err := p.Acquire(context.Background(), "deepseek/deepseek-v4-flash")
+	if err != nil {
+		t.Fatalf("Acquire(flash) blocked by glm-5.2 quota cooldown: %v", err)
+	}
+	if lease == nil {
+		t.Fatal("Acquire(flash) = nil lease")
+	}
+	p.LeaseRelease(lease)
+}
+
+// TestAdmissionQuota429TagsModelAndIsolates pins issue #178 end-to-end: a
+// 429 quota-exhaustion on session CREATE for glm-5.2 whose body omits the
+// model field is tagged with the requested model by the admission path,
+// cools the token per-model, and the same token still admits flash after.
+func TestAdmissionQuota429TagsModelAndIsolates(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+
+	var creates atomic.Int32
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && creates.Add(1) == 1 {
+			// First create (glm-5.2): quota-exhausted 429 with NO model
+			// field — the proxy must tag the requested model itself.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(429)
+			_, _ = io.WriteString(w, `{"status":"rate_limited","limit":2,"recentCount":2,"period":"pacific_day","resetAt":"2026-08-25T07:00:00.000Z","retryAfterMs":60000}`)
+			return
+		}
+		// Subsequent creates (flash) and probes/polls: active.
+		expiresAt := time.Now().Add(30 * time.Minute).UTC().Format("2006-01-02T15:04:05.000Z07:00")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-abc-123","expiresAt":"`+expiresAt+`"}`)
+	}
+	p := newTestPool(t, mock)
+
+	_, err := p.Acquire(context.Background(), "z-ai/glm-5.2")
+	var rle *upstream.RateLimitError
+	if !errors.As(err, &rle) {
+		t.Fatalf("Acquire(z-ai/glm-5.2) = %v, want 429", err)
+	}
+	if rle.Model != "z-ai/glm-5.2" {
+		t.Errorf("RLE.Model = %q, want %q (tagged from the requested model)", rle.Model, "z-ai/glm-5.2")
+	}
+	if !isQuotaExhaustedError(rle) {
+		t.Errorf("RLE not classified as quota exhaustion: %+v", rle)
+	}
+
+	// The same token now serves flash despite the glm-5.2 quota cooldown.
+	lease, err := p.Acquire(context.Background(), "deepseek/deepseek-v4-flash")
+	if err != nil {
+		t.Fatalf("Acquire(flash) blocked by glm-5.2 quota cooldown: %v", err)
+	}
+	if lease == nil {
+		t.Fatal("Acquire(flash) = nil lease")
+	}
+	p.LeaseRelease(lease)
+}

--- a/internal/pool/scarce.go
+++ b/internal/pool/scarce.go
@@ -74,9 +74,16 @@ func scarceModelSet(models []string) map[string]bool {
 
 // isQuotaExhaustedError reports whether rle represents a session quota exhaustion
 // (recentCount >= limit or local session quota error) as opposed to a transient rate limit.
+// Issue #178: a refusal carrying a reset timestamp or a pacific_day/pacific_week
+// period is quota-shaped too — those are the quota windows the upstream serves
+// on daily/weekly caps, so the pool treats them as per-model quota exhaustion
+// and lets the token keep serving its other models.
 func isQuotaExhaustedError(rle *upstream.RateLimitError) bool {
 	if rle == nil {
 		return false
+	}
+	if !rle.ResetAt.IsZero() || rle.Period == "pacific_day" || rle.Period == "pacific_week" || isDailyCapReset(rle) {
+		return true
 	}
 	if rle.Limit > 0 && rle.RecentCount >= rle.Limit {
 		return true
@@ -85,6 +92,18 @@ func isQuotaExhaustedError(rle *upstream.RateLimitError) bool {
 		return true
 	}
 	return false
+}
+
+// isDailyCapReset mirrors upstream.isDailyCapReset: a no-timestamp 429 body
+// signals a genuine daily-cap reset when the quota period is
+// pacific_day/pacific_week AND the recent counter is at/over the limit (the
+// session-quota bodies the CLI serves on daily-cap refusals). The pool needs
+// its own copy because the upstream helper is unexported.
+func isDailyCapReset(rle *upstream.RateLimitError) bool {
+	if rle.Period != "pacific_day" && rle.Period != "pacific_week" {
+		return false
+	}
+	return rle.Limit > 0 && rle.RecentCount >= rle.Limit
 }
 func bridgeQuotaRemaining(entry *bridgeEntry, model string) (known bool, remaining float64, capped bool) {
 	q, ok := entry.session.Snapshot().QuotaByModel[model]

--- a/internal/pool/snapshot.go
+++ b/internal/pool/snapshot.go
@@ -99,6 +99,7 @@ func (p *Pool) Snapshot() []TokenSnapshot {
 			SessionActiveUsersForIP: ss.ActiveUsersForIP,
 			QuotaByModel:            ss.QuotaByModel,
 			Entitlement:             ss.Entitlement,
+			GlmPromo:                ss.GlmPromo,
 			Standing:                ss.Standing,
 			TransientRetries:        tok.client.TransientRetries(),
 			FingerprintRotations:    tok.client.FingerprintRotations(),

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -131,6 +131,11 @@ type Manager struct {
 	// commit(non-nil) without fresh quota restores it so the dashboard
 	// quota table stays visible between quota-carrying responses.
 	savedQuota map[string]upstream.ModelQuota
+	// savedGlmPromo preserves the last glmPromo block across
+	// invalidation/re-admission cycles, mirroring savedQuota (issue #178):
+	// the GLM promo quota row must stay visible while the session is
+	// between quota-carrying responses.
+	savedGlmPromo string
 
 	// adopt is the issue #97 CLI-session adoption mode (ADOPT_CLI_SESSION):
 	// nil (default) = create sessions normally. When set, the manager adopts
@@ -194,6 +199,10 @@ type cachedState struct {
 	// admission/poll that carried rateLimitsByModel (key = model id);
 	// nil until such a response is seen.
 	quotaByModel map[string]upstream.ModelQuota
+	// glmPromo carries the raw upstream glmPromo block ({dailySessions,
+	// endsAt}) from the last admission/poll that included it (issue #178);
+	// "" until such a response is seen.
+	glmPromo string
 	// standing is the upstream account standing block (issue #96); nil until
 	// an admission/poll that carried it.
 	standing *upstream.SessionStanding
@@ -249,6 +258,12 @@ func (m *Manager) commit(cs *cachedState) {
 		if m.state.quotaByModel != nil {
 			m.savedQuota = m.state.quotaByModel
 		}
+		// Stash the glmPromo block the same way (issue #178): it survives
+		// invalidation so the GLM promo row stays on the dashboard between
+		// quota-carrying responses.
+		if m.state.glmPromo != "" {
+			m.savedGlmPromo = m.state.glmPromo
+		}
 	}
 	// Restore the previously-seen quota map when the new state omits
 	// rateLimitsByModel (the upstream intermittently drops the field on
@@ -256,6 +271,11 @@ func (m *Manager) commit(cs *cachedState) {
 	// dashboard quota table visible between quota-carrying responses.
 	if cs != nil && cs.quotaByModel == nil && m.savedQuota != nil {
 		cs.quotaByModel = m.savedQuota
+	}
+	// Restore the previously-seen glmPromo block when the new state omits
+	// it (issue #178), mirroring the quota-map restore above.
+	if cs != nil && cs.glmPromo == "" && m.savedGlmPromo != "" {
+		cs.glmPromo = m.savedGlmPromo
 	}
 	m.state = cs
 	if m.store != nil && m.key != "" {
@@ -469,6 +489,11 @@ type SessionSnapshot struct {
 	// upstream wire nests entitlement inside each rate-limit entry.
 	QuotaByModel map[string]QuotaSnapshot
 	Entitlement  map[string]float64
+	// GlmPromo carries the raw upstream glmPromo block ({dailySessions,
+	// endsAt}) from the last admission/poll (issue #178); "" when absent.
+	// Kept as a string so callers render the shape without the upstream
+	// adding fields.
+	GlmPromo string
 	// Standing is the upstream account standing block (issue #96); nil until
 	// an admission/poll that carried it.
 	Standing *upstream.SessionStanding
@@ -524,6 +549,7 @@ func (m *Manager) Snapshot() SessionSnapshot {
 		ExpiresAt:          m.state.expiresAt,
 		GracePeriodEndsAt:  m.state.gracePeriodEndsAt,
 		QuotaByModel:       quota,
+		GlmPromo:           m.state.glmPromo,
 		Standing:           m.state.standing,
 	}
 }

--- a/internal/session/session_admission.go
+++ b/internal/session/session_admission.go
@@ -130,7 +130,7 @@ func (m *Manager) adoptOrCreate(ctx context.Context, requestedModel string) (*up
 	adopt := m.adopt
 	m.mu.Unlock()
 	if adopt == nil || !adopt.Enabled {
-		return m.client.CreateSessionForModel(ctx, requestedModel)
+		return m.createSessionForModel(ctx, requestedModel)
 	}
 
 	owner, ok := m.adoptOwner()
@@ -145,7 +145,7 @@ func (m *Manager) adoptOrCreate(ctx context.Context, requestedModel string) (*up
 	if owner.PID <= 0 || !adopt.testAlive(owner.PID) {
 		// The CLI process is not running: the proxy may create (and own) a
 		// session for the account, exactly like the reference fallback.
-		return m.client.CreateSessionForModel(ctx, requestedModel)
+		return m.createSessionForModel(ctx, requestedModel)
 	}
 	if owner.InstanceID == "" {
 		return nil, fmt.Errorf("ADOPT_CLI_SESSION: the FreeBuff CLI is running but no session instance was recorded — refusing to create a competing session (stop the CLI or retry)")
@@ -184,6 +184,22 @@ func (m *Manager) adoptOrCreate(ctx context.Context, requestedModel string) (*up
 	default:
 		return nil, fmt.Errorf("ADOPT_CLI_SESSION: CLI session %s is not adoptable (status %q) — refusing to create a competing session (restart the CLI or stop it)", shortInstance(owner.InstanceID), status)
 	}
+}
+
+// createSessionForModel POSTs a fresh session for model and tags any
+// rate-limit refusal with the requested model (issue #178): upstream 429
+// quota bodies can omit the model field, and the pool needs it to isolate
+// the cooldown per model — a quota cap on z-ai/glm-5.2 must not block
+// deepseek/deepseek-v4-flash on the same token.
+func (m *Manager) createSessionForModel(ctx context.Context, model string) (*upstream.SessionState, error) {
+	st, err := m.client.CreateSessionForModel(ctx, model)
+	if err != nil {
+		var rle *upstream.RateLimitError
+		if errors.As(err, &rle) && rle.Model == "" {
+			rle.Model = model
+		}
+	}
+	return st, err
 }
 
 // shortInstance renders a session instance id's first 8 chars for logs.
@@ -379,6 +395,7 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string, preemptive
 				ipPrivacySignals:   st.IpPrivacySignals,
 				limit:              st.Limit,
 				quotaByModel:       st.RateLimitsByModel,
+				glmPromo:           st.GlmPromo,
 				standing:           st.Standing,
 			})
 			// Issue #60: the successful admission refreshes the probe cache
@@ -430,6 +447,7 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string, preemptive
 				position:   st.Position,
 				queueDepth: st.QueueDepth,
 				pollAt:     pollAt,
+				glmPromo:   st.GlmPromo,
 			})
 			m.mu.Unlock()
 			slog.Debug("session queued", "instance_id", st.InstanceID, "model", model,

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -35,6 +35,9 @@ type persistedState struct {
 	CountryCode        string                    `json:"country_code"`
 	CountryBlockReason string                    `json:"country_block_reason"`
 	QuotaByModel       map[string]persistedQuota `json:"quota_by_model,omitempty"`
+	// GlmPromo is the raw upstream glmPromo block ({dailySessions,
+	// endsAt}); "" when absent (issue #178).
+	GlmPromo string `json:"glm_promo,omitempty"`
 }
 
 // persistedQuota is one model's live session quota persisted on disk.
@@ -218,6 +221,7 @@ func (s *Store) Load(key string) *cachedState {
 		pollAt:             ps.PollAt,
 		countryCode:        ps.CountryCode,
 		countryBlockReason: ps.CountryBlockReason,
+		glmPromo:           ps.GlmPromo,
 	}
 	if len(ps.QuotaByModel) > 0 {
 		cs.quotaByModel = make(map[string]upstream.ModelQuota, len(ps.QuotaByModel))
@@ -269,6 +273,7 @@ func (s *Store) Save(key string, cs *cachedState) {
 		PollAt:             cs.pollAt,
 		CountryCode:        cs.countryCode,
 		CountryBlockReason: cs.countryBlockReason,
+		GlmPromo:           cs.glmPromo,
 	}
 	if len(cs.quotaByModel) > 0 {
 		ps := s.data[key]

--- a/internal/testutil/mockupstream.go
+++ b/internal/testutil/mockupstream.go
@@ -71,6 +71,11 @@ type MockUpstream struct {
 	// model id) so tests can exercise quota parsing end-to-end.
 	RateLimitsByModel map[string]any
 
+	// GlmPromo, when non-nil, is embedded in the active session body as the
+	// glmPromo block ({dailySessions, endsAt}; issue #178) so tests can
+	// exercise the promo-quota data chain end-to-end.
+	GlmPromo map[string]any
+
 	// CountryCode / CountryBlockReason, when non-empty, are embedded in the
 	// active session body (wire shape parsed by upstream's sessionCall) so
 	// tests can exercise region reporting end-to-end.
@@ -327,6 +332,7 @@ func (m *MockUpstream) handleSession(w http.ResponseWriter, r *http.Request) {
 	position, depth, waitMs := m.QueuePosition, m.QueueDepth, m.EstimatedWaitMs
 	instanceID, expiresIn := m.InstanceID, m.ExpiresIn
 	limits := m.RateLimitsByModel
+	glmPromo := m.GlmPromo
 	countryCode, countryBlockReason := m.CountryCode, m.CountryBlockReason
 	standing := m.Standing
 	m.mu.Unlock()
@@ -343,6 +349,9 @@ func (m *MockUpstream) handleSession(w http.ResponseWriter, r *http.Request) {
 		}
 		if len(limits) > 0 {
 			body["rateLimitsByModel"] = limits
+		}
+		if len(glmPromo) > 0 {
+			body["glmPromo"] = glmPromo
 		}
 		if countryCode != "" {
 			body["countryCode"] = countryCode
@@ -415,6 +424,7 @@ func (m *MockUpstream) handleProbe(w http.ResponseWriter) {
 	m.mu.Lock()
 	instanceID := m.InstanceID
 	limits := m.RateLimitsByModel
+	glmPromo := m.GlmPromo
 	countryCode, countryBlockReason := m.CountryCode, m.CountryBlockReason
 	m.mu.Unlock()
 	if len(limits) == 0 {
@@ -424,6 +434,9 @@ func (m *MockUpstream) handleProbe(w http.ResponseWriter) {
 		"status":            "active",
 		"instanceId":        instanceID,
 		"rateLimitsByModel": limits,
+	}
+	if len(glmPromo) > 0 {
+		body["glmPromo"] = glmPromo
 	}
 	// The probe mirrors the full admission shape (region state included —
 	// the vendored CLI's session GET serves the same without any


### PR DESCRIPTION
Closes #178

## Problem
Two related gaps reported on #176/#154:
1. **Per-model quota cooldown isolation**: upstream admission 429 quota bodies can omit the model field. The pool fell back to a *global* token cooldown, so one model's quota exhaustion (z-ai/glm-5.2 referral promo, gpt-5.6-luna 1-session) blocked *every* model on that token — deepseek/deepseek-v4-flash and mimo/mimo-v2.5 went 429 for the wrong reason.
2. **GLM invisible in dashboard**: upstream serves GLM quota in a dedicated `glmPromo` block (`{"dailySessions": N, "endsAt": "..."}`), not inside `rateLimitsByModel`. `tokensData()` only iterated the rate-limit map, so z-ai/glm-5.2 never rendered.

## Fix
- `internal/session/session_admission.go`: `createSessionForModel` tags `rle.Model = model` when admission returns a 429.
- `internal/pool/acquire.go`: both Acquire paths tag `rle.Model` before `CooldownRateLimit`.
- `internal/pool/scarce.go`: `isQuotaExhaustedError` now recognizes reset-window quota shapes (non-zero `ResetAt`, `pacific_day`/`pacific_week` period, daily-cap reset) as model-specific exhaustion.
- `internal/session/session.go`: `savedGlmPromo` preserved across invalidation/re-admission (mirrors `savedQuota`); `SessionSnapshot.GlmPromo` carries the raw block.
- `internal/pool/snapshot.go`: `TokenSnapshot.GlmPromo` forwards it.
- `internal/dashboard/dashboard_data.go`: `tokensData()` synthesizes a `z-ai/glm-5.2` promo row (`Period: "promo"`, `ResetAt: endsAt`, `Entitled: "referral"`) with usage bars when `GlmPromo` is present.

## Tests
- `TestQuotaCooldownIsolationAcrossModels` — pool_scarce_test.go
- `TestAdmissionQuota429TagsModelAndIsolates` — pool_scarce_test.go
- `TestTokensDataGlmPromoSynthesis` — dashboard_test.go

## Evidence
- `env -u AUTH_TOKENS -u ADMIN_TOKEN go test -count=1 ./internal/pool/ ./internal/session/ ./internal/dashboard/ ./internal/server/` — all ok
- `gofmt -l cmd internal` clean; `go vet ./cmd/... ./internal/...` clean