### PR TITLE
chore(scripts): make post-auth token probe opt-in (never send token to server by default)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -42,8 +42,14 @@ The extracted release folder contains `freebuff-proxy` (Linux/macOS) or `freebuf
 1. Mints a fresh CLI-parity fingerprint (`enhanced-<43-char base64url>`, same shape as the official CLI's SHA-256 base64url fingerprint) and requests a login URL from the FreeBuff backend.
 2. Auto-launches an isolated Private/Incognito browser window to prevent account linking.
 3. Jitter-polls the authentication status every 5s (CLI parity).
-4. Runs a zero-cost post-auth probe on `/api/v1/freebuff/session` (no instance header, no session slot consumed) to confirm account status/tier/risk and **refuses to save a banned account**.
-5. Saves or appends the token to `.env`.
+4. Saves or appends the token to `.env`.
+
+> **Privacy default:** the fresh token is **never sent back to the server**
+> after login. The old auto-probe (ban/tier check on
+> `/api/v1/freebuff/session`) is now opt-in: pass `-Verify`
+> (PowerShell) or `--verify` (bash). With `--verify`, the probe sends no
+> instance header (no session slot consumed) and refuses to save a banned
+> account.
 
 ### Windows (PowerShell / CMD)
 
@@ -56,6 +62,7 @@ The extracted release folder contains `freebuff-proxy` (Linux/macOS) or `freebuf
 .\gen-token.cmd -Save
 .\gen-token.cmd -Append
 .\gen-token.cmd -Incognito
