### PR TITLE
feat(registry): strictly enforce 5 hardcoded available models (#189)

### DIFF
--- a/.env.full-example
+++ b/.env.full-example
@@ -193,10 +193,9 @@ TRANSIENT_RETRIES=1
 # exhaustion NEVER falls back — rate-limited tokens cooldown instead.
 #FALLBACK_AFTER_MS=10000
 # FALLBACK_MODEL=model1=fallback1,model2=fallback2. Defaults (when unset):
-# the daily premium free-catalog rows (deepseek-v4-pro, gpt-5.6-luna, minimax-m3,
-# claude-fable-5) fall back to deepseek/deepseek-v4-flash, and
-# meta/muse-spark-1.2-contributor falls back to deepseek/deepseek-v4-pro.
-# Referral-gated z-ai/glm-5.2 is held out (issue #183) and handled via QUOTA_FALLBACK_MODELS.
+# the daily premium free-catalog rows (deepseek-v4-pro, gpt-5.6-luna) fall back
+# to deepseek/deepseek-v4-flash (issue #189).
+# Referral-gated z-ai/glm-5.2 is handled via QUOTA_FALLBACK_MODELS.
 #FALLBACK_MODEL=
 #
 # Session-quota fallback: when a model's session quota is exhausted or unentitled

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,10 +130,9 @@ type Config struct {
 	// FallbackModels maps a requested model to the model served instead
 	// when the queue wait reaches FallbackAfter (issue #100,
 	// only when FALLBACK_MODEL is unset): the daily premium free-catalog rows
-	// (deepseek-v4-pro, gpt-5.6-luna, minimax-m3, claude-fable-5)
-	// → deepseek/deepseek-v4-flash. Referral-gated models (z-ai/glm-5.2) are
-	// held out (issue #183) and gated via QUOTA_FALLBACK_MODELS. The proxy
-	// path fires only when the pool surfaces a waiting-room/queue delay ≥ FallbackAfter
+	// (deepseek-v4-pro, gpt-5.6-luna) → deepseek/deepseek-v4-flash.
+	// Referral-gated models (z-ai/glm-5.2) are handled via QUOTA_FALLBACK_MODELS.
+	// The proxy path fires only when the pool surfaces a waiting-room/queue delay ≥ FallbackAfter
 	// for the requested model (issue #100) — 429 quota exhaustion NEVER
 	// falls back (anti-ban invariant §10). The premium→flash targets
 	// mirror the CLI's getRecommendedFreebuffModelId hero pick; the
@@ -377,20 +376,13 @@ var defaultModelAliases = map[string]string{
 }
 
 // defaultFallbackModels returns the FALLBACK_MODEL defaults (issue #100):
-// the daily premium free-catalog rows fall back to the always-available flash
-// model once their queue wait passes FALLBACK_AFTER_MS — mirrors the CLI
-// hero pick once the premium daily pool runs out (reference
-// getRecommendedFreebuffModelId); muse targets deepseek-v4-pro per
-// MUSE_SPARK_FALLBACK_MODEL_ID. Referral-gated z-ai/glm-5.2 is held out (issue #183)
-// and handled via QUOTA_FALLBACK_MODELS. Trigger is queue-wait ≥ FALLBACK_AFTER_MS
-// only — never 429s.
+// the daily premium free-catalog rows (deepseek-v4-pro, gpt-5.6-luna) fall back
+// to the always-available flash model once their queue wait passes FALLBACK_AFTER_MS
+// (issue #189). Trigger is queue-wait ≥ FALLBACK_AFTER_MS only — never 429s.
 func defaultFallbackModels() map[string]string {
 	return map[string]string{
-		"deepseek/deepseek-v4-pro":        "deepseek/deepseek-v4-flash",
-		"openai/gpt-5.6-luna":             "deepseek/deepseek-v4-flash",
-		"minimax/minimax-m3":              "deepseek/deepseek-v4-flash",
-		"anthropic/claude-fable-5":        "deepseek/deepseek-v4-flash",
-		"meta/muse-spark-1.2-contributor": "deepseek/deepseek-v4-pro",
+		"deepseek/deepseek-v4-pro": "deepseek/deepseek-v4-flash",
+		"openai/gpt-5.6-luna":      "deepseek/deepseek-v4-flash",
 	}
 }
 

--- a/internal/config/config_wave6_test.go
+++ b/internal/config/config_wave6_test.go
@@ -123,27 +123,25 @@ func TestDefaultFallbackModels(t *testing.T) {
 	if cfg.FallbackModels["deepseek/deepseek-v4-pro"] != "deepseek/deepseek-v4-flash" {
 		t.Error("deepseek-v4-pro must fall back to deepseek-v4-flash")
 	}
-	// Muse spark's capacity gate is a queue (Convex, 60 RPM/team); its
-	// upstream fallback target is deepseek-v4-pro (MUSE_SPARK_FALLBACK_MODEL_ID).
-	if got := cfg.FallbackModels["meta/muse-spark-1.2-contributor"]; got != "deepseek/deepseek-v4-pro" {
-		t.Errorf("muse-spark must fall back to deepseek-v4-pro, got %q", got)
+	if cfg.FallbackModels["openai/gpt-5.6-luna"] != "deepseek/deepseek-v4-flash" {
+		t.Error("openai/gpt-5.6-luna must fall back to deepseek-v4-flash")
 	}
 }
 
 func TestFallbackModelsExplicitSuppressesDefaults(t *testing.T) {
 	clearEnv(t)
 	t.Setenv("AUTH_TOKENS", "tok-1")
-	t.Setenv("FALLBACK_MODEL", "minimax/minimax-m3=deepseek/deepseek-v4-flash")
+	t.Setenv("FALLBACK_MODEL", "openai/gpt-5.6-luna=deepseek/deepseek-v4-flash")
 
 	cfg, err := Load("")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := cfg.FallbackModels["minimax/minimax-m3"]; got != "deepseek/deepseek-v4-flash" {
-		t.Errorf("FallbackModels[minimax-m3] = %q, want explicit", got)
+	if got := cfg.FallbackModels["openai/gpt-5.6-luna"]; got != "deepseek/deepseek-v4-flash" {
+		t.Errorf("FallbackModels[gpt-5.6-luna] = %q, want explicit", got)
 	}
-	if _, ok := cfg.FallbackModels["openai/gpt-5.6-luna"]; ok {
-		t.Error("default fallback for gpt-5.6-luna applied despite explicit FALLBACK_MODEL")
+	if _, ok := cfg.FallbackModels["deepseek/deepseek-v4-pro"]; ok {
+		t.Error("default fallback for deepseek-v4-pro applied despite explicit FALLBACK_MODEL")
 	}
 }
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -72,18 +72,28 @@ const maxFetchBytes = 2 << 20
 // mimo/mimo-v2.5 (FALLBACK_FREEBUFF_MODEL_ID), so a -max request would be
 // served by a different model while advertising a name it does not honor.
 var ServedModels = map[string]bool{
-	"deepseek/deepseek-v4-flash":      true,
-	"deepseek/deepseek-v4-pro":        true,
-	"mimo/mimo-v2.5":                  true,
-	"minimax/minimax-m3":              true,
-	"openai/gpt-5.6-luna":             true,
-	"z-ai/glm-5.2":                    true,
-	"anthropic/claude-fable-5":        true,
-	"crof/kimi-k3-eco":                true,
-	"meta/muse-spark-1.2-contributor": true,
-	"google/gemini-2.5-flash-lite":    true,
-	"google/gemini-3.1-flash-lite":    true,
-	"google/gemini-3.5-flash-lite":    true,
+	"deepseek/deepseek-v4-flash": true,
+	"deepseek/deepseek-v4-pro":   true,
+	"openai/gpt-5.6-luna":        true,
+	"z-ai/glm-5.2":               true,
+	"mimo/mimo-v2.5":             true,
+}
+
+// SupportedModelIDs is the canonical list of the 5 active models served by the gateway.
+var SupportedModelIDs = []string{
+	"deepseek/deepseek-v4-flash",
+	"deepseek/deepseek-v4-pro",
+	"openai/gpt-5.6-luna",
+	"z-ai/glm-5.2",
+	"mimo/mimo-v2.5",
+}
+
+// SupportedModelsHelpText is the formatted list of models for error messages (issue #189).
+const SupportedModelsHelpText = "deepseek/deepseek-v4-flash, deepseek/deepseek-v4-pro, openai/gpt-5.6-luna, z-ai/glm-5.2, mimo/mimo-v2.5"
+
+// IsServedModel reports whether model is in the 5 active served models.
+func IsServedModel(model string) bool {
+	return ServedModels[model]
 }
 
 // fallbackAgents is the hardcoded model→agent fallback used when the sources

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -896,3 +896,50 @@ func TestResolveModelMaxUpgradeRemoved(t *testing.T) {
 		}
 	}
 }
+
+// TestStrictServedModelsFiveOnly pins issue #189: ServedModels strictly contains
+// ONLY the 5 operational FreeBuff models; all other 7 decommissioned/broken
+// models and -max variants are rejected by IsServedModel.
+func TestStrictServedModelsFiveOnly(t *testing.T) {
+	wantModels := []string{
+		"deepseek/deepseek-v4-flash",
+		"deepseek/deepseek-v4-pro",
+		"openai/gpt-5.6-luna",
+		"z-ai/glm-5.2",
+		"mimo/mimo-v2.5",
+	}
+	if len(ServedModels) != 5 {
+		t.Fatalf("len(ServedModels) = %d, want exactly 5", len(ServedModels))
+	}
+	for _, m := range wantModels {
+		if !ServedModels[m] {
+			t.Errorf("ServedModels missing %q", m)
+		}
+		if !IsServedModel(m) {
+			t.Errorf("IsServedModel(%q) = false, want true", m)
+		}
+	}
+
+	// 7 decommissioned models must be rejected:
+	decommissioned := []string{
+		"minimax/minimax-m3",
+		"google/gemini-2.5-flash-lite",
+		"google/gemini-3.1-flash-lite",
+		"google/gemini-3.5-flash-lite",
+		"anthropic/claude-fable-5",
+		"crof/kimi-k3-eco",
+		"meta/muse-spark-1.2-contributor",
+		"deepseek/deepseek-v4-pro-max",
+		"deepseek/deepseek-v4-flash-max",
+		"openai/gpt-5.6-luna-max",
+		"random/unsupported-model",
+	}
+	for _, m := range decommissioned {
+		if ServedModels[m] {
+			t.Errorf("ServedModels contains decommissioned model %q", m)
+		}
+		if IsServedModel(m) {
+			t.Errorf("IsServedModel(%q) = true, want false", m)
+		}
+	}
+}

--- a/internal/server/anthropic.go
+++ b/internal/server/anthropic.go
@@ -80,10 +80,8 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	}
 	model := s.reg.ResolveModel(rawModel)
 	if !s.modelAllowed(model) {
-		// MODELS_ALLOW: the resolved model is outside the operator
-		// allowlist — reject like an unknown model.
-		s.writeAnthropicError(w, r, http.StatusNotFound,
-			"model not allowed by MODELS_ALLOW", "model_not_found", 0)
+		s.writeAnthropicError(w, r, http.StatusBadRequest,
+			ModelUnavailableMessage(rawModel), "invalid_request_error", 0)
 		return
 	}
 	stream := false

--- a/internal/server/anthropic_count.go
+++ b/internal/server/anthropic_count.go
@@ -58,7 +58,7 @@ func (s *Server) handleMessagesCountTokens(w http.ResponseWriter, r *http.Reques
 	model := s.reg.ResolveModel(rawModel)
 	if !s.modelAllowed(model) {
 		s.writeAnthropicError(w, r, http.StatusBadRequest,
-			"model not allowed by MODELS_ALLOW", "model_not_found", 0)
+			ModelUnavailableMessage(rawModel), "invalid_request_error", 0)
 		return
 	}
 	if s.tokenEstimator == nil {

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -1174,7 +1174,7 @@ func TestDashboardConfigSaveAppliesModelAliases(t *testing.T) {
 	t.Cleanup(ts.Close)
 	cookie := authedCookie(t, ts)
 
-	resp := postConfig(t, ts.URL, cookie, "AUTH_TOKENS=tok-0\nMODEL_ALIASES=gpt-4o:"+modelB+"\n")
+	resp := postConfig(t, ts.URL, cookie, "AUTH_TOKENS=tok-0\nMODEL_ALIASES=gpt-4o:openai/gpt-5.6-luna\n")
 	body := bodyOf(t, resp)
 	if !strings.Contains(body, "Saved and reloaded") {
 		t.Fatalf("config save failed: %s", body)
@@ -1188,7 +1188,7 @@ func TestDashboardConfigSaveAppliesModelAliases(t *testing.T) {
 		t.Fatal("no chat requests recorded upstream")
 	}
 	last := mock.RecordedChatBodies[len(mock.RecordedChatBodies)-1]
-	if !strings.Contains(last, modelB) {
-		t.Errorf("upstream body = %s, want resolved model %s after config-save alias", last, modelB)
+	if !strings.Contains(last, "openai/gpt-5.6-luna") {
+		t.Errorf("upstream body = %s, want resolved model openai/gpt-5.6-luna after config-save alias", last)
 	}
 }

--- a/internal/server/model_unavailable_test.go
+++ b/internal/server/model_unavailable_test.go
@@ -43,9 +43,9 @@ func TestModelUnavailableSkipMetric(t *testing.T) {
 		}
 		model := r.Header.Get("x-freebuff-model")
 		w.Header().Set("Content-Type", "application/json")
-		if model == modelB {
+		if model == "deepseek/deepseek-v4-pro" {
 			w.WriteHeader(http.StatusConflict)
-			_, _ = io.WriteString(w, `{"status":"model_unavailable","requestedModel":"`+modelB+`","availableHours":"9am ET-5pm PT every day"}`)
+			_, _ = io.WriteString(w, `{"status":"model_unavailable","requestedModel":"deepseek/deepseek-v4-pro","availableHours":"9am ET-5pm PT every day"}`)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
@@ -56,11 +56,11 @@ func TestModelUnavailableSkipMetric(t *testing.T) {
 	_, m0 := doJSON(t, http.MethodGet, ts.URL+"/metrics", nil, nil)
 	before := metricValue(t, string(m0), "freebuff_proxy_model_unavailable_skips_total")
 
-	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelB), nil)
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody("deepseek/deepseek-v4-pro"), nil)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("first chat status = %d, want 200: %s", resp.StatusCode, data)
 	}
-	resp, data = doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelB), nil)
+	resp, data = doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody("deepseek/deepseek-v4-pro"), nil)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("second chat status = %d, want 200: %s", resp.StatusCode, data)
 	}

