### PR TITLE
fix(pool): gate GLM 5.2 to tokens with verified referral entitlement (#183)

### DIFF
--- a/.env.full-example
+++ b/.env.full-example
@@ -193,11 +193,16 @@ TRANSIENT_RETRIES=1
 # exhaustion NEVER falls back — rate-limited tokens cooldown instead.
 #FALLBACK_AFTER_MS=10000
 # FALLBACK_MODEL=model1=fallback1,model2=fallback2. Defaults (when unset):
-# the premium free-catalog rows (deepseek-v4-pro, gpt-5.6-luna, minimax-m3,
-# claude-fable-5, glm-5.2) fall back to deepseek/deepseek-v4-flash, and
+# the daily premium free-catalog rows (deepseek-v4-pro, gpt-5.6-luna, minimax-m3,
+# claude-fable-5) fall back to deepseek/deepseek-v4-flash, and
 # meta/muse-spark-1.2-contributor falls back to deepseek/deepseek-v4-pro.
+# Referral-gated z-ai/glm-5.2 is held out (issue #183) and handled via QUOTA_FALLBACK_MODELS.
 #FALLBACK_MODEL=
-
+#
+# Session-quota fallback: when a model's session quota is exhausted or unentitled
+# (QUOTA_FALLBACK_MODELS=model1=fallback1,model2=fallback2; issue #155, #183).
+# Defaults: deepseek/deepseek-v4-flash=mimo/mimo-v2.5,z-ai/glm-5.2=deepseek/deepseek-v4-flash.
+#QUOTA_FALLBACK_MODELS=
 # ── Cost safety ──────────────────────────────────────────────────────────
 # MUST stay "free": any other value routes requests as PAID and fresh free
 # accounts get 402 "Out of credits". Do not change this.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,11 +129,11 @@ type Config struct {
 	FallbackAfter time.Duration
 	// FallbackModels maps a requested model to the model served instead
 	// when the queue wait reaches FallbackAfter (issue #100,
-	// FALLBACK_MODEL=model1=fallback1,model2=fallback2). Defaults (applied
-	// only when FALLBACK_MODEL is unset): the premium free-catalog rows
-	// (deepseek-v4-pro, gpt-5.6-luna, minimax-m3, claude-fable-5,
-	// glm-5.2) → deepseek/deepseek-v4-flash. The proxy path fires only
-	// when the pool surfaces a waiting-room/queue delay ≥ FallbackAfter
+	// only when FALLBACK_MODEL is unset): the daily premium free-catalog rows
+	// (deepseek-v4-pro, gpt-5.6-luna, minimax-m3, claude-fable-5)
+	// → deepseek/deepseek-v4-flash. Referral-gated models (z-ai/glm-5.2) are
+	// held out (issue #183) and gated via QUOTA_FALLBACK_MODELS. The proxy
+	// path fires only when the pool surfaces a waiting-room/queue delay ≥ FallbackAfter
 	// for the requested model (issue #100) — 429 quota exhaustion NEVER
 	// falls back (anti-ban invariant §10). The premium→flash targets
 	// mirror the CLI's getRecommendedFreebuffModelId hero pick; the
@@ -145,8 +145,8 @@ type Config struct {
 	// Default: ["deepseek/deepseek-v4-pro", "openai/gpt-5.6-luna"].
 	ScarceSessionModels []string
 	// QuotaFallbackModels maps a model to its fallback model when its session
-	// quota is exhausted (QUOTA_FALLBACK_MODELS; comma-separated k=v pairs).
-	// Default: {"deepseek/deepseek-v4-flash": "mimo/mimo-v2.5"}.
+	// quota is exhausted or unentitled (QUOTA_FALLBACK_MODELS; comma-separated k=v pairs).
+	// Default: {"deepseek/deepseek-v4-flash": "mimo/mimo-v2.5", "z-ai/glm-5.2": "deepseek/deepseek-v4-flash"}.
 	QuotaFallbackModels map[string]string
 	// AdoptCLISession, when enabled (ADOPT_CLI_SESSION=false default),
 	// makes the proxy behave like the official CLI for a single account:
@@ -377,11 +377,12 @@ var defaultModelAliases = map[string]string{
 }
 
 // defaultFallbackModels returns the FALLBACK_MODEL defaults (issue #100):
-// the premium free-catalog rows fall back to the always-available flash
+// the daily premium free-catalog rows fall back to the always-available flash
 // model once their queue wait passes FALLBACK_AFTER_MS — mirrors the CLI
 // hero pick once the premium daily pool runs out (reference
 // getRecommendedFreebuffModelId); muse targets deepseek-v4-pro per
-// MUSE_SPARK_FALLBACK_MODEL_ID. Trigger is queue-wait ≥ FALLBACK_AFTER_MS
+// MUSE_SPARK_FALLBACK_MODEL_ID. Referral-gated z-ai/glm-5.2 is held out (issue #183)
+// and handled via QUOTA_FALLBACK_MODELS. Trigger is queue-wait ≥ FALLBACK_AFTER_MS
 // only — never 429s.
 func defaultFallbackModels() map[string]string {
 	return map[string]string{
@@ -389,17 +390,18 @@ func defaultFallbackModels() map[string]string {
 		"openai/gpt-5.6-luna":             "deepseek/deepseek-v4-flash",
 		"minimax/minimax-m3":              "deepseek/deepseek-v4-flash",
 		"anthropic/claude-fable-5":        "deepseek/deepseek-v4-flash",
-		"z-ai/glm-5.2":                    "deepseek/deepseek-v4-flash",
 		"meta/muse-spark-1.2-contributor": "deepseek/deepseek-v4-pro",
 	}
 }
 
-// defaultQuotaFallbackModels returns the QUOTA_FALLBACK_MODELS defaults (issue #155):
-// when a model's session quota is exhausted (all 5 premium sessions used for flash),
-// the proxy falls back to the unlimited-session mimo-v2.5 model.
+// defaultQuotaFallbackModels returns the QUOTA_FALLBACK_MODELS defaults (issue #155, #183):
+// when a model's session quota is exhausted (all 5 premium sessions used for flash)
+// or unentitled (referral-only GLM 5.2 on accounts with 0 referral credits),
+// the proxy falls back to an available model (flash for GLM, mimo for flash).
 func defaultQuotaFallbackModels() map[string]string {
 	return map[string]string{
 		"deepseek/deepseek-v4-flash": "mimo/mimo-v2.5",
+		"z-ai/glm-5.2":               "deepseek/deepseek-v4-flash",
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -458,6 +458,9 @@ func TestQuotaFallbackModels(t *testing.T) {
 		if got := cfg.QuotaFallbackModels["deepseek/deepseek-v4-flash"]; got != "mimo/mimo-v2.5" {
 			t.Errorf("QuotaFallbackModels[flash] = %q, want mimo/mimo-v2.5", got)
 		}
+		if got := cfg.QuotaFallbackModels["z-ai/glm-5.2"]; got != "deepseek/deepseek-v4-flash" {
+			t.Errorf("QuotaFallbackModels[glm-5.2] = %q, want deepseek/deepseek-v4-flash", got)
+		}
 	})
 	t.Run("env override", func(t *testing.T) {
 		clearEnv(t)

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -415,7 +415,7 @@ func pageServer(t *testing.T, tokens int, page string, mut func(*config.Config),
 }
 
 // dashModel is the fallback-registry model the quota seeding chats use.
-const dashModel = "z-ai/glm-5.2"
+const dashModel = "deepseek/deepseek-v4-flash"
 
 // quotaPageServer builds a tokens page whose session admission carries the
 // mock-configured quota state (rateLimitsByModel entries, glmPromo block),
@@ -487,8 +487,8 @@ func TestTokensPageQuotaRows(t *testing.T) {
 					"streak":   3,
 				},
 			},
-			"deepseek/deepseek-v4-flash": map[string]any{
-				"model":       "deepseek/deepseek-v4-flash",
+			"anthropic/claude-fable-5": map[string]any{
+				"model":       "anthropic/claude-fable-5",
 				"limit":       100,
 				"recentCount": 80, // exactly at NearLimit threshold
 				"period":      "pacific_day",

--- a/internal/pool/bridge.go
+++ b/internal/pool/bridge.go
@@ -262,5 +262,10 @@ func (p *Pool) ProbeToken(ctx context.Context, token int) (*upstream.SessionStat
 	if token < 0 || token >= len(*toks) {
 		return nil, fmt.Errorf("pool: token %d out of range", token)
 	}
-	return (*toks)[token].client.ProbeAccount(ctx)
+	tok := (*toks)[token]
+	st, err := tok.client.ProbeAccount(ctx)
+	if err == nil && st != nil {
+		tok.session.UpdateQuotaFromProbe(st)
+	}
+	return st, err
 }

--- a/internal/pool/glm_referral_test.go
+++ b/internal/pool/glm_referral_test.go
@@ -1,0 +1,198 @@
+// glm_referral_test.go — issue #183: referral-gated model (z-ai/glm-5.2)
+// entitlement gating and quota fallback. Only tokens with verified GLM
+// entitlement are permitted to admit GLM 5.2 sessions, preventing unentitled
+// accounts from getting permanently hard-banned by upstream fraud checks.
+package pool
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"freebuff-proxy/internal/config"
+	"freebuff-proxy/internal/testutil"
+	"freebuff-proxy/internal/upstream"
+)
+
+// TestUnentitledPoolTokenGlmQuotaFallback verifies that requesting z-ai/glm-5.2
+// on a pool where no token holds referral entitlement automatically quota-falls
+// back to deepseek/deepseek-v4-flash without sending any upstream session create
+// for GLM 5.2 (which upstream punishes with 403 account_banned).
+func TestUnentitledPoolTokenGlmQuotaFallback(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+
+	var glmCreates atomic.Int32
+	var flashCreates atomic.Int32
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		model := r.Header.Get("x-freebuff-model")
+		if model == "z-ai/glm-5.2" {
+			glmCreates.Add(1)
+		} else if model == "deepseek/deepseek-v4-flash" {
+			flashCreates.Add(1)
+		}
+		expiresAt := time.Now().Add(30 * time.Minute).UTC().Format("2006-01-02T15:04:05.000Z07:00")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-flash-123","model":"deepseek/deepseek-v4-flash","expiresAt":"`+expiresAt+`"}`)
+	}
+
+	p := newTestPool(t, mock)
+
+	lease, err := p.Acquire(context.Background(), "z-ai/glm-5.2")
+	if err != nil {
+		t.Fatalf("Acquire(z-ai/glm-5.2) failed: %v", err)
+	}
+	defer p.LeaseRelease(lease)
+
+	if glmCreates.Load() != 0 {
+		t.Errorf("glmCreates = %d, want 0 (unentitled token must never send session create for GLM 5.2)", glmCreates.Load())
+	}
+	if flashCreates.Load() == 0 {
+		t.Error("flashCreates = 0, want fallback session created for deepseek/deepseek-v4-flash")
+	}
+	if lease.Model != "deepseek/deepseek-v4-flash" {
+		t.Errorf("lease.Model = %q, want deepseek/deepseek-v4-flash", lease.Model)
+	}
+	if lease.FallbackReason != "quota_exhausted" {
+		t.Errorf("lease.FallbackReason = %q, want quota_exhausted", lease.FallbackReason)
+	}
+}
+
+// TestUnentitledPoolTokenGlmRefusalWithoutFallback verifies that when
+// QUOTA_FALLBACK_MODELS is explicitly empty, an unentitled request for
+// z-ai/glm-5.2 returns a clean 429 rate limit error without sending any
+// upstream session create.
+func TestUnentitledPoolTokenGlmRefusalWithoutFallback(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+
+	var glmCreates atomic.Int32
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-freebuff-model") == "z-ai/glm-5.2" {
+			glmCreates.Add(1)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-1"}`)
+	}
+
+	p := newTestPoolCfg(t, func(c *config.Config) {
+		c.QuotaFallbackModels = map[string]string{} // disable quota fallback
+	}, mock)
+
+	_, err := p.Acquire(context.Background(), "z-ai/glm-5.2")
+	if err == nil {
+		t.Fatal("Acquire(z-ai/glm-5.2) succeeded, want 429 rate-limit error")
+	}
+	var rle *upstream.RateLimitError
+	if !errors.As(err, &rle) {
+		t.Fatalf("err = %v, want *upstream.RateLimitError", err)
+	}
+	if !strings.Contains(rle.Body, "referral entitlement required") && !strings.Contains(rle.Body, "no referral quota") {
+		t.Errorf("rle.Body = %q, want referral entitlement notice", rle.Body)
+	}
+	if glmCreates.Load() != 0 {
+		t.Errorf("glmCreates = %d, want 0", glmCreates.Load())
+	}
+}
+
+// TestEntitledPoolTokenWithGlmPromo verifies that a token with an active
+// GlmPromo block is permitted to open a z-ai/glm-5.2 session without falling back.
+func TestEntitledPoolTokenWithGlmPromo(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+
+	var glmCreates atomic.Int32
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-freebuff-model") == "z-ai/glm-5.2" {
+			glmCreates.Add(1)
+		}
+		expiresAt := time.Now().Add(30 * time.Minute).UTC().Format("2006-01-02T15:04:05.000Z07:00")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-glm-123","model":"z-ai/glm-5.2","expiresAt":"`+expiresAt+`","glmPromo":{"dailySessions":2,"endsAt":"2099-01-01T00:00:00Z"}}`)
+	}
+
+	p := newTestPool(t, mock)
+
+	// Seed token 0 with active GlmPromo
+	toks := p.toks.Load()
+	(*toks)[0].session.Invalidate()
+	// Run a probe that populates GlmPromo
+	mock.GlmPromo = map[string]any{
+		"dailySessions": 2,
+		"endsAt":        "2099-01-01T00:00:00Z",
+	}
+	_, _ = p.ProbeToken(context.Background(), 0)
+
+	lease, err := p.Acquire(context.Background(), "z-ai/glm-5.2")
+	if err != nil {
+		t.Fatalf("Acquire(z-ai/glm-5.2) failed: %v", err)
+	}
+	defer p.LeaseRelease(lease)
+
+	if lease.Model != "z-ai/glm-5.2" {
+		t.Errorf("lease.Model = %q, want z-ai/glm-5.2", lease.Model)
+	}
+	if lease.FallbackReason != "" {
+		t.Errorf("lease.FallbackReason = %q, want empty (no fallback)", lease.FallbackReason)
+	}
+	if glmCreates.Load() == 0 {
+		t.Error("glmCreates = 0, want GLM 5.2 session create for entitled token")
+	}
+}
+
+// TestBridgeUnentitledGlmFallback verifies that in bridge mode an unentitled
+// client token falls back to deepseek/deepseek-v4-flash via QuotaFallbackModels
+// without attempting an unentitled upstream GLM create.
+func TestBridgeUnentitledGlmFallback(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+
+	var glmCreates atomic.Int32
+	var flashCreates atomic.Int32
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		model := r.Header.Get("x-freebuff-model")
+		if model == "z-ai/glm-5.2" {
+			glmCreates.Add(1)
+		} else if model == "deepseek/deepseek-v4-flash" {
+			flashCreates.Add(1)
+		}
+		expiresAt := time.Now().Add(30 * time.Minute).UTC().Format("2006-01-02T15:04:05.000Z07:00")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-bridge-flash","model":"deepseek/deepseek-v4-flash","expiresAt":"`+expiresAt+`"}`)
+	}
+
+	p := newBridgePool(t, mock)
+	cfg := *p.cfg.Load()
+	cfg.QuotaFallbackModels = map[string]string{
+		"z-ai/glm-5.2": "deepseek/deepseek-v4-flash",
+	}
+	p.SetConfig(&cfg)
+
+	lease, err := p.AcquireBridge(context.Background(), "user-bridge-token", "z-ai/glm-5.2")
+	if err != nil {
+		t.Fatalf("AcquireBridge failed: %v", err)
+	}
+	defer p.LeaseRelease(lease)
+
+	if glmCreates.Load() != 0 {
+		t.Errorf("glmCreates = %d, want 0", glmCreates.Load())
+	}
+	if flashCreates.Load() == 0 {
+		t.Error("flashCreates = 0, want fallback session create for flash")
+	}
+	if lease.Model != "deepseek/deepseek-v4-flash" {
+		t.Errorf("lease.Model = %q, want deepseek/deepseek-v4-flash", lease.Model)
+	}
+	if lease.FallbackReason != "quota_exhausted" {
+		t.Errorf("lease.FallbackReason = %q, want quota_exhausted", lease.FallbackReason)
+	}
+}

--- a/internal/pool/glm_referral_test.go
+++ b/internal/pool/glm_referral_test.go
@@ -30,10 +30,10 @@ func TestUnentitledPoolTokenGlmQuotaFallback(t *testing.T) {
 	var glmCreates atomic.Int32
 	var flashCreates atomic.Int32
 	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
-		model := r.Header.Get("x-freebuff-model")
-		if model == "z-ai/glm-5.2" {
+		switch r.Header.Get("x-freebuff-model") {
+		case "z-ai/glm-5.2":
 			glmCreates.Add(1)
-		} else if model == "deepseek/deepseek-v4-flash" {
+		case "deepseek/deepseek-v4-flash":
 			flashCreates.Add(1)
 		}
 		expiresAt := time.Now().Add(30 * time.Minute).UTC().Format("2006-01-02T15:04:05.000Z07:00")
@@ -158,10 +158,10 @@ func TestBridgeUnentitledGlmFallback(t *testing.T) {
 	var glmCreates atomic.Int32
 	var flashCreates atomic.Int32
 	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
-		model := r.Header.Get("x-freebuff-model")
-		if model == "z-ai/glm-5.2" {
+		switch r.Header.Get("x-freebuff-model") {
+		case "z-ai/glm-5.2":
 			glmCreates.Add(1)
-		} else if model == "deepseek/deepseek-v4-flash" {
+		case "deepseek/deepseek-v4-flash":
 			flashCreates.Add(1)
 		}
 		expiresAt := time.Now().Add(30 * time.Minute).UTC().Format("2006-01-02T15:04:05.000Z07:00")

--- a/internal/pool/pool_scarce_test.go
+++ b/internal/pool/pool_scarce_test.go
@@ -19,7 +19,7 @@ import (
 
 // TestQuotaCooldownIsolationAcrossModels pins issue #178 at the pool level:
 // a token whose remembered cooldown is a quota exhaustion for one model is
-// still eligible for a DIFFERENT model — the glm-5.2 daily cap must not
+// still eligible for a DIFFERENT model — the luna daily cap must not
 // block flash on the same token — while the capped model itself keeps
 // surfacing the remembered 429.
 func TestQuotaCooldownIsolationAcrossModels(t *testing.T) {
@@ -28,9 +28,9 @@ func TestQuotaCooldownIsolationAcrossModels(t *testing.T) {
 	p := newTestPool(t, mock)
 
 	// Seed token 1's cooldown exactly as an upstream quota-exhaustion 429
-	// for glm-5.2 lands: quota fields at/over the limit with a future reset.
+	// for gpt-5.6-luna lands: quota fields at/over the limit with a future reset.
 	rle := &upstream.RateLimitError{
-		Model:       "z-ai/glm-5.2",
+		Model:       "openai/gpt-5.6-luna",
 		Status:      "rate_limited",
 		RetryAfter:  time.Hour,
 		Limit:       2,
@@ -42,16 +42,16 @@ func TestQuotaCooldownIsolationAcrossModels(t *testing.T) {
 	p.CooldownTokenRateLimit(0, rle)
 
 	// The capped model itself is refused: the token is cooling down for it.
-	_, err := p.Acquire(context.Background(), "z-ai/glm-5.2")
+	_, err := p.Acquire(context.Background(), "openai/gpt-5.6-luna")
 	var got *upstream.RateLimitError
 	if !errors.As(err, &got) {
-		t.Fatalf("Acquire(z-ai/glm-5.2) on quota-capped token = %v, want 429", err)
+		t.Fatalf("Acquire(openai/gpt-5.6-luna) on quota-capped token = %v, want 429", err)
 	}
 
 	// A different model on the SAME token is not blocked by that cooldown.
 	lease, err := p.Acquire(context.Background(), "deepseek/deepseek-v4-flash")
 	if err != nil {
-		t.Fatalf("Acquire(flash) blocked by glm-5.2 quota cooldown: %v", err)
+		t.Fatalf("Acquire(flash) blocked by luna quota cooldown: %v", err)
 	}
 	if lease == nil {
 		t.Fatal("Acquire(flash) = nil lease")
@@ -60,7 +60,7 @@ func TestQuotaCooldownIsolationAcrossModels(t *testing.T) {
 }
 
 // TestAdmissionQuota429TagsModelAndIsolates pins issue #178 end-to-end: a
-// 429 quota-exhaustion on session CREATE for glm-5.2 whose body omits the
+// 429 quota-exhaustion on session CREATE for luna whose body omits the
 // model field is tagged with the requested model by the admission path,
 // cools the token per-model, and the same token still admits flash after.
 func TestAdmissionQuota429TagsModelAndIsolates(t *testing.T) {
@@ -70,11 +70,12 @@ func TestAdmissionQuota429TagsModelAndIsolates(t *testing.T) {
 	var creates atomic.Int32
 	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && creates.Add(1) == 1 {
-			// First create (glm-5.2): quota-exhausted 429 with NO model
+			// First create (gpt-5.6-luna): quota-exhausted 429 with NO model
 			// field — the proxy must tag the requested model itself.
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(429)
-			_, _ = io.WriteString(w, `{"status":"rate_limited","limit":2,"recentCount":2,"period":"pacific_day","resetAt":"2026-08-25T07:00:00.000Z","retryAfterMs":60000}`)
+			_, _ = io.WriteString(w, `{"status":"rate_limited","limit":2,"recentCount":2,"period":"pacific_day","resetAt":"`+
+				time.Now().Add(time.Hour).UTC().Format("2006-01-02T15:04:05.000Z07:00")+`","retryAfterMs":3600000}`)
 			return
 		}
 		// Subsequent creates (flash) and probes/polls: active.
@@ -83,24 +84,25 @@ func TestAdmissionQuota429TagsModelAndIsolates(t *testing.T) {
 		w.WriteHeader(200)
 		_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-abc-123","expiresAt":"`+expiresAt+`"}`)
 	}
+
 	p := newTestPool(t, mock)
 
-	_, err := p.Acquire(context.Background(), "z-ai/glm-5.2")
+	_, err := p.Acquire(context.Background(), "openai/gpt-5.6-luna")
 	var rle *upstream.RateLimitError
 	if !errors.As(err, &rle) {
-		t.Fatalf("Acquire(z-ai/glm-5.2) = %v, want 429", err)
+		t.Fatalf("Acquire(openai/gpt-5.6-luna) = %v, want 429", err)
 	}
-	if rle.Model != "z-ai/glm-5.2" {
-		t.Errorf("RLE.Model = %q, want %q (tagged from the requested model)", rle.Model, "z-ai/glm-5.2")
+	if rle.Model != "openai/gpt-5.6-luna" {
+		t.Errorf("RLE.Model = %q, want %q (tagged from the requested model)", rle.Model, "openai/gpt-5.6-luna")
 	}
 	if !isQuotaExhaustedError(rle) {
 		t.Errorf("RLE not classified as quota exhaustion: %+v", rle)
 	}
 
-	// The same token now serves flash despite the glm-5.2 quota cooldown.
+	// The same token now serves flash despite the luna quota cooldown.
 	lease, err := p.Acquire(context.Background(), "deepseek/deepseek-v4-flash")
 	if err != nil {
-		t.Fatalf("Acquire(flash) blocked by glm-5.2 quota cooldown: %v", err)
+		t.Fatalf("Acquire(flash) blocked by luna quota cooldown: %v", err)
 	}
 	if lease == nil {
 		t.Fatal("Acquire(flash) = nil lease")

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -22,10 +22,10 @@ import (
 // glm-5.2 and claude-fable-5 are owned by their dedicated one-model agents.
 // Tests pin the offline (fallback) state.
 const (
-	modelA = "z-ai/glm-5.2"
-	modelB = "anthropic/claude-fable-5"
-	agentA = "base2-free-glm"
-	agentB = "base2-free-fable"
+	modelA = "anthropic/claude-fable-5"
+	modelB = "deepseek/deepseek-v4-flash"
+	agentA = "base2-free-fable"
+	agentB = "base2-free-deepseek-flash"
 )
 
 // newTestPool wires one mock upstream per token through real clients and
@@ -45,6 +45,10 @@ func newTestPoolCfg(t *testing.T, mut func(*config.Config), mocks ...*testutil.M
 		SessionCallTimeout: 5 * time.Second,
 		RegistryRefresh:    6 * time.Hour,
 		UpstreamBaseURL:    "https://www.codebuff.com",
+		QuotaFallbackModels: map[string]string{
+			"deepseek/deepseek-v4-flash": "mimo/mimo-v2.5",
+			"z-ai/glm-5.2":               "deepseek/deepseek-v4-flash",
+		},
 	}
 	if mut != nil {
 		mut(cfg)

--- a/internal/pool/quota.go
+++ b/internal/pool/quota.go
@@ -6,15 +6,43 @@ import (
 	"freebuff-proxy/internal/upstream"
 )
 
+// ReferralGatedModel is the referral-earned model in the FreeBuff catalog
+// (issue #183, reference freebuff-models.ts:1327-1370). It is NOT part of the
+// daily free session pool and requires explicit referral quota or active promo.
+const ReferralGatedModel = "z-ai/glm-5.2"
+
+// isReferralGatedModel reports whether model is referral-only.
+func isReferralGatedModel(model string) bool {
+	return model == ReferralGatedModel
+}
+
 // quotaRemaining reports the token's session-quota state for model from the
-// last admission (issue #85): known reports whether the quota is known with
+// last admission (issue #85, #183): known reports whether the quota is known with
 // a positive remaining allowance; remaining is the positive delta; capped
-// reports RecentCount >= Limit with a future ResetAt (the token must be
-// skipped this pass — it cannot serve the model right now). Quotas with a
-// past/absent ResetAt are treated as fresh (the window rolled) and never
-// capped.
+// reports RecentCount >= Limit with a future ResetAt, or absence of referral
+// entitlement for referral-gated models (the token must be skipped this pass —
+// it cannot serve the model right now). Quotas with a past/absent ResetAt are
+// treated as fresh (the window rolled) and never capped.
 func quotaRemaining(tok *tokenEntry, model string) (known bool, remaining float64, capped bool) {
-	q, ok := tok.session.Snapshot().QuotaByModel[model]
+	snap := tok.session.Snapshot()
+	if isReferralGatedModel(model) {
+		if !snap.HasGlmEntitlement() {
+			// Token has no referral entitlement for GLM 5.2. Treat as capped
+			// so it is excluded from admission attempts (prevents 403 account_banned).
+			return false, 0, true
+		}
+		if q, ok := snap.QuotaByModel[model]; ok && q.Limit > 0 {
+			resetFuture := !q.ResetAt.IsZero() && q.ResetAt.After(time.Now())
+			if resetFuture && q.RecentCount >= q.Limit {
+				return false, 0, true
+			}
+			if q.RecentCount < q.Limit {
+				return true, q.Limit - q.RecentCount, false
+			}
+		}
+		return true, 1, false
+	}
+	q, ok := snap.QuotaByModel[model]
 	if !ok || q.Limit <= 0 {
 		return false, 0, false
 	}
@@ -31,13 +59,18 @@ func quotaRemaining(tok *tokenEntry, model string) (known bool, remaining float6
 }
 
 // quotaLimitError builds the 429 surfaced when token is excluded for the
-// model's exhausted session quota (issue #85): RetryAfter is the time until
+// model's exhausted session quota (issue #85, #183): RetryAfter is the time until
 // the window reset, mirroring the upstream RateLimitError contract.
 func quotaLimitError(tok *tokenEntry, model string) *upstream.RateLimitError {
-	q := tok.session.Snapshot().QuotaByModel[model]
+	snap := tok.session.Snapshot()
+	q := snap.QuotaByModel[model]
 	retryAfter := time.Duration(0)
 	if !q.ResetAt.IsZero() && q.ResetAt.After(time.Now()) {
 		retryAfter = time.Until(q.ResetAt)
+	}
+	body := "session quota exhausted for model"
+	if isReferralGatedModel(model) && !snap.HasGlmEntitlement() {
+		body = "referral entitlement required for " + model
 	}
 	return &upstream.RateLimitError{
 		Status:      "rate_limited",
@@ -46,7 +79,7 @@ func quotaLimitError(tok *tokenEntry, model string) *upstream.RateLimitError {
 		Limit:       q.Limit,
 		RecentCount: q.RecentCount,
 		ResetAt:     q.ResetAt,
-		Body:        "session quota exhausted for model",
+		Body:        body,
 	}
 }
 

--- a/internal/pool/scarce.go
+++ b/internal/pool/scarce.go
@@ -3,6 +3,7 @@ package pool
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"freebuff-proxy/internal/session"
@@ -88,7 +89,7 @@ func isQuotaExhaustedError(rle *upstream.RateLimitError) bool {
 	if rle.Limit > 0 && rle.RecentCount >= rle.Limit {
 		return true
 	}
-	if rle.Body == "session quota exhausted for model" {
+	if rle.Body == "session quota exhausted for model" || strings.Contains(rle.Body, "referral entitlement required") || strings.Contains(rle.Body, "no referral quota") {
 		return true
 	}
 	return false
@@ -106,7 +107,23 @@ func isDailyCapReset(rle *upstream.RateLimitError) bool {
 	return rle.Limit > 0 && rle.RecentCount >= rle.Limit
 }
 func bridgeQuotaRemaining(entry *bridgeEntry, model string) (known bool, remaining float64, capped bool) {
-	q, ok := entry.session.Snapshot().QuotaByModel[model]
+	snap := entry.session.Snapshot()
+	if isReferralGatedModel(model) {
+		if !snap.HasGlmEntitlement() {
+			return false, 0, true
+		}
+		if q, ok := snap.QuotaByModel[model]; ok && q.Limit > 0 {
+			resetFuture := !q.ResetAt.IsZero() && q.ResetAt.After(time.Now())
+			if resetFuture && q.RecentCount >= q.Limit {
+				return false, 0, true
+			}
+			if q.RecentCount < q.Limit {
+				return true, q.Limit - q.RecentCount, false
+			}
+		}
+		return true, 1, false
+	}
+	q, ok := snap.QuotaByModel[model]
 	if !ok || q.Limit <= 0 {
 		return false, 0, false
 	}
@@ -128,17 +145,23 @@ func bridgeQuotaCapped(entry *bridgeEntry, model string) bool {
 
 // bridgeQuotaLimitError builds the 429 RateLimitError for a quota-capped bridge entry.
 func bridgeQuotaLimitError(entry *bridgeEntry, model string) *upstream.RateLimitError {
-	q := entry.session.Snapshot().QuotaByModel[model]
+	snap := entry.session.Snapshot()
+	q := snap.QuotaByModel[model]
 	retryAfter := time.Duration(0)
 	if !q.ResetAt.IsZero() && q.ResetAt.After(time.Now()) {
 		retryAfter = time.Until(q.ResetAt)
 	}
+	body := "session quota exhausted for model"
+	if isReferralGatedModel(model) && !snap.HasGlmEntitlement() {
+		body = "referral entitlement required for " + model
+	}
 	return &upstream.RateLimitError{
 		Status:      "rate_limited",
+		Model:       model,
 		RetryAfter:  retryAfter,
 		Limit:       q.Limit,
 		RecentCount: q.RecentCount,
 		ResetAt:     q.ResetAt,
-		Body:        "session quota exhausted for model",
+		Body:        body,
 	}
 }

--- a/internal/server/anthropic_test.go
+++ b/internal/server/anthropic_test.go
@@ -15,7 +15,7 @@ import (
 	"freebuff-proxy/internal/testutil"
 )
 
-const testModelA = "z-ai/glm-5.2"
+const testModelA = "deepseek/deepseek-v4-flash"
 
 func testChunk(id string, created int64, payload string) string {
 	return fmt.Sprintf(`{"id":%q,"object":"chat.completion.chunk","created":%d,"model":%q,%s}`, id, created, testModelA, payload)

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -1174,7 +1174,7 @@ func TestDashboardConfigSaveAppliesModelAliases(t *testing.T) {
 	t.Cleanup(ts.Close)
 	cookie := authedCookie(t, ts)
 
-	resp := postConfig(t, ts.URL, cookie, "AUTH_TOKENS=tok-0\nMODEL_ALIASES=gpt-4o:"+modelA+"\n")
+	resp := postConfig(t, ts.URL, cookie, "AUTH_TOKENS=tok-0\nMODEL_ALIASES=gpt-4o:"+modelB+"\n")
 	body := bodyOf(t, resp)
 	if !strings.Contains(body, "Saved and reloaded") {
 		t.Fatalf("config save failed: %s", body)
@@ -1188,7 +1188,7 @@ func TestDashboardConfigSaveAppliesModelAliases(t *testing.T) {
 		t.Fatal("no chat requests recorded upstream")
 	}
 	last := mock.RecordedChatBodies[len(mock.RecordedChatBodies)-1]
-	if !strings.Contains(last, modelA) {
-		t.Errorf("upstream body = %s, want resolved model %s after config-save alias", last, modelA)
+	if !strings.Contains(last, modelB) {
+		t.Errorf("upstream body = %s, want resolved model %s after config-save alias", last, modelB)
 	}
 }

--- a/internal/server/fallback_transparency_test.go
+++ b/internal/server/fallback_transparency_test.go
@@ -132,12 +132,12 @@ func TestFallbackTransparencyQueueTimeout(t *testing.T) {
 	mock.EstimatedWaitMs = 20000                        // > FALLBACK_AFTER_MS (10s)
 	// The fallback model's upstream chat echoes the REQUESTED model: the
 	// relay must stamp the actually-served fallback model onto the chunks.
-	mock.ChatBody = chatSSE("z-ai/glm-5.2")
+	mock.ChatBody = chatSSE("deepseek/deepseek-v4-pro")
 	srv, _ := newTestServerCfg(t, nil, func(c *config.Config) {
 		c.FallbackAfter = 10 * time.Second
-		c.FallbackModels = map[string]string{"z-ai/glm-5.2": "deepseek/deepseek-v4-flash"}
+		c.FallbackModels = map[string]string{"deepseek/deepseek-v4-pro": "deepseek/deepseek-v4-flash"}
 	}, mock)
-	body := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	body := `{"model":"deepseek/deepseek-v4-pro","messages":[{"role":"user","content":"hi"}],"stream":true}`
 	resp, data := doJSON(t, http.MethodPost, srv.URL+"/v1/chat/completions", []byte(body), nil)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (fallback served): %s", resp.StatusCode, data)
@@ -169,10 +169,24 @@ func quotaExhaustionMock(t *testing.T) *testutil.MockUpstream {
 	t.Cleanup(mock.Close)
 	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"status":"none"}`)
+			return
+		}
 		if r.Method == http.MethodPost {
 			switch r.Header.Get("x-freebuff-model") {
-			case modelA:
-				// Session quota exhausted for the requested model.
+			case "deepseek/deepseek-v4-flash":
+				// The fallback model admits fine.
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, fmt.Sprintf(`{
+					"status": "active",
+					"instanceId": "inst-fallback",
+					"model": %q,
+					"expiresAt": %q
+				}`, "deepseek/deepseek-v4-flash", time.Now().Add(time.Hour).Format(time.RFC3339)))
+			default:
+				// Requested model is quota exhausted.
 				w.WriteHeader(http.StatusTooManyRequests)
 				_, _ = io.WriteString(w, fmt.Sprintf(`{
 					"status": "rate_limited",
@@ -182,22 +196,12 @@ func quotaExhaustionMock(t *testing.T) *testutil.MockUpstream {
 					"period": "pacific_day",
 					"resetAt": %q,
 					"retryAfterMs": 3600000
-				}`, modelA, time.Now().Add(time.Hour).Format(time.RFC3339)))
-			default:
-				// The fallback model admits fine.
-				w.WriteHeader(http.StatusOK)
-				_, _ = io.WriteString(w, fmt.Sprintf(`{
-					"status": "active",
-					"instanceId": "inst-fallback",
-					"model": %q,
-					"expiresAt": %q
 				}`, r.Header.Get("x-freebuff-model"), time.Now().Add(time.Hour).Format(time.RFC3339)))
 			}
 			return
 		}
 		http.NotFound(w, r)
 	}
-	// Upstream chat for the fallback model echoes the REQUESTED model: the
 	// relay must stamp the served fallback model.
 	mock.ChatBody = chatSSE("z-ai/glm-5.2")
 	return mock
@@ -291,7 +295,7 @@ func TestFallbackTransparencyAnthropic(t *testing.T) {
 	srvDirect, _ := newTestServer(t, []string{"anthropic-key"}, direct)
 
 	// Direct streaming: message_start names the requested model.
-	reqBody := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	reqBody := `{"model":"` + modelA + `","messages":[{"role":"user","content":"hi"}],"stream":true}`
 	resp, data := doJSON(t, http.MethodPost, srvDirect.URL+"/v1/messages", []byte(reqBody),
 		map[string]string{"anthropic-api-key": "anthropic-key", "anthropic-version": "2023-06-01"})
 	if resp.StatusCode != http.StatusOK {
@@ -317,7 +321,7 @@ func TestFallbackTransparencyAnthropic(t *testing.T) {
 	}
 
 	// Direct non-streaming: message object model names the served model.
-	reqBodyNS := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":false}`
+	reqBodyNS := `{"model":"` + modelA + `","messages":[{"role":"user","content":"hi"}],"stream":false}`
 	respNS, dataNS := doJSON(t, http.MethodPost, srvDirect.URL+"/v1/messages", []byte(reqBodyNS),
 		map[string]string{"anthropic-api-key": "anthropic-key", "anthropic-version": "2023-06-01"})
 	if respNS.StatusCode != http.StatusOK {
@@ -338,8 +342,8 @@ func TestFallbackTransparencyAnthropic(t *testing.T) {
 	srvFB, _ := newTestServerCfg(t, []string{"anthropic-key"}, func(c *config.Config) {
 		c.QuotaFallbackModels = map[string]string{"z-ai/glm-5.2": "deepseek/deepseek-v4-flash"}
 	}, fb)
-
-	respFB, dataFB := doJSON(t, http.MethodPost, srvFB.URL+"/v1/messages", []byte(reqBody),
+	reqBodyGlm := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	respFB, dataFB := doJSON(t, http.MethodPost, srvFB.URL+"/v1/messages", []byte(reqBodyGlm),
 		map[string]string{"anthropic-api-key": "anthropic-key", "anthropic-version": "2023-06-01"})
 	if respFB.StatusCode != http.StatusOK {
 		t.Fatalf("fallback stream status = %d, want 200: %s", respFB.StatusCode, dataFB)
@@ -364,7 +368,8 @@ func TestFallbackTransparencyAnthropic(t *testing.T) {
 	}
 
 	// Non-streaming fallback: message object model names the served model.
-	respFBNS, dataFBNS := doJSON(t, http.MethodPost, srvFB.URL+"/v1/messages", []byte(reqBodyNS),
+	reqBodyGlmNS := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":false}`
+	respFBNS, dataFBNS := doJSON(t, http.MethodPost, srvFB.URL+"/v1/messages", []byte(reqBodyGlmNS),
 		map[string]string{"anthropic-api-key": "anthropic-key", "anthropic-version": "2023-06-01"})
 	if respFBNS.StatusCode != http.StatusOK {
 		t.Fatalf("fallback non-stream status = %d, want 200: %s", respFBNS.StatusCode, dataFBNS)

--- a/internal/server/harness_compatibility_test.go
+++ b/internal/server/harness_compatibility_test.go
@@ -40,7 +40,7 @@ func TestAnthropicClaudeCodeStreamingSequence(t *testing.T) {
 	ts, _ := newTestServerCfg(t, []string{"anthropic-test-key"}, nil, mock)
 
 	reqBody := `{
-		"model": "z-ai/glm-5.2",
+		"model": "deepseek/deepseek-v4-flash",
 		"messages": [
 			{"role": "user", "content": "List files in directory"}
 		],
@@ -179,7 +179,7 @@ func TestAnthropicNonStreamingMessage(t *testing.T) {
 	ts, _ := newTestServer(t, nil, mock)
 
 	reqBody := `{
-		"model": "z-ai/glm-5.2",
+		"model": "deepseek/deepseek-v4-flash",
 		"messages": [{"role": "user", "content": "Read foo.go"}],
 		"stream": false
 	}`
@@ -255,8 +255,7 @@ func TestOpenAIMultiTurnSchemaCompliance(t *testing.T) {
 	ts, _ := newTestServer(t, nil, mock)
 
 	reqBody := `{
-		"model": "z-ai/glm-5.2",
-		"messages": [{"role": "user", "content": "Hi"}],
+		"model": "deepseek/deepseek-v4-flash",
 		"functions": [{"name": "get_weather", "parameters": {"type": "object", "properties": {"loc": {"type": "string"}}}}],
 		"function_call": "auto"
 	}`
@@ -336,7 +335,7 @@ func TestAnthropicErrorEnvelopeStructure(t *testing.T) {
 	ts, _ := newTestServer(t, nil, mock)
 
 	// Empty messages array -> 400 with Anthropic error envelope
-	reqBody := `{"model": "z-ai/glm-5.2", "messages": []}`
+	reqBody := `{"model": "deepseek/deepseek-v4-flash", "messages": []}`
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/messages", strings.NewReader(reqBody))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
@@ -389,7 +388,7 @@ func TestBridgeModeAnthropicAndOpenAI(t *testing.T) {
 	ts, _ := newBridgeTestServer(t, mock)
 
 	// 1. Anthropic endpoint with anthropic-api-key
-	req1, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/messages", strings.NewReader(`{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}]}`))
+	req1, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/messages", strings.NewReader(`{"model":"deepseek/deepseek-v4-flash","messages":[{"role":"user","content":"hi"}]}`))
 	req1.Header.Set("Content-Type", "application/json")
 	req1.Header.Set("anthropic-api-key", "token-anthropic-key")
 	resp1, err := http.DefaultClient.Do(req1)
@@ -403,7 +402,7 @@ func TestBridgeModeAnthropicAndOpenAI(t *testing.T) {
 	}
 
 	// 2. Anthropic endpoint with x-api-key
-	req2, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/messages", strings.NewReader(`{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}]}`))
+	req2, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/messages", strings.NewReader(`{"model":"deepseek/deepseek-v4-flash","messages":[{"role":"user","content":"hi"}]}`))
 	req2.Header.Set("Content-Type", "application/json")
 	req2.Header.Set("x-api-key", "token-x-key")
 	resp2, err := http.DefaultClient.Do(req2)
@@ -417,7 +416,7 @@ func TestBridgeModeAnthropicAndOpenAI(t *testing.T) {
 	}
 
 	// 3. OpenAI endpoint with Authorization: Bearer
-	req3, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/chat/completions", strings.NewReader(`{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}]}`))
+	req3, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/chat/completions", strings.NewReader(`{"model":"deepseek/deepseek-v4-flash","messages":[{"role":"user","content":"hi"}]}`))
 	req3.Header.Set("Content-Type", "application/json")
 	req3.Header.Set("Authorization", "Bearer token-bearer-key")
 	resp3, err := http.DefaultClient.Do(req3)
@@ -431,7 +430,7 @@ func TestBridgeModeAnthropicAndOpenAI(t *testing.T) {
 	}
 
 	// 4. Missing token -> 401
-	req4, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/messages", strings.NewReader(`{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}]}`))
+	req4, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/messages", strings.NewReader(`{"model":"deepseek/deepseek-v4-flash","messages":[{"role":"user","content":"hi"}]}`))
 	req4.Header.Set("Content-Type", "application/json")
 	resp4, err := http.DefaultClient.Do(req4)
 	if err != nil {
@@ -494,7 +493,7 @@ func TestAnthropicStreamEndTurnOnlyStopReason(t *testing.T) {
 	}
 	ts, _ := newTestServer(t, nil, mock)
 
-	reqBody := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	reqBody := `{"model":"deepseek/deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"stream":true}`
 	req, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/messages", strings.NewReader(reqBody))
 	if err != nil {
 		t.Fatal(err)
@@ -555,7 +554,7 @@ func TestAnthropicStreamThinkingClosedBeforeToolUse(t *testing.T) {
 	}
 	ts, _ := newTestServer(t, nil, mock)
 
-	reqBody := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":true,"thinking":{"type":"enabled","budget_tokens":1024}}`
+	reqBody := `{"model":"deepseek/deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"stream":true,"thinking":{"type":"enabled","budget_tokens":1024}}`
 	req, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/messages", strings.NewReader(reqBody))
 	if err != nil {
 		t.Fatal(err)
@@ -643,7 +642,7 @@ func TestAnthropicStreamReasoningAfterTextReopensThinking(t *testing.T) {
 	}
 	ts, _ := newTestServer(t, nil, mock)
 
-	reqBody := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	reqBody := `{"model":"deepseek/deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"stream":true}`
 	req, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/messages", strings.NewReader(reqBody))
 	if err != nil {
 		t.Fatal(err)
@@ -732,7 +731,7 @@ func TestAnthropicMessagesRateLimitErrorEnvelope(t *testing.T) {
 		c.RateLimitBurst = 2
 	}, mock)
 
-	body := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	body := `{"model":"deepseek/deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"stream":true}`
 	for i := range 2 {
 		resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/messages", []byte(body), nil)
 		if resp.StatusCode != http.StatusOK {
@@ -777,7 +776,7 @@ func TestAnthropicMessagesDecodeErrorEnvelope(t *testing.T) {
 	mock.ChatBody = "data: {not-json}\n\ndata: [DONE]\n\n"
 	ts, _ := newTestServer(t, nil, mock)
 
-	body := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":false}`
+	body := `{"model":"deepseek/deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"stream":false}`
 	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/messages", []byte(body), nil)
 	if resp.StatusCode != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502: %s", resp.StatusCode, truncate(string(data), 300))

--- a/internal/server/model_unavailable_test.go
+++ b/internal/server/model_unavailable_test.go
@@ -43,9 +43,9 @@ func TestModelUnavailableSkipMetric(t *testing.T) {
 		}
 		model := r.Header.Get("x-freebuff-model")
 		w.Header().Set("Content-Type", "application/json")
-		if model == modelA {
+		if model == modelB {
 			w.WriteHeader(http.StatusConflict)
-			_, _ = io.WriteString(w, `{"status":"model_unavailable","requestedModel":"`+modelA+`","availableHours":"9am ET-5pm PT every day"}`)
+			_, _ = io.WriteString(w, `{"status":"model_unavailable","requestedModel":"`+modelB+`","availableHours":"9am ET-5pm PT every day"}`)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
@@ -56,11 +56,11 @@ func TestModelUnavailableSkipMetric(t *testing.T) {
 	_, m0 := doJSON(t, http.MethodGet, ts.URL+"/metrics", nil, nil)
 	before := metricValue(t, string(m0), "freebuff_proxy_model_unavailable_skips_total")
 
-	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelB), nil)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("first chat status = %d, want 200: %s", resp.StatusCode, data)
 	}
-	resp, data = doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	resp, data = doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelB), nil)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("second chat status = %d, want 200: %s", resp.StatusCode, data)
 	}

--- a/internal/server/server_edge_test.go
+++ b/internal/server/server_edge_test.go
@@ -669,7 +669,7 @@ func truncate(s string, n int) string {
 func TestMetricsModelLockedTotal(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
-	const lockModel = "deepseek/deepseek-v4-flash"
+	lockModel := modelB
 	var mu sync.Mutex
 	bAttempts := 0
 	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
@@ -715,7 +715,7 @@ func TestMetricsModelLockedTotal(t *testing.T) {
 		t.Fatalf("metrics status = %d, want 200: %s", resp.StatusCode, truncate(string(data), 200))
 	}
 	body := string(data)
-	want := `freebuff_proxy_model_locked_total{token="1",from="z-ai/glm-5.2",to="deepseek/deepseek-v4-flash"} 1`
+	want := fmt.Sprintf(`freebuff_proxy_model_locked_total{token="1",from="%s",to="%s"} 1`, modelA, modelB)
 	if !strings.Contains(body, want) {
 		t.Errorf("metrics missing %s in:\n%s", want, body)
 	}

--- a/internal/server/server_models_test.go
+++ b/internal/server/server_models_test.go
@@ -384,7 +384,7 @@ func TestModelsAllowList(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	ts, _ := newTestServerCfg(t, nil, func(c *config.Config) {
-		c.ModelsAllow = []string{"deepseek/deepseek-v4-flash", modelA}
+		c.ModelsAllow = []string{"deepseek/deepseek-v4-flash", modelB}
 	}, mock)
 
 	resp, data := doJSON(t, http.MethodGet, ts.URL+"/v1/models", nil, nil)
@@ -401,12 +401,12 @@ func TestModelsAllowList(t *testing.T) {
 	}
 	seen := map[string]bool{}
 	for _, m := range out.Data {
-		if m.ID != "deepseek/deepseek-v4-flash" && m.ID != modelA {
+		if m.ID != "deepseek/deepseek-v4-flash" && m.ID != modelB {
 			t.Errorf("model %q listed outside MODELS_ALLOW", m.ID)
 		}
 		seen[m.ID] = true
 	}
-	if !seen["deepseek/deepseek-v4-flash"] || !seen[modelA] {
+	if !seen["deepseek/deepseek-v4-flash"] || !seen[modelB] {
 		t.Errorf("allowlisted models missing from /v1/models: %v", seen)
 	}
 	if len(out.Data) != 2 {
@@ -423,7 +423,7 @@ func TestModelsAllowRejectsChat(t *testing.T) {
 		c.ModelsAllow = []string{"deepseek/deepseek-v4-flash"}
 	}, mock)
 
-	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelB), nil)
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("chat status = %d, want 404: %s", resp.StatusCode, data)
 	}
@@ -454,11 +454,11 @@ func TestModelsAllowResolvedAlias(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	ts, _ := newTestServerCfg(t, nil, func(c *config.Config) {
-		c.ModelAliases = map[string]string{"glm-alias": modelA}
+		c.ModelAliases = map[string]string{"fable-alias": modelB}
 		c.ModelsAllow = []string{"deepseek/deepseek-v4-flash"}
 	}, mock)
 
-	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody("glm-alias"), nil)
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody("fable-alias"), nil)
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("chat (alias) status = %d, want 404: %s", resp.StatusCode, data)
 	}
@@ -656,7 +656,7 @@ func TestMetricsQuotaLines(t *testing.T) {
 		`freebuff_proxy_quota_recent{token="1",model="z-ai/glm-5.2",period="pacific_day"} 4`,
 		`freebuff_proxy_quota_limit{token="1",model="z-ai/glm-5.2",period="pacific_day"} 5`,
 		`freebuff_proxy_quota_remaining{token="1",model="z-ai/glm-5.2",period="pacific_day"} 1`,
-		`freebuff_proxy_session_remaining_seconds{token="1",model="z-ai/glm-5.2"}`,
+		fmt.Sprintf(`freebuff_proxy_session_remaining_seconds{token="1",model="%s"}`, modelA),
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("metrics missing %s in:\n%s", want, body)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -24,7 +24,8 @@ import (
 
 // modelA must map to an agent with EXCLUSIVE ownership in the registry
 // fallback map (see internal/registry/registry_test.go expectedFallback).
-const modelA = "z-ai/glm-5.2"
+const modelA = "deepseek/deepseek-v4-flash"
+const modelB = "anthropic/claude-fable-5"
 
 // newTestServer wires the real stack - mock upstream per token, real
 // clients/session managers, fallback registry, pool, and the server - behind
@@ -47,6 +48,10 @@ func newTestServerCfg(t *testing.T, apiKeys []string, mut func(*config.Config), 
 		APIKeys:            apiKeys,
 		LogAccess:          true,
 		DashboardEnabled:   true,
+		QuotaFallbackModels: map[string]string{
+			"deepseek/deepseek-v4-flash": "mimo/mimo-v2.5",
+			"z-ai/glm-5.2":               "deepseek/deepseek-v4-flash",
+		},
 	}
 	if mut != nil {
 		mut(cfg)
@@ -161,6 +166,18 @@ func quotaMock(t *testing.T) *testutil.MockUpstream {
 	mock := testutil.NewMock()
 	t.Cleanup(mock.Close)
 	mock.RateLimitsByModel = map[string]any{
+		modelA: map[string]any{
+			"model":       modelA,
+			"limit":       5,
+			"recentCount": 4,
+			"period":      "pacific_day",
+			"resetAt":     "2026-08-16T07:00:00.000Z",
+			"entitlementBreakdown": map[string]any{
+				"base":     1,
+				"referral": 1,
+				"streak":   3,
+			},
+		},
 		"z-ai/glm-5.2": map[string]any{
 			"model":       "z-ai/glm-5.2",
 			"limit":       5,

--- a/internal/server/server_wave6_test.go
+++ b/internal/server/server_wave6_test.go
@@ -77,7 +77,7 @@ func TestPlaygroundChatStreams(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	srv := newServer(t, mock, nil)
-	body := `{"model":"z-ai/glm-5.2","prompt":"ping","stream":true}`
+	body := `{"model":"deepseek/deepseek-v4-flash","prompt":"ping","stream":true}`
 	req := httptest.NewRequest(http.MethodPost, "/admin/playground/chat", strings.NewReader(body))
 	req.Host = "127.0.0.1:3457"
 	req.RemoteAddr = "127.0.0.1:12345"
@@ -176,9 +176,9 @@ func TestChatFallbackAfterWaitingRoom(t *testing.T) {
 	mock.EstimatedWaitMs = 20000                        // > FALLBACK_AFTER_MS (10s)
 	srv := newServerCfg(t, mock, func(c *config.Config) {
 		c.FallbackAfter = 10 * time.Second
-		c.FallbackModels = map[string]string{"z-ai/glm-5.2": "deepseek/deepseek-v4-flash"}
+		c.FallbackModels = map[string]string{"deepseek/deepseek-v4-pro": "deepseek/deepseek-v4-flash"}
 	})
-	body := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	body := `{"model":"deepseek/deepseek-v4-pro","messages":[{"role":"user","content":"hi"}],"stream":true}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
 	req.Host = "127.0.0.1:3457"
 	rec := httptest.NewRecorder()
@@ -200,9 +200,9 @@ func TestChatNoFallbackBelowThreshold(t *testing.T) {
 	mock.EstimatedWaitMs = 1000 // < FALLBACK_AFTER_MS
 	srv := newServerCfg(t, mock, func(c *config.Config) {
 		c.FallbackAfter = 10 * time.Second
-		c.FallbackModels = map[string]string{"z-ai/glm-5.2": "deepseek/deepseek-v4-flash"}
+		c.FallbackModels = map[string]string{"deepseek/deepseek-v4-pro": "deepseek/deepseek-v4-flash"}
 	})
-	body := `{"model":"z-ai/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	body := `{"model":"deepseek/deepseek-v4-pro","messages":[{"role":"user","content":"hi"}],"stream":true}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
 	req.Host = "127.0.0.1:3457"
 	rec := httptest.NewRecorder()

--- a/internal/session/glm_guard_test.go
+++ b/internal/session/glm_guard_test.go
@@ -1,0 +1,125 @@
+// glm_guard_test.go — issue #183: pre-admission entitlement guard for
+// referral-gated z-ai/glm-5.2 model. The session manager probes unadmitted
+// accounts before sending POST /api/sessions/create with x-freebuff-model: z-ai/glm-5.2
+// so unentitled accounts are rejected locally rather than banned upstream.
+package session
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"freebuff-proxy/internal/testutil"
+	"freebuff-proxy/internal/upstream"
+)
+
+// TestEnsureSessionForModelGlmGuardUnentitled verifies that an account with no
+// referral credits is probed with a safe GET and rejected with 429 without ever
+// sending a POST create for GLM 5.2.
+func TestEnsureSessionForModelGlmGuardUnentitled(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+
+	var getProbes atomic.Int32
+	var postCreates atomic.Int32
+
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			getProbes.Add(1)
+			// Return account state with standard models but NO GLM entitlement
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status": "none",
+				"rateLimitsByModel": map[string]any{
+					"deepseek/deepseek-v4-flash": map[string]any{
+						"model":       "deepseek/deepseek-v4-flash",
+						"limit":       5,
+						"recentCount": 0,
+						"period":      "pacific_day",
+					},
+				},
+			})
+			return
+		}
+		if r.Method == http.MethodPost {
+			postCreates.Add(1)
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status":     "active",
+				"instanceId": "inst-glm-danger",
+				"model":      r.Header.Get("x-freebuff-model"),
+			})
+		}
+	}
+
+	mgr := newTestSession(t, mock)
+
+	_, err := mgr.EnsureSessionForModel(context.Background(), "z-ai/glm-5.2")
+	if err == nil {
+		t.Fatal("EnsureSessionForModel(z-ai/glm-5.2) succeeded, want 429 rate limit refusal")
+	}
+
+	var rle *upstream.RateLimitError
+	if !errors.As(err, &rle) {
+		t.Fatalf("err = %v, want *upstream.RateLimitError", err)
+	}
+	if rle.Model != "z-ai/glm-5.2" {
+		t.Errorf("rle.Model = %q, want z-ai/glm-5.2", rle.Model)
+	}
+
+	if getProbes.Load() == 0 {
+		t.Error("getProbes = 0, want zero-cost probe GET before admission")
+	}
+	if postCreates.Load() != 0 {
+		t.Errorf("postCreates = %d, want 0 (POST create must never be sent for unentitled GLM request)", postCreates.Load())
+	}
+}
+
+// TestEnsureSessionForModelGlmGuardEntitled verifies that an account whose
+// probe response reveals a live glmPromo is permitted to proceed with session
+// admission for GLM 5.2.
+func TestEnsureSessionForModelGlmGuardEntitled(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+
+	var getProbes atomic.Int32
+	var postCreates atomic.Int32
+
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			getProbes.Add(1)
+			// Return account state with active glmPromo
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status": "none",
+				"glmPromo": map[string]any{
+					"dailySessions": 2,
+					"endsAt":        "2099-01-01T00:00:00Z",
+				},
+			})
+			return
+		}
+		if r.Method == http.MethodPost {
+			postCreates.Add(1)
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status":     "active",
+				"instanceId": "inst-glm-success",
+				"model":      "z-ai/glm-5.2",
+				"expiresAt":  time.Now().Add(30 * time.Minute).Format(time.RFC3339),
+			})
+		}
+	}
+
+	mgr := newTestSession(t, mock)
+
+	instance, err := mgr.EnsureSessionForModel(context.Background(), "z-ai/glm-5.2")
+	if err != nil {
+		t.Fatalf("EnsureSessionForModel(z-ai/glm-5.2) failed: %v", err)
+	}
+	if instance != "inst-glm-success" {
+		t.Errorf("instance = %q, want inst-glm-success", instance)
+	}
+	if postCreates.Load() == 0 {
+		t.Error("postCreates = 0, want session create for entitled GLM request")
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -12,6 +12,7 @@ package session
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -512,12 +513,28 @@ type QuotaSnapshot struct {
 
 // Snapshot returns a best-effort view of the cached session state. All
 // fields may be zero when no session has been created yet. Added for
-// internal/pool snapshotting; no upstream calls are made.
 func (m *Manager) Snapshot() SessionSnapshot {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.state == nil {
-		return SessionSnapshot{}
+		var quota map[string]QuotaSnapshot
+		if len(m.savedQuota) > 0 {
+			quota = make(map[string]QuotaSnapshot, len(m.savedQuota))
+			for modelID, q := range m.savedQuota {
+				quota[modelID] = QuotaSnapshot{
+					Model:       q.Model,
+					Limit:       q.Limit,
+					RecentCount: q.RecentCount,
+					ResetAt:     q.ResetAt,
+					Period:      q.Period,
+					Entitlement: q.Entitlement,
+				}
+			}
+		}
+		return SessionSnapshot{
+			QuotaByModel: quota,
+			GlmPromo:     m.savedGlmPromo,
+		}
 	}
 	quota := make(map[string]QuotaSnapshot, len(m.state.quotaByModel))
 	for modelID, q := range m.state.quotaByModel {
@@ -551,6 +568,113 @@ func (m *Manager) Snapshot() SessionSnapshot {
 		QuotaByModel:       quota,
 		GlmPromo:           m.state.glmPromo,
 		Standing:           m.state.standing,
+	}
+}
+
+// HasGlmEntitlement reports whether the session snapshot holds an active
+// referral quota or valid unexpired promo for z-ai/glm-5.2 (issue #183).
+func (s SessionSnapshot) HasGlmEntitlement() bool {
+	if q, ok := s.QuotaByModel["z-ai/glm-5.2"]; ok && q.Limit > 0 {
+		if q.RecentCount < q.Limit {
+			return true
+		}
+		if !q.ResetAt.IsZero() && q.ResetAt.Before(time.Now()) {
+			return true
+		}
+	}
+	if s.GlmPromo != "" {
+		var gp struct {
+			DailySessions float64 `json:"dailySessions"`
+			EndsAt        string  `json:"endsAt"`
+		}
+		if err := json.Unmarshal([]byte(s.GlmPromo), &gp); err == nil && gp.DailySessions > 0 {
+			if gp.EndsAt == "" {
+				return true
+			}
+			if ends, err := time.Parse(time.RFC3339, gp.EndsAt); err == nil {
+				if ends.After(time.Now()) {
+					return true
+				}
+			} else {
+				return true
+			}
+		}
+	}
+	if s.Entitlement != nil {
+		if s.Entitlement["glm"] > 0 || s.Entitlement["z-ai/glm-5.2"] > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// HasGlmEntitlement reports whether the manager currently holds verified
+// referral entitlement for z-ai/glm-5.2 from active or saved quota/promo (issue #183).
+func (m *Manager) HasGlmEntitlement() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.hasGlmEntitlementLocked()
+}
+
+func (m *Manager) hasGlmEntitlementLocked() bool {
+	quota := m.savedQuota
+	promo := m.savedGlmPromo
+	if m.state != nil {
+		if m.state.quotaByModel != nil {
+			quota = m.state.quotaByModel
+		}
+		if m.state.glmPromo != "" {
+			promo = m.state.glmPromo
+		}
+	}
+	if q, ok := quota["z-ai/glm-5.2"]; ok && q.Limit > 0 {
+		if q.RecentCount < q.Limit {
+			return true
+		}
+		if !q.ResetAt.IsZero() && q.ResetAt.Before(time.Now()) {
+			return true
+		}
+	}
+	if promo != "" {
+		var gp struct {
+			DailySessions float64 `json:"dailySessions"`
+			EndsAt        string  `json:"endsAt"`
+		}
+		if err := json.Unmarshal([]byte(promo), &gp); err == nil && gp.DailySessions > 0 {
+			if gp.EndsAt == "" {
+				return true
+			}
+			if ends, err := time.Parse(time.RFC3339, gp.EndsAt); err == nil {
+				if ends.After(time.Now()) {
+					return true
+				}
+			} else {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// UpdateQuotaFromProbe records the quota map and glmPromo block from a zero-cost
+// session probe into the manager's saved state (issue #183).
+func (m *Manager) UpdateQuotaFromProbe(st *upstream.SessionState) {
+	if st == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if st.GlmPromo != "" {
+		m.savedGlmPromo = st.GlmPromo
+		if m.state != nil {
+			m.state.glmPromo = st.GlmPromo
+		}
+	}
+	if len(st.RateLimitsByModel) > 0 {
+		m.savedQuota = st.RateLimitsByModel
+		if m.state != nil {
+			m.state.quotaByModel = st.RateLimitsByModel
+		}
 	}
 }
 

--- a/internal/session/session_admission.go
+++ b/internal/session/session_admission.go
@@ -192,6 +192,41 @@ func (m *Manager) adoptOrCreate(ctx context.Context, requestedModel string) (*up
 // the cooldown per model — a quota cap on z-ai/glm-5.2 must not block
 // deepseek/deepseek-v4-flash on the same token.
 func (m *Manager) createSessionForModel(ctx context.Context, model string) (*upstream.SessionState, error) {
+	if model == "z-ai/glm-5.2" {
+		// Pre-admission guard (issue #183): z-ai/glm-5.2 is referral-only.
+		// If the token has never probed/admitted (or has no known GLM entitlement),
+		// probe first with a zero-cost GET /api/v1/freebuff/session to check
+		// whether the account holds referral quota or an active promo.
+		// If unentitled, fail fast before sending POST /api/sessions/create
+		// with x-freebuff-model: z-ai/glm-5.2 (which upstream punishes with 403 account_banned).
+		if !m.HasGlmEntitlement() {
+			if m.client != nil {
+				if probeState, err := m.client.ProbeAccount(ctx); err == nil && probeState != nil {
+					m.mu.Lock()
+					if probeState.GlmPromo != "" {
+						m.savedGlmPromo = probeState.GlmPromo
+						if m.state != nil {
+							m.state.glmPromo = probeState.GlmPromo
+						}
+					}
+					if len(probeState.RateLimitsByModel) > 0 {
+						m.savedQuota = probeState.RateLimitsByModel
+						if m.state != nil {
+							m.state.quotaByModel = probeState.RateLimitsByModel
+						}
+					}
+					m.mu.Unlock()
+				}
+			}
+			if !m.HasGlmEntitlement() {
+				return nil, &upstream.RateLimitError{
+					Status: "rate_limited",
+					Model:  model,
+					Body:   "token has no referral quota for " + model,
+				}
+			}
+		}
+	}
 	st, err := m.client.CreateSessionForModel(ctx, model)
 	if err != nil {
 		var rle *upstream.RateLimitError


### PR DESCRIPTION
## Summary

Fixes #183 by aligning `freebuff-proxy` with the official FreeBuff CLI referral mechanism: **only auth tokens that actually possess referral entitlement or active promo quota are permitted to open `z-ai/glm-5.2` sessions**.

## Context & Root Cause (Issue #183)

1. Upstream FreeBuff treats `z-ai/glm-5.2` (`base2-free-glm`) as strictly referral-gated (`FreebuffStreakRewardPool = 'glm'`).
2. When an account with 0 referral quota / no promo attempts session admission for `z-ai/glm-5.2`, upstream does **not** return a 429 quota limit; upstream fraud/entitlement checks classify the unentitled admission attempt as unauthorized abuse and immediately return:
   ```
   Turn execution failed provider_code=account_banned model=z-ai/glm-5.2 reason=auth_failed status=403 retryable=false
   ```
   This permanently hard-bans the token.
3. Previously, `defaultFallbackModels()` included `"z-ai/glm-5.2": "deepseek/deepseek-v4-flash"` which encouraged trying GLM first during queue wait, and `acquireOrder` did not check referral entitlement before attempting session creation.

## Changes

1. **Config Defaults (`internal/config/config.go`)**:
   - Removed `z-ai/glm-5.2` from default `FALLBACK_MODEL` (queue waiting-room fallback).
   - Added `z-ai/glm-5.2: deepseek/deepseek-v4-flash` to default `QUOTA_FALLBACK_MODELS`. Unentitled or quota-exhausted requests for GLM 5.2 now automatically and safely fall back to `deepseek/deepseek-v4-flash` without touching upstream `base2-free-glm`.

2. **Entitlement Tracking & Pool Gating (`internal/session`, `internal/pool`)**:
   - Added `HasGlmEntitlement()` method on `session.SessionSnapshot` and `session.Manager` to verify active referral quota (`QuotaByModel["z-ai/glm-5.2"] > 0`), valid unexpired promo (`GlmPromo`), or direct entitlement map.
   - Updated `quotaRemaining` and `bridgeQuotaRemaining` to treat tokens without GLM entitlement as capped for `z-ai/glm-5.2`.
   - In `acquireOrder`, unentitled tokens are excluded from candidate pools for `z-ai/glm-5.2`. If all tokens lack entitlement, the request falls back seamlessly via `QUOTA_FALLBACK_MODELS` with `x-freebuff-fallback: quota_exhausted`.

3. **Pre-Admission Guard in Session Manager (`internal/session/session_admission.go`)**:
   - Added a fail-safe check in `createSessionForModel("z-ai/glm-5.2")`: if the account is cold/unprobed, it sends a zero-cost `GET /api/v1/freebuff/session` probe first. If the probe confirms 0 referral entitlement, it fails fast with 429 locally before ever sending `POST /api/sessions/create` with `x-freebuff-model: z-ai/glm-5.2`.

4. **Tests**:
   - Added `internal/pool/glm_referral_test.go` covering unentitled pool quota fallback, refusal without fallback, entitled token selection with `GlmPromo`, and bridge mode fallback.
   - Added `internal/session/glm_guard_test.go` covering pre-admission probe gating.
   - Updated server and dashboard test fixtures to use non-referral model `deepseek/deepseek-v4-flash` as default test model.

## Verification

- `env -u AUTH_TOKENS -u ADMIN_TOKEN go test -count=1 ./cmd/... ./internal/...` (20/20 packages pass)
- `gofmt -l cmd internal` (clean)
- `go vet ./cmd/... ./internal/...` (clean)
- `go build -tags dashboard ./cmd/... ./internal/...` (clean)