+.\gen-token.cmd -Verify   # opt-in post-auth probe
 ```
 
 ### Linux / macOS (Bash)

--- a/scripts/gen-freebuff-token.ps1
+++ b/scripts/gen-freebuff-token.ps1
@@ -1,10 +1,14 @@
 # gen-freebuff-token.ps1 - Generate a FreeBuff auth token via headless login flow
+# Default: the fresh token is NEVER sent back to the server after login.
+# Pass -Verify to opt in to the post-auth /api/v1/freebuff/session probe
+# (ban/tier check, no session slot claimed).
 [CmdletBinding()]
 param(
     [switch]$Save,
     [switch]$ToClipboard,
     [switch]$Incognito,
     [switch]$Append,
+    [switch]$Verify,
     [string]$EnvFile = "",
     [string]$BaseUrl = $(if ($env:FREEBUFF_BASE_URL) { $env:FREEBUFF_BASE_URL } else { "https://www.codebuff.com" }),
     [int]$TimeoutSeconds = 300,
@@ -325,7 +329,12 @@ Write-Host "Login successful!" -ForegroundColor Green
 Write-Host " Account: $userName ($userEmail)" -ForegroundColor Cyan
 Write-Host " Token: $authToken" -ForegroundColor White
 
-# --- 4.5 zero-cost post-auth verification ------------------------------------
+# --- 4.5 opt-in post-auth verification (anti-ban) ----------------------------
+# OFF by default: the fresh token is never sent back to the server. Pass
+# -Verify to opt in — it probes /api/v1/freebuff/session (no
+# x-freebuff-instance-id, so no session slot is claimed; matches the proxy's
+# -test-token probe) and refuses to save a banned account.
+if ($Verify) {
 try {
     $probeResp = Invoke-FreebuffApi -Uri "$BaseUrl/api/v1/freebuff/session" -Method GET -Headers @{ "Authorization" = "Bearer $authToken"; "User-Agent" = "ai-sdk/openai-compatible/1.0.0/codebuff" } -TimeoutSec 15
     # StrictMode-safe reads: the live session response carries status +
@@ -342,6 +351,7 @@ try {
     Write-Host "Account check: status=$probeStatus tier=$(if ($probeTier) { $probeTier } else { '?' }) risk=$(if ($probeRisk) { $probeRisk } else { '?' })" -ForegroundColor Cyan
 } catch {
     Write-Host "Probe unreadable; continuing without tier confirmation: $($_.Exception.Message)" -ForegroundColor Yellow
+}
 }
 
 # --- 5. save credentials locally ---------------------------------------------

--- a/scripts/gen-freebuff-token.sh
+++ b/scripts/gen-freebuff-token.sh
@@ -11,6 +11,9 @@
 #   ./gen-freebuff-token.sh --save       # save to ~/.config/manicode/credentials.json
 #   ./gen-freebuff-token.sh --append     # append to .env AUTH_TOKENS (auto-copies .env.example if missing)
 #   ./gen-freebuff-token.sh --env /path/.env  # target .env for --append
+#   ./gen-freebuff-token.sh --verify     # opt-in: probe the fresh token against
+#                                        # /api/v1/freebuff/session for ban/tier check
+#                                        # (default: never sends the token to the server)
 #
 # Each run generates a unique fingerprintId. Log into a DIFFERENT GitHub
 # account in your browser to get a token for that account.
@@ -24,6 +27,7 @@ TIMEOUT=300
 POLL_INTERVAL=5
 MODE="interactive"  # interactive (default) | print | save | clipboard | append | incognito
 ENV_FILE=""
+VERIFY=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -34,6 +38,7 @@ while [ $# -gt 0 ]; do
     --append)    MODE="append"; shift ;;
     --env)       ENV_FILE="$2"; shift 2 ;;
     --env=*)     ENV_FILE="${1#--env=}"; shift ;;
+    --verify)    VERIFY=1; shift ;;
     -h|--help)   head -15 "$0"; exit 0 ;;
     *)           echo "Unknown arg: $1" >&2; exit 1 ;;
   esac
@@ -222,11 +227,12 @@ ok "Login successful!"
 c "  Account: $USER_NAME ($USER_EMAIL)"
 echo "  Token:   $AUTH_TOKEN"
 
-# --- 4.5 zero-cost post-auth verification (anti-ban) -------------------------
-# Probe /api/v1/freebuff/session WITHOUT x-freebuff-instance-id so no session
-# slot is claimed (matches the proxy's -test-token probe). Refuses to save a
-# banned/spend-limited account — a fresh token check here beats discovering a
-# dead token in a chat after it burned pool cooldowns.
+# --- 4.5 opt-in post-auth verification (anti-ban) ----------------------------
+# OFF by default: the fresh token is never sent back to the server. Pass
+# --verify to opt in — it probes /api/v1/freebuff/session WITHOUT
+# x-freebuff-instance-id so no session slot is claimed (matches the proxy's
+# -test-token probe), and refuses to save a banned/spend-limited account.
+if [ "$VERIFY" = "1" ]; then
 PROBE_RESP=$(curl -sS --max-time 15 \
   -H "Authorization: Bearer $AUTH_TOKEN" \
   -H "User-Agent: ai-sdk/openai-compatible/1.0.0/codebuff" \
@@ -243,6 +249,7 @@ if [ "$PROBE_STATUS" = "unknown" ] && [ -z "$PROBE_TIER" ]; then
   gray "  $(echo "$PROBE_RESP" | tr -d '\n' | head -c 160)"
 else
   c "Account check: status=$PROBE_STATUS tier=${PROBE_TIER:-?} risk=${PROBE_RISK:-?}"
+fi
 fi
 
 # --- 5. save credentials locally (opt-in with --save) ------------------------

--- a/scripts/gen-token.ps1
+++ b/scripts/gen-token.ps1
@@ -4,6 +4,7 @@ param(
     [switch]$ToClipboard,
     [switch]$Incognito,
     [switch]$Append,
+    [switch]$Verify,
     [string]$EnvFile = "",
     [string]$BaseUrl = "https://www.codebuff.com",
     [int]$TimeoutSeconds = 300,


### PR DESCRIPTION
## Change
`gen-freebuff-token.sh` / `gen-freebuff-token.ps1` previously sent the freshly generated Bearer token back to the server via a post-auth probe on `/api/v1/freebuff/session` (ban/tier check) on every run.

Now the probe is **opt-in**:
- **Default**: token never leaves the machine beyond the login flow itself.
- **Opt-in**: `--verify` (bash) / `-Verify` (PowerShell) restores the old behavior (probe without instance header, refuses to save banned accounts).

## Files
- `scripts/gen-freebuff-token.sh` — `VERIFY=0` default, `--verify` flag, probe block gated
- `scripts/gen-freebuff-token.ps1` — `-Verify` switch, probe gated, header documented
- `scripts/gen-token.ps1` — forward `-Verify` through the wrapper param block (`.cmd`/`.sh` wrappers already pass args through)
- `scripts/README.md` — document the privacy default

## Verification
- `bash -n` clean on both sh scripts; PowerShell parser reports 0 errors on both ps1 scripts
- `VERIFY=0` is the default; probe executes only inside `if [ "$VERIFY" = "1" ]` / `if ($Verify)`