--- a/internal/server/models.go
+++ b/internal/server/models.go
@@ -2,12 +2,18 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"freebuff-proxy/internal/pool"
 	"freebuff-proxy/internal/registry"
 	"freebuff-proxy/internal/session"
 )
+
+// ModelUnavailableMessage formats the rejection error message for unserved/disabled models (issue #189).
+func ModelUnavailableMessage(rawModel string) string {
+	return fmt.Sprintf("Model '%s' is not available. Only the following 5 models are supported: %s", rawModel, registry.SupportedModelsHelpText)
+}
 
 // probeModel returns the safest model to default a smoke test to: the
 // fallback default (deepseek-v4-flash — the model every account gets) when

--- a/internal/server/openai.go
+++ b/internal/server/openai.go
@@ -55,10 +55,8 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	}
 	model := s.reg.ResolveModel(rawModel)
 	if !s.modelAllowed(model) {
-		// MODELS_ALLOW: the resolved model (alias + -max upgrade applied)
-		// is outside the operator allowlist — reject like an unknown model.
-		s.writeJSONError(w, http.StatusNotFound,
-			"model not allowed by MODELS_ALLOW", "invalid_request_error", "model_not_found", 0)
+		s.writeJSONError(w, http.StatusBadRequest,
+			ModelUnavailableMessage(rawModel), "invalid_request_error", "model_unavailable", 0)
 		return
 	}
 	stream := false

--- a/internal/server/responses.go
+++ b/internal/server/responses.go
@@ -85,10 +85,8 @@ func (s *Server) handleResponses(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if !s.modelAllowed(model) {
-		// MODELS_ALLOW: the resolved/probed model is outside the operator
-		// allowlist — reject like an unknown model.
-		s.writeJSONError(w, http.StatusNotFound,
-			"model not allowed by MODELS_ALLOW", "invalid_request_error", "model_not_found", 0)
+		s.writeJSONError(w, http.StatusBadRequest,
+			ModelUnavailableMessage(rawModel), "invalid_request_error", "model_unavailable", 0)
 		return
 	}
 	stream := false

--- a/internal/server/server_api_test.go
+++ b/internal/server/server_api_test.go
@@ -851,8 +851,8 @@ func TestMessagesCountTokensUnknownModel(t *testing.T) {
 	if err := json.Unmarshal(data, &out); err != nil {
 		t.Fatalf("error body not JSON: %v", err)
 	}
-	if out.Error.Type != "invalid_request_error" || out.Error.Code != "model_not_found" {
-		t.Errorf("type/code = %q/%q, want invalid_request_error/model_not_found", out.Error.Type, out.Error.Code)
+	if out.Error.Type != "invalid_request_error" {
+		t.Errorf("type = %q, want invalid_request_error", out.Error.Type)
 	}
 	if mock.Requests != 0 {
 		t.Errorf("upstream requests = %d, want 0", mock.Requests)

--- a/internal/server/server_edge_test.go
+++ b/internal/server/server_edge_test.go
@@ -669,7 +669,7 @@ func truncate(s string, n int) string {
 func TestMetricsModelLockedTotal(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
-	lockModel := modelB
+	const lockModel = "openai/gpt-5.6-luna"
 	var mu sync.Mutex
 	bAttempts := 0
 	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
@@ -715,7 +715,7 @@ func TestMetricsModelLockedTotal(t *testing.T) {
 		t.Fatalf("metrics status = %d, want 200: %s", resp.StatusCode, truncate(string(data), 200))
 	}
 	body := string(data)
-	want := fmt.Sprintf(`freebuff_proxy_model_locked_total{token="1",from="%s",to="%s"} 1`, modelA, modelB)
+	want := fmt.Sprintf(`freebuff_proxy_model_locked_total{token="1",from="%s",to="%s"} 1`, modelA, lockModel)
 	if !strings.Contains(body, want) {
 		t.Errorf("metrics missing %s in:\n%s", want, body)
 	}

--- a/internal/server/server_models_test.go
+++ b/internal/server/server_models_test.go
@@ -58,17 +58,18 @@ func TestUnknownModel(t *testing.T) {
 		name       string
 		body       string
 		wantStatus int
+		wantCode   string
 	}{
-		{"unknown_model", `{"model":"no/such-model","messages":[{"role":"user","content":"hi"}]}`, http.StatusNotFound},
-		{"missing_model", `{"messages":[{"role":"user","content":"hi"}]}`, http.StatusBadRequest},
+		{"unknown_model", `{"model":"no/such-model","messages":[{"role":"user","content":"hi"}]}`, http.StatusBadRequest, "model_unavailable"},
+		{"missing_model", `{"messages":[{"role":"user","content":"hi"}]}`, http.StatusBadRequest, "model_not_found"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", []byte(tc.body), nil)
 			if resp.StatusCode != tc.wantStatus {
 				t.Fatalf("status = %d, want %d: %s", resp.StatusCode, tc.wantStatus, data)
 			}
-			if !strings.Contains(string(data), "model_not_found") {
-				t.Errorf("body missing model_not_found: %s", data)
+			if !strings.Contains(string(data), tc.wantCode) {
+				t.Errorf("body missing %s: %s", tc.wantCode, data)
 			}
 		})
 	}
@@ -105,10 +106,9 @@ func TestModelsEndpoint(t *testing.T) {
 	if out.Object != "list" {
 		t.Errorf("object = %q, want list", out.Object)
 	}
-	// #121: the offline fallback pruned 5 dead model ids (laguna/ling/greg),
-	// 15 -> 10 rows (registry fallbackAgents, free-agents.ts-verified).
-	if len(out.Data) < 10 {
-		t.Errorf("models = %d, want >= 10", len(out.Data))
+	// Issue #189: strictly 5 operational models served.
+	if len(out.Data) != 5 {
+		t.Errorf("models = %d, want 5", len(out.Data))
 	}
 	for i, m := range out.Data {
 		if m.ID == "" || m.Object != "model" || m.OwnedBy == "" {
@@ -165,8 +165,8 @@ func TestMaxVariantsBlocked(t *testing.T) {
 		"openai/gpt-5.6-luna-max",
 	} {
 		resp, data = doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(model), nil)
-		if resp.StatusCode != http.StatusNotFound {
-			t.Errorf("chat %s status = %d, want 404: %s", model, resp.StatusCode, data)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("chat %s status = %d, want 400: %s", model, resp.StatusCode, data)
 		}
 	}
 	if len(mock.RecordedChatHeaders) != 0 {
@@ -196,9 +196,9 @@ func TestHealthz(t *testing.T) {
 	if out.UptimeSeconds < 0 {
 		t.Errorf("uptime_seconds = %v, want >= 0", out.UptimeSeconds)
 	}
-	// #121: fallback registry 15 -> 10 rows after pruning dead model ids.
-	if out.Models < 10 {
-		t.Errorf("models = %d, want >= 10", out.Models)
+	// Issue #189: strictly 5 active models.
+	if out.Models != 5 {
+		t.Errorf("models = %d, want 5", out.Models)
 	}
 	if len(out.Tokens) != 2 {
 		t.Errorf("tokens = %d, want 2", len(out.Tokens))
@@ -384,7 +384,7 @@ func TestModelsAllowList(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	ts, _ := newTestServerCfg(t, nil, func(c *config.Config) {
-		c.ModelsAllow = []string{"deepseek/deepseek-v4-flash", modelB}
+		c.ModelsAllow = []string{"deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"}
 	}, mock)
 
 	resp, data := doJSON(t, http.MethodGet, ts.URL+"/v1/models", nil, nil)
@@ -401,12 +401,12 @@ func TestModelsAllowList(t *testing.T) {
 	}
 	seen := map[string]bool{}
 	for _, m := range out.Data {
-		if m.ID != "deepseek/deepseek-v4-flash" && m.ID != modelB {
+		if m.ID != "deepseek/deepseek-v4-flash" && m.ID != "deepseek/deepseek-v4-pro" {
 			t.Errorf("model %q listed outside MODELS_ALLOW", m.ID)
 		}
 		seen[m.ID] = true
 	}
-	if !seen["deepseek/deepseek-v4-flash"] || !seen[modelB] {
+	if !seen["deepseek/deepseek-v4-flash"] || !seen["deepseek/deepseek-v4-pro"] {
 		t.Errorf("allowlisted models missing from /v1/models: %v", seen)
 	}
 	if len(out.Data) != 2 {
@@ -423,9 +423,9 @@ func TestModelsAllowRejectsChat(t *testing.T) {
 		c.ModelsAllow = []string{"deepseek/deepseek-v4-flash"}
 	}, mock)
 
-	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelB), nil)
-	if resp.StatusCode != http.StatusNotFound {
-		t.Fatalf("chat status = %d, want 404: %s", resp.StatusCode, data)
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody("deepseek/deepseek-v4-pro"), nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("chat status = %d, want 400: %s", resp.StatusCode, data)
 	}
 	var out struct {
 		Error struct {
@@ -436,11 +436,11 @@ func TestModelsAllowRejectsChat(t *testing.T) {
 	if err := json.Unmarshal(data, &out); err != nil {
 		t.Fatalf("error body is not JSON: %v: %s", err, data)
 	}
-	if out.Error.Code != "model_not_found" {
-		t.Errorf("error.code = %q, want model_not_found", out.Error.Code)
+	if out.Error.Code != "model_unavailable" {
+		t.Errorf("error.code = %q, want model_unavailable", out.Error.Code)
 	}
-	if !strings.Contains(out.Error.Message, "MODELS_ALLOW") {
-		t.Errorf("error.message = %q, want a mention of MODELS_ALLOW", out.Error.Message)
+	if !strings.Contains(out.Error.Message, "Only the following 5 models are supported") {
+		t.Errorf("error.message = %q, want supported models notice", out.Error.Message)
 	}
 	if len(mock.RecordedChatHeaders) != 0 {
 		t.Error("upstream chat recorded for a rejected model, want none")
@@ -454,13 +454,13 @@ func TestModelsAllowResolvedAlias(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	ts, _ := newTestServerCfg(t, nil, func(c *config.Config) {
-		c.ModelAliases = map[string]string{"fable-alias": modelB}
+		c.ModelAliases = map[string]string{"pro-alias": "deepseek/deepseek-v4-pro"}
 		c.ModelsAllow = []string{"deepseek/deepseek-v4-flash"}
 	}, mock)
 
-	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody("fable-alias"), nil)
-	if resp.StatusCode != http.StatusNotFound {
-		t.Fatalf("chat (alias) status = %d, want 404: %s", resp.StatusCode, data)
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody("pro-alias"), nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("chat (alias) status = %d, want 400: %s", resp.StatusCode, data)
 	}
 	var out struct {
 		Error struct {
@@ -470,8 +470,8 @@ func TestModelsAllowResolvedAlias(t *testing.T) {
 	if err := json.Unmarshal(data, &out); err != nil {
 		t.Fatalf("error body is not JSON: %v: %s", err, data)
 	}
-	if out.Error.Code != "model_not_found" {
-		t.Errorf("error.code = %q, want model_not_found", out.Error.Code)
+	if out.Error.Code != "model_unavailable" {
+		t.Errorf("error.code = %q, want model_unavailable", out.Error.Code)
 	}
 	if len(mock.RecordedChatHeaders) != 0 {
 		t.Error("upstream chat recorded for a rejected alias, want none")
@@ -497,13 +497,13 @@ func TestModelsAllowPassthrough(t *testing.T) {
 	}
 	// A -max id NOT in the allowlist stays rejected (no implicit expansion).
 	resp, data = doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody("deepseek/deepseek-v4-pro-max"), nil)
-	if resp.StatusCode != http.StatusNotFound {
-		t.Fatalf("chat (unlisted -max) status = %d, want 404: %s", resp.StatusCode, data)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("chat (unlisted -max) status = %d, want 400: %s", resp.StatusCode, data)
 	}
 	// A model outside the list stays rejected.
 	resp, data = doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
-	if resp.StatusCode != http.StatusNotFound {
-		t.Fatalf("chat (disallowed) status = %d, want 404: %s", resp.StatusCode, data)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("chat (disallowed) status = %d, want 400: %s", resp.StatusCode, data)
 	}
 
 	// /v1/models lists exactly the allowlist, nothing else.
@@ -558,8 +558,8 @@ func TestModelsAllowEmptyIsOpen(t *testing.T) {
 	if err := json.Unmarshal(data, &out); err != nil {
 		t.Fatalf("models is not JSON: %v: %s", err, data)
 	}
-	if len(out.Data) < 2 {
-		t.Fatalf("model count = %d, want full catalog (no allowlist)", len(out.Data))
+	if len(out.Data) != 5 {
+		t.Errorf("model count = %d, want 5 (all operational models served)", len(out.Data))
 	}
 	var hasModelA, hasFlash bool
 	for _, m := range out.Data {
@@ -757,5 +757,126 @@ func TestMetricsTransientRetryCounters(t *testing.T) {
 	// and the fingerprint value line must not be emitted (only when > 0).
 	if strings.Contains(body, "freebuff_proxy_fingerprint_rotations_total{token=\"1\"}") {
 		t.Errorf("metrics emitted a fingerprint rotation value with no rotation: %s", body)
+	}
+}
+
+// TestStrictFiveModelsEnforced pins issue #189 end-to-end:
+//  1. GET /v1/models returns strictly the 5 operational models.
+//  2. Any request targeting a disabled model on OpenAI chat, Anthropic messages,
+//     or OpenAI responses returns immediate fast-fail with model_unavailable.
+//  3. /healthz reports models: 5.
+func TestStrictFiveModelsEnforced(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	ts, _ := newTestServer(t, nil, mock)
+
+	// 1. /v1/models check
+	resp, data := doJSON(t, http.MethodGet, ts.URL+"/v1/models", nil, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /v1/models status = %d, want 200: %s", resp.StatusCode, data)
+	}
+	var out struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal /v1/models: %v", err)
+	}
+	if len(out.Data) != 5 {
+		t.Fatalf("models count = %d, want exactly 5", len(out.Data))
+	}
+	wantSet := map[string]bool{
+		"deepseek/deepseek-v4-flash": true,
+		"deepseek/deepseek-v4-pro":   true,
+		"openai/gpt-5.6-luna":        true,
+		"z-ai/glm-5.2":               true,
+		"mimo/mimo-v2.5":             true,
+	}
+	for _, m := range out.Data {
+		if !wantSet[m.ID] {
+			t.Errorf("/v1/models listed unexpected model %q", m.ID)
+		}
+	}
+
+	disabledModels := []string{
+		"minimax/minimax-m3",
+		"google/gemini-2.5-flash-lite",
+		"google/gemini-3.1-flash-lite",
+		"google/gemini-3.5-flash-lite",
+		"anthropic/claude-fable-5",
+		"crof/kimi-k3-eco",
+		"meta/muse-spark-1.2-contributor",
+	}
+
+	for _, dm := range disabledModels {
+		// OpenAI chat completions -> 400 model_unavailable
+		body := `{"model":"` + dm + `","messages":[{"role":"user","content":"hi"}]}`
+		respChat, dataChat := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", []byte(body), nil)
+		if respChat.StatusCode != http.StatusBadRequest {
+			t.Errorf("chat %s status = %d, want 400: %s", dm, respChat.StatusCode, dataChat)
+		}
+		var errChat struct {
+			Error struct {
+				Message string `json:"message"`
+				Type    string `json:"type"`
+				Code    string `json:"code"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(dataChat, &errChat); err != nil {
+			t.Errorf("chat %s response not JSON: %v", dm, err)
+		}
+		if errChat.Error.Code != "model_unavailable" {
+			t.Errorf("chat %s error code = %q, want model_unavailable", dm, errChat.Error.Code)
+		}
+		if !strings.Contains(errChat.Error.Message, "Only the following 5 models are supported") {
+			t.Errorf("chat %s message = %q, want supported models notice", dm, errChat.Error.Message)
+		}
+
+		// Anthropic messages -> 400 invalid_request_error
+		respMsg, dataMsg := doJSON(t, http.MethodPost, ts.URL+"/v1/messages", []byte(body), map[string]string{
+			"anthropic-version": "2023-06-01",
+		})
+		if respMsg.StatusCode != http.StatusBadRequest {
+			t.Errorf("messages %s status = %d, want 400: %s", dm, respMsg.StatusCode, dataMsg)
+		}
+		var errAnthropic struct {
+			Type  string `json:"type"`
+			Error struct {
+				Type    string `json:"type"`
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(dataMsg, &errAnthropic); err != nil {
+			t.Errorf("messages %s response not JSON: %v", dm, err)
+		}
+		if errAnthropic.Error.Type != "invalid_request_error" {
+			t.Errorf("messages %s error type = %q, want invalid_request_error", dm, errAnthropic.Error.Type)
+		}
+		if !strings.Contains(errAnthropic.Error.Message, "Only the following 5 models are supported") {
+			t.Errorf("messages %s message = %q, want supported models notice", dm, errAnthropic.Error.Message)
+		}
+
+		// OpenAI responses -> 400 model_unavailable
+		bodyResp := `{"model":"` + dm + `","input":"hi"}`
+		respResp, dataResp := doJSON(t, http.MethodPost, ts.URL+"/v1/responses", []byte(bodyResp), nil)
+		if respResp.StatusCode != http.StatusBadRequest {
+			t.Errorf("responses %s status = %d, want 400: %s", dm, respResp.StatusCode, dataResp)
+		}
+	}
+
+	// Health check
+	respH, dataH := doJSON(t, http.MethodGet, ts.URL+"/healthz", nil, nil)
+	if respH.StatusCode != http.StatusOK {
+		t.Fatalf("healthz status = %d, want 200", respH.StatusCode)
+	}
+	var health struct {
+		Models int `json:"models"`
+	}
+	if err := json.Unmarshal(dataH, &health); err != nil {
+		t.Fatalf("unmarshal healthz: %v", err)
+	}
+	if health.Models != 5 {
+		t.Errorf("health.Models = %d, want 5", health.Models)
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -25,7 +25,6 @@ import (
 // modelA must map to an agent with EXCLUSIVE ownership in the registry
 // fallback map (see internal/registry/registry_test.go expectedFallback).
 const modelA = "deepseek/deepseek-v4-flash"
-const modelB = "anthropic/claude-fable-5"
 
 // newTestServer wires the real stack - mock upstream per token, real
 // clients/session managers, fallback registry, pool, and the server - behind


### PR DESCRIPTION
## Summary

Fixes #189 by hardcoding `freebuff-proxy` to strictly serve and advertise **ONLY the 5 operational FreeBuff models**, permanently removing the 7 obsolete, broken, or decommissioned models from the catalog and rejecting unsupported model requests with fast-fail `model_unavailable` / `invalid_request_error`.

---

### The ONLY 5 Operational Models Supported

| # | Model Identifier | Upstream Model Name | Quota & Operational Rules |
| :---: | :--- | :--- | :--- |
| **1** | `deepseek/deepseek-v4-flash` | **DeepSeek V4 Flash** | **5 sessions / day** (shared daily premium pool) |
| **2** | `deepseek/deepseek-v4-pro` | **DeepSeek V4 Pro** | **1 session / day** (closed peak hours 9am ET - 5pm PT) |
| **3** | `openai/gpt-5.6-luna` | **GPT-5.6 Luna** | **1 session / day** |
| **4** | `z-ai/glm-5.2` | **GLM 5.2** | **Referral / Streak Gated** (1 session per credit) |
| **5** | `mimo/mimo-v2.5` | **MiMo 2.5** | **Unlimited** |

---

### The 7 Models Permanently Decommissioned & Rejected

1. `minimax/minimax-m3`
2. `google/gemini-2.5-flash-lite`
3. `google/gemini-3.1-flash-lite`
4. `google/gemini-3.5-flash-lite`
5. `anthropic/claude-fable-5`
6. `crof/kimi-k3-eco`
7. `meta/muse-spark-1.2-contributor`

---

### Key Changes

1. **Registry (`internal/registry/registry.go`)**:
   - Hardcoded `ServedModels` to contain strictly the 5 active models.
   - Added `SupportedModelIDs`, `SupportedModelsHelpText`, and `IsServedModel` helpers.

2. **Fast-Fail Gateway Rejection (`internal/server`)**:
   - `openai.go`, `responses.go`: Reject unsupported models with 400 Bad Request:
     ```json
     {
       "error": {
         "message": "Model '...' is not available. Only the following 5 models are supported: deepseek/deepseek-v4-flash, deepseek/deepseek-v4-pro, openai/gpt-5.6-luna, z-ai/glm-5.2, mimo/mimo-v2.5",
         "type": "invalid_request_error",
         "code": "model_unavailable"
       }
     }
     ```
   - `anthropic.go`, `anthropic_count.go`: Reject unsupported models with 400 Bad Request:
     ```json
     {
       "type": "error",
       "error": {
         "type": "invalid_request_error",
         "message": "Model '...' is not available. Only the following 5 models are supported: deepseek/deepseek-v4-flash, deepseek/deepseek-v4-pro, openai/gpt-5.6-luna, z-ai/glm-5.2, mimo/mimo-v2.5"
       }
     }
     ```

3. **Catalog & Health/Metrics Surfaces**:
   - `GET /v1/models` outputs strictly the 5 operational models (9router only discovers and routes to these 5).
   - `GET /v1/models/{model...}` returns 404 `model_not_found` for unserved models.
   - `/healthz` and Prometheus metrics export `models: 5`.

4. **Config Defaults (`internal/config/config.go`)**:
   - `defaultFallbackModels()` pruned to `deepseek/deepseek-v4-pro` and `openai/gpt-5.6-luna` ➔ `deepseek/deepseek-v4-flash`.

5. **Tests**:
   - Added `TestStrictServedModelsFiveOnly` in `internal/registry/registry_test.go`.
   - Added `TestStrictFiveModelsEnforced` in `internal/server/server_models_test.go`.

---

### Verification
- `env -u AUTH_TOKENS -u ADMIN_TOKEN go test -count=1 ./cmd/... ./internal/...` (20/20 packages pass)
- `gofmt -l cmd internal` (clean)
- `go vet ./cmd/... ./internal/...` (clean)
- `go build -tags dashboard ./cmd/... ./internal/...` (clean)
