### PR TITLE
fix(registry): update pinned snapshot and fallback table to match upstream

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -126,6 +126,7 @@ var fallbackAgents = []agentModels{
 	{agent: "base2-free-deepseek-flash-max", models: []string{"deepseek/deepseek-v4-flash-max"}},
 	{agent: "base2-free-luna-max", models: []string{"openai/gpt-5.6-luna-max"}},
 	{agent: "base2-free-muse-spark", models: []string{"meta/muse-spark-1.2-contributor"}},
+	{agent: "base2-free-ox-alpha", models: []string{"stealth/ox-alpha"}},
 	{agent: "base2-free-fable", models: []string{"anthropic/claude-fable-5"}},
 	{agent: "base2-free-cloud-planner", models: []string{"deepseek/deepseek-v4-flash"}},
 	{agent: "base2-free-cloud-planner-limited", models: []string{"mimo/mimo-v2.5"}},
@@ -162,6 +163,7 @@ var fallbackRootByModel = map[string]string{
 	"crof/kimi-k3-eco":                "base2-free-kimi-k3-eco",
 	"anthropic/claude-fable-5":        "base2-free-fable",
 	"meta/muse-spark-1.2-contributor": "base2-free-muse-spark",
+	"stealth/ox-alpha":                "base2-free-ox-alpha",
 }
 
 // ErrModelNotFound is returned by AgentForModel for models absent from the

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -51,6 +51,7 @@ var expectedFallback = map[string]string{
 	"openai/gpt-5.6-luna-max":         "base2-free-luna-max",
 	"meta/muse-spark-1.2-contributor": "base2-free-muse-spark",
 	"anthropic/claude-fable-5":        "base2-free-fable",
+	"stealth/ox-alpha":                "base2-free-ox-alpha",
 	"google/gemini-2.5-flash-lite":    "file-picker",
 	"google/gemini-3.1-flash-lite":    "file-picker-max",
 	"google/gemini-3.5-flash-lite":    "file-picker-max",

--- a/internal/registry/testdata/upstream/free-agents.ts
+++ b/internal/registry/testdata/upstream/free-agents.ts
@@ -18,6 +18,7 @@ import {
   FREEBUFF_KIMI_K3_ECO_MODEL_ID,
   FREEBUFF_MINIMAX_M3_MODEL_ID,
   FREEBUFF_MUSE_SPARK_12_CONTRIBUTOR_MODEL_ID,
+  FREEBUFF_OX_ALPHA_MODEL_ID,
   LIMITED_FREEBUFF_MODEL_ID,
   FREEBUFF_MIMO_V25_MODEL_ID,
 } from './freebuff-models'
@@ -44,6 +45,25 @@ export const FREE_COST_MODE = 'free' as const
  * system prompts so they pass requestHasFreebuffSystemMarker.
  */
 export const FREEBUFF_DESKTOP_THREAD_AGENT_ID = 'freebuff-desktop-thread'
+
+/**
+ * The root Freebuff Desktop's AUTO-RUN decider runs under: the agent that picks
+ * what a tab on Auto does next when a turn ends with nothing queued (see
+ * freebuff-desktop/src/server/services/mission.ts). It is not the working
+ * agent — it never edits files or runs commands, it only chooses the next input.
+ *
+ * It is a first-party free-mode ROOT for the same reason the thread agent is,
+ * and it has to be one: a decision is made BETWEEN turns, so there is no running
+ * root for it to hang off and the subagent hierarchy gate would 403 it. Before
+ * it was listed here it fell through to the metered path and 402'd
+ * ("Out of credits") for the entire free-mode population, which is most of
+ * Desktop — auto-run simply never produced a next step for them.
+ *
+ * One id for every model, like the thread roots: the decision runs on whatever
+ * model the tab's turns run on, which is also the model its free session was
+ * admitted with. Anything else would 403 with `session_model_mismatch`.
+ */
+export const FREEBUFF_DESKTOP_AUTORUN_AGENT_ID = 'freebuff-desktop-autorun'
 
 /**
  * Suffix for the base3 desktop roots. The single-loop agent is a different
@@ -105,6 +125,7 @@ export const FREEBUFF_WEB_BASE3_AGENT_ID_BY_MODEL: Record<string, string> = {
   [FREEBUFF_GLM_V52_MODEL_ID]: 'base3-free-glm',
   [FREEBUFF_KIMI_K3_ECO_MODEL_ID]: 'base3-free-kimi-k3-eco',
   [FREEBUFF_MUSE_SPARK_12_CONTRIBUTOR_MODEL_ID]: 'base3-free-muse-spark',
+  [FREEBUFF_OX_ALPHA_MODEL_ID]: 'base3-free-ox-alpha',
 }
 
 /**
@@ -146,17 +167,20 @@ export const FREEBUFF_BASE3_AGENT_IDS: ReadonlySet<string> = new Set([
  * to. There is one variant per model because a bundled agent's model comes from
  * its definition, not from the request.
  *
- * BOTH tiers now plan on DeepSeek V4 Flash (2026-08-01, was MiniMax M3 for full
- * access). The old split existed because planning is short and quality-
- * sensitive, so it was worth a pricier model than the build; the V4-Flash-0731
- * GA build removed that tradeoff by being the strongest coding/tool-use model
- * we serve as well as the cheapest. Planning on it is now both better and free
- * of the premium pool, which the planner was the cheapest route into.
+ * BOTH TIERS PLAN ON THE UNLIMITED MODEL, and they converged again on
+ * 2026-08-18. The planner followed DeepSeek V4 Flash onto the premium pool for
+ * a few hours and was moved straight off it, because being OUT of that pool is
+ * the property this agent is designed around: a planner turn never touches a
+ * sandbox, so a premium-pooled planner is both the cheapest abuse route into
+ * the premium pool and a way for an ordinary user to spend their day's sessions
+ * without building anything. It tracks FALLBACK_FREEBUFF_MODEL_ID rather than
+ * naming a model, so it cannot drift back in the next time a model is
+ * re-tiered.
  *
- * A consequence: the two variants are pinned to the same model, so the model no
- * longer distinguishes them — see cloudPlannerAgentIdForModel. The limited
- * variant is kept registered (not deleted) so planner sessions already dispatched
- * under its id keep resolving; it is safe to remove once none are in flight.
+ * With the two variants sharing a model there is nothing to route on, so
+ * cloudPlannerAgentIdForModel returns the primary for both — see the guard
+ * there, which exists because the naive comparison sends every full-access turn
+ * to the LIMITED root the moment the models agree.
  *
  * Exported so the agent definitions, the planner UI's forced model, and the
  * "Start building" hand-off all read one set of values. They must agree: the
@@ -164,26 +188,28 @@ export const FREEBUFF_BASE3_AGENT_IDS: ReadonlySet<string> = new Set([
  * different model is rejected with session_model_mismatch.
  */
 export const CLOUD_PLANNER_AGENT_ID = 'base2-free-cloud-planner'
-export const CLOUD_PLANNER_MODEL_ID = FREEBUFF_DEEPSEEK_V4_FLASH_MODEL_ID
+export const CLOUD_PLANNER_MODEL_ID = FALLBACK_FREEBUFF_MODEL_ID
 export const CLOUD_PLANNER_LIMITED_AGENT_ID = 'base2-free-cloud-planner-limited'
 export const CLOUD_PLANNER_LIMITED_MODEL_ID = LIMITED_FREEBUFF_MODEL_ID
 
 /**
  * The model the build runs on after "Start building".
  *
- * DeepSeek V4 Flash since 2026-08-01 (was V4 Pro), for the same reason
- * DEFAULT_FREEBUFF_WEB_MODEL_ID is: the V4-Flash-0731 GA build is the strongest
- * coding model we serve and the cheapest. The build is where the tokens are —
- * one build outweighs its whole planning conversation by orders of magnitude —
- * so this is the single biggest place that choice pays off, and it takes builds
- * out of the premium session pool entirely.
+ * The unlimited model (FALLBACK_FREEBUFF_MODEL_ID) since 2026-08-18, when V4
+ * Flash became premium; V4 Flash held this from 2026-08-01, and V4 Pro before
+ * that. The build is where the tokens are — one build outweighs its whole
+ * planning conversation by orders of magnitude — so keeping builds OUT of the
+ * premium session pool matters more here than anywhere else. Following the
+ * fallback rather than naming a model is what makes that survive a re-tiering:
+ * this constant would otherwise have quietly put every Cloud build on the
+ * premium pool the hour Flash moved.
  *
  * Now the same model as the planner. That does NOT let the hand-off reuse the
  * planner's session: "Start building" still admits its own
  * (BlankCloudPlanControls.beginBuild), which is what a model-locked session
  * requires and remains correct whether or not the two models agree.
  */
-export const CLOUD_BUILD_MODEL_ID = FREEBUFF_DEEPSEEK_V4_FLASH_MODEL_ID
+export const CLOUD_BUILD_MODEL_ID = FALLBACK_FREEBUFF_MODEL_ID
 
 /** The planner model a given access tier is permitted to run. */
 export function cloudPlannerModelForAccessTier(
@@ -209,19 +235,29 @@ export function cloudBuildModelForAccessTier(
  *
  * The client picks which of these the build session is admitted on, because
  * only the client learns that the premium pool is spent — so the id arrives
- * from the browser and must be validated rather than trusted. Exactly two are
- * allowed: the recommended build model, and the always-available unlimited
- * fallback the user may choose when the premium pool is exhausted. Anything
- * else falls back to CLOUD_BUILD_MODEL_ID, so a forged request cannot steer a
- * free build onto an arbitrary model.
+ * from the browser and must be validated rather than trusted. Anything outside
+ * this set falls back to CLOUD_BUILD_MODEL_ID, so a forged request cannot steer
+ * a free build onto an arbitrary model.
+ *
+ * Three entries: the recommended build model, the always-available unlimited
+ * fallback a user may choose when the premium pool is exhausted, and the
+ * limited tier's build model — read from the tier helper, and redundant until
+ * that tier stopped building on Flash. Without it this rejected the very model
+ * cloudBuildModelForAccessTier('limited') hands the client.
  */
+const CLOUD_BUILD_MODEL_IDS: ReadonlySet<string> = new Set([
+  CLOUD_BUILD_MODEL_ID,
+  FALLBACK_FREEBUFF_MODEL_ID,
+  cloudBuildModelForAccessTier('limited'),
+])
+
 export function isCloudBuildModelId(model: string | null | undefined): boolean {
-  return model === CLOUD_BUILD_MODEL_ID || model === FALLBACK_FREEBUFF_MODEL_ID
+  return !!model && CLOUD_BUILD_MODEL_IDS.has(model)
 }
 
 /** The build model to run for a request, after validating the client's choice.
- *  Limited tiers need no special case here: runTriggerGates coerces whatever
- *  this returns down to the one model that tier permits. */
+ *  Bounds only the ids a browser may name: runTriggerGates still coerces
+ *  whatever survives down to the one model the caller's tier permits. */
 export function resolveCloudBuildModel(
   requested: string | null | undefined,
 ): string {
@@ -231,19 +267,29 @@ export function resolveCloudBuildModel(
 }
 
 /**
- * The planner variant to run. Always the primary one now: both variants pin the
- * same model, so the model cannot pick between them, and keying off it would
- * route EVERY caller — full access included — to the agent labelled
- * "(limited)". Limited tiers are served correctly by the primary variant
- * because Flash is a model their tier permits.
+ * The planner variant to run, chosen by the model the caller resolved.
  *
- * Kept as a function taking the model so callers need not change, and so the
- * choice has one place to live again if the tiers ever diverge on model.
+ * Matches the LIMITED model rather than the primary one, so an unknown or
+ * absent model falls to the primary root. That direction is deliberate: a
+ * limited caller who somehow reached the primary is corrected by
+ * runTriggerGates, while the reverse would put every full-access planner turn
+ * on the agent labelled "(limited)".
  */
 export function cloudPlannerAgentIdForModel(
-  _model: string | null | undefined,
+  model: string | null | undefined,
 ): string {
-  return CLOUD_PLANNER_AGENT_ID
+  // When the two variants share a model there is nothing to route on, and the
+  // comparison below would send EVERY turn — full access included — to the
+  // limited root. Both roots accept the shared model, so this is a routing and
+  // attribution question rather than an admission one, and the primary is the
+  // right answer. The tiers converged again on 2026-08-18 when the planner
+  // followed the unlimited model onto MiMo 2.5.
+  if (CLOUD_PLANNER_MODEL_ID === CLOUD_PLANNER_LIMITED_MODEL_ID) {
+    return CLOUD_PLANNER_AGENT_ID
+  }
+  return model === CLOUD_PLANNER_LIMITED_MODEL_ID
+    ? CLOUD_PLANNER_LIMITED_AGENT_ID
+    : CLOUD_PLANNER_AGENT_ID
 }
 
 /**
@@ -276,6 +322,10 @@ export const FREEBUFF_ROOT_AGENT_IDS = [
   // other root so its subagents pass the hierarchy gate; the model, not this
   // list, is what keeps it off the CLI and Desktop.
   'base2-free-muse-spark',
+  // Freebuff Web and Cloud only (Ox Alpha), for the same reason and with the
+  // same division of labour: the model's absence from SUPPORTED_FREEBUFF_MODELS
+  // is what keeps it off the CLI and Desktop, not this list.
+  'base2-free-ox-alpha',
   // Capacity-limited trial orchestrator (Claude Fable 5). Reachable only while
   // the server is still advertising the offer, but it must be listed here
   // unconditionally: a session admitted while the pool was open runs its full
@@ -304,10 +354,14 @@ export const FREEBUFF_ROOT_AGENT_IDS = [
   'base3-free-glm',
   'base3-free-kimi-k3-eco',
   'base3-free-muse-spark',
+  'base3-free-ox-alpha',
   // Freebuff CLI base3 roots. Every other id it needs is already above,
   // shared with Web; Fable is the one model the CLI offers and Web does not.
   'base3-free-fable',
   ...FREEBUFF_DESKTOP_THREAD_AGENT_IDS,
+  // The Desktop auto-run decider. Spawns nothing, but the hierarchy gate reads
+  // this list for the ROOT itself, and a decision has no parent run to hang off.
+  FREEBUFF_DESKTOP_AUTORUN_AGENT_ID,
 ] as const
 const FREEBUFF_ROOT_AGENT_ID_SET: ReadonlySet<string> = new Set(
   FREEBUFF_ROOT_AGENT_IDS,
@@ -323,6 +377,7 @@ export const FREEBUFF_ROOT_AGENT_ID_BY_MODEL: Record<string, string> = {
   [FREEBUFF_KIMI_K3_ECO_MODEL_ID]: 'base2-free-kimi-k3-eco',
   [FREEBUFF_FABLE_5_MODEL_ID]: 'base2-free-fable',
   [FREEBUFF_MUSE_SPARK_12_CONTRIBUTOR_MODEL_ID]: 'base2-free-muse-spark',
+  [FREEBUFF_OX_ALPHA_MODEL_ID]: 'base2-free-ox-alpha',
 }
 
 /**
@@ -446,6 +501,13 @@ export const FREE_MODE_AGENT_MODELS: Record<string, Set<string>> = {
   'base2-free-deepseek': new Set([FREEBUFF_DEEPSEEK_V4_PRO_MODEL_ID]),
   'base2-free-deepseek-flash': new Set([FREEBUFF_DEEPSEEK_V4_FLASH_MODEL_ID]),
   'base2-free-mimo': new Set([FREEBUFF_MIMO_V25_MODEL_ID]),
+  // M3 was WITHDRAWN on 2026-08-20 (see FREEBUFF_PAUSED_FREE_MODEL_IDS), and
+  // this entry stays on purpose. Withdrawal is enforced at ADMISSION: no new
+  // session can be opened for the model. Sessions admitted before the deploy
+  // are still live, and they reach this allowlist on every turn — deleting the
+  // row would fail them mid-turn with free_mode_invalid_agent_model, which is
+  // the same client wedge the withdrawal was shaped to avoid (#1801). Let them
+  // drain; the door is already shut in front of them.
   'base2-free-minimax-m3': new Set([FREEBUFF_MINIMAX_M3_MODEL_ID]),
   'base2-free-luna': new Set([FREEBUFF_GPT_5_6_LUNA_MODEL_ID]),
   'base2-free-glm': new Set([FREEBUFF_GLM_V52_MODEL_ID]),
@@ -467,6 +529,11 @@ export const FREE_MODE_AGENT_MODELS: Record<string, Set<string>> = {
   'base2-free-muse-spark': new Set([
     FREEBUFF_MUSE_SPARK_12_CONTRIBUTOR_MODEL_ID,
   ]),
+  // Web/Cloud-only Ox Alpha root, pinned to its one model like every other. The
+  // pinning matters here even though the model is free: an agent id is the
+  // handle a hand-written caller reaches for, and a root allowed more than one
+  // model is a door onto everything else it allows.
+  'base2-free-ox-alpha': new Set([FREEBUFF_OX_ALPHA_MODEL_ID]),
   // Limited-offer trial root. Only this agent may run Fable for free, and only
   // on Fable — the pool accounting keys off the model, so a root that could
   // also run something else would let a session escape it.
@@ -498,6 +565,10 @@ export const FREE_MODE_AGENT_MODELS: Record<string, Set<string>> = {
   [getFreebuffDesktopThreadAgentId('local', 'base3')]: FREEBUFF_DESKTOP_MODELS,
   [getFreebuffDesktopThreadAgentId('worktree', 'base3')]:
     FREEBUFF_DESKTOP_MODELS,
+  // The auto-run decider reads the same set for the same reason: it decides on
+  // the tab's own model, which is the one that tab's session was admitted with.
+  // Pinning it to a single model instead would 403 every tab on any other one.
+  [FREEBUFF_DESKTOP_AUTORUN_AGENT_ID]: FREEBUFF_DESKTOP_MODELS,
 
   // File exploration agents
   'file-picker': new Set(['google/gemini-2.5-flash-lite']),
@@ -608,6 +679,12 @@ export const FREEBUFF_ROOT_SYSTEM_PROMPT_OPENINGS = [
   'You are Buffy, the coding agent behind Codebuff.',
   // freebuff_bundled_agents.ts CLOUD_PLANNER_SYSTEM_PROMPT — planner roots.
   'You are Buffy, the Freebuff Cloud project planner.',
+  // freebuff-desktop/.../services/mission.ts — the Desktop mission decider.
+  // Its own opening rather than base3's: that prompt tells the model it is the
+  // coding agent, and this one spends its length establishing the opposite
+  // ("you never edit files or run commands"). Position 0 is the worst place to
+  // say the wrong thing about who is reading.
+  'You are Buffy, the auto-run agent behind Freebuff Desktop.',
   // LEGACY — base2's opening before 92371caa8 (2026-07-07). The prompt is
   // compiled into the CLI binary and the launcher force-updates on every start,
   // so this only covers installs whose update path is broken (offline,
@@ -710,6 +787,52 @@ export function isFreeModeAllowedAgentModel(
   }
 
   return false
+}
+
+/**
+ * A model the SERVER substituted, running on an agent free mode already knows.
+ *
+ * Most free-mode roots are pinned to exactly one model — `base3-free-deepseek-
+ * flash` allows Flash and nothing else — which assumes the model a request
+ * carries is the one its client picked. That stops being true whenever the
+ * server overrides the pick, which now happens two ways: a model LEAVES A TIER
+ * (Flash left the limited tier on 2026-08-18) or a model is PAUSED for free
+ * mode entirely (V4 Pro, later the same day). Admission and
+ * `checkSessionAdmissible` both substitute, and the request reaches a pinned
+ * root carrying the model WE chose.
+ *
+ * Both halves of the free-mode decision must admit that request — the gate in
+ * chat/completions and the billing check in llm-api/helpers.ts. If they
+ * disagree it falls into the METERED path: credit ledger writes for an account
+ * with no balance. Same trap `isHoneypotFreeModeAllowed` avoids, same shape.
+ *
+ * Cannot be an escalation, which is what the allowlist exists to prevent. Both
+ * accepted targets are models the server picks for users it is stepping DOWN,
+ * never up: the limited tier's only model, and the always-available fallback
+ * every surface lands on when a premium pool is spent. They name the same model
+ * today; they are checked separately because that is a coincidence of the
+ * current catalog rather than a rule, and the day it stops being true this
+ * must keep accepting both.
+ */
+export function isLimitedTierSubstitutedModel(
+  fullAgentId: string,
+  model: string,
+): boolean {
+  if (
+    model !== LIMITED_FREEBUFF_MODEL_ID &&
+    model !== FALLBACK_FREEBUFF_MODEL_ID
+  ) {
+    return false
+  }
+
+  const { publisherId, agentId } = parseAgentId(fullAgentId)
+  if (!agentId) return false
+  if (publisherId && publisherId !== 'codebuff') return false
+
+  // Known free-mode agent, and not a programmatic one (empty set) — the same
+  // two conditions isFreeModeAllowedAgentModel checks before the model itself.
+  const allowedModels = FREE_MODE_AGENT_MODELS[agentId]
+  return !!allowedModels && allowedModels.size > 0
 }
 
 /**

--- a/internal/registry/testdata/upstream/freebuff-models.ts
+++ b/internal/registry/testdata/upstream/freebuff-models.ts
@@ -4,6 +4,10 @@ import {
   getZonedParts,
   type ZonedDateParts,
 } from '../util/zoned-time'
+import {
+  deepSeekExpensiveWindowEndsAt,
+  isDeepSeekExpensiveWindow,
+} from './freebuff-peak-hours'
 import { mimoModels } from './model-config'
 import {
   FREEBUFF_DEEPSEEK_V4_FLASH_MODEL_ID,
@@ -14,10 +18,7 @@ import {
   FREEBUFF_AI_TRAINING_NOTICE,
   type FreebuffModelDataUse,
 } from './freebuff-data-use'
-import {
-  clampReasoningEffort,
-  type ReasoningEffort,
-} from './reasoning-effort'
+import { clampReasoningEffort, type ReasoningEffort } from './reasoning-effort'
 
 export {
   FREEBUFF_DEEPSEEK_V4_FLASH_MODEL_ID,
@@ -41,7 +42,20 @@ export interface FreebuffModelOption {
   /** One-line description shown next to the label. */
   tagline: string
   /** Availability policy for the selector and server-side admission. */
-  availability: 'always' | 'deployment_hours'
+  availability: 'always' | 'deployment_hours' | 'off_peak_only'
+  /**
+   * Where a pick lands while THIS model is closed by `availability`.
+   *
+   * Without it an unavailable pick falls to FALLBACK_FREEBUFF_MODEL_ID, which
+   * is the unlimited row — correct when a model is gone, wrong when it is
+   * merely asleep and a better substitute is awake. V4 Flash closes at peak
+   * precisely so its traffic lands on V4 Pro, and a silent detour to MiMo would
+   * defeat the whole point of closing it.
+   *
+   * Advisory, not a guarantee: it is used only when the named model is itself
+   * available, so this can never strand a pick on a second closed row.
+   */
+  unavailableFallback?: string
   /** Optional caveat shown in the picker (e.g. AI-training warning).
    *  Rendered in the warning/secondary color so users spot it before
    *  picking the model. */
@@ -164,10 +178,12 @@ export const FREEBUFF_GLM_V52_MODEL_ID = 'z-ai/glm-5.2'
  *  and BYOK callers alike (see applyOpenRouterProviderRouting and
  *  applyFreebuffReasoningDefaults in web/src/llm-api/openrouter.ts):
  *
- *   - Routing is PINNED to OpenAI's own endpoint. OpenRouter also lists Azure
- *     and Amazon Bedrock for this model at $1.00/$6.00 per M — 10x OpenAI's
- *     $0.10/$0.60 — so unpinned routing is a silent 10x bill (cf. the
- *     Kimi/Infron unit-price doubling, 2026-07-29).
+ *   - Routing PREFERS OpenAI's own endpoint ($0.10/$0.60 per M) via `order`,
+ *     with fallbacks allowed and cost bounded by FREEBUFF_GPT_5_6_LUNA_MAX_PRICE
+ *     rather than by the pin. A hard pin (allow_fallbacks:false) held until
+ *     2026-08-16, when OpenAI began refusing every request from this account
+ *     ("Policy Violation: this user has been blocked") and took Luna to a 100%
+ *     failure rate with four usable endpoints sitting under the ceiling.
  *   - Reasoning effort is `high`. Luna is cheap enough per token that the
  *     quality is worth more than the reasoning tokens.
  *
@@ -175,12 +191,13 @@ export const FREEBUFF_GLM_V52_MODEL_ID = 'z-ai/glm-5.2'
  *  (agents/constants.ts) is this same model id, so keying either off the model
  *  alone would change Codebuff's paid lite mode as a side effect. */
 export const FREEBUFF_GPT_5_6_LUNA_MODEL_ID = 'openai/gpt-5.6-luna'
-/** OpenRouter provider slug Luna is pinned to. */
+/** OpenRouter provider slug Luna prefers (first in `provider.order`). */
 export const FREEBUFF_GPT_5_6_LUNA_PROVIDER_ROUTE = 'openai'
 /** Price ceiling for Luna, USD per million tokens. Sent as OpenRouter's
- *  `provider.max_price`, which REFUSES the request rather than serving above
- *  it, so a provider re-pricing surfaces as a loud error instead of a 10x
- *  invoice.
+ *  `provider.max_price`, which REFUSES to route above it rather than serving
+ *  and billing, so a provider re-pricing surfaces as a loud error instead of a
+ *  surprise invoice. Since 2026-08-16 this — not a hard provider pin — is the
+ *  sole cost guarantee, so it must not be widened casually.
  *
  *  This is a COST FENCE, not an assertion of the list price, and the gap is
  *  deliberate on both sides:
@@ -190,13 +207,14 @@ export const FREEBUFF_GPT_5_6_LUNA_PROVIDER_ROUTE = 'openai'
  *     found that satisfy the max price for this request" — verified against the
  *     live API on 2026-07-30, where 0.11/0.61 passed and 0.1/0.6 did not. A
  *     ceiling equal to list is an outage waiting on a rounding change.
- *   - It must sit WELL BELOW $1.00/$6.00, which is what Azure, Azure EU
- *     ($1.10/$6.60) and Amazon Bedrock charge for this model. Blocking those is
- *     the whole point.
+ *   - It must stay under the next tier up. Azure, Azure EU and Amazon Bedrock
+ *     listed $1.00/$6.00 when this was written and re-priced to $0.20/$1.20 by
+ *     2026-08-16; the ceiling admits them at today's price and would exclude
+ *     them again if they returned to the old one.
  *
- *  Half of Azure's price leaves room for OpenAI's own tiers (list $0.10/$0.60,
- *  priority $0.20/$1.20) and for ordinary price drift, while still failing
- *  closed long before a 10x endpoint could serve a request. */
+ *  The headroom covers OpenAI's own tiers (list $0.10/$0.60, priority
+ *  $0.20/$1.20, flex $0.05/$0.30) and ordinary price drift, while still failing
+ *  closed well before a 10x endpoint could serve a request. */
 export const FREEBUFF_GPT_5_6_LUNA_MAX_PRICE = {
   prompt: 0.5,
   completion: 3.0,
@@ -308,6 +326,64 @@ export const MUSE_SPARK_CONTRIBUTOR_RPM = 60
 export const FREEBUFF_MUSE_SPARK_REASONING_EFFORT = 'xhigh' as const
 
 /**
+ * Ox Alpha — an anonymous ("stealth") frontier coding model, served through
+ * OpenRouter at a list price of zero while its host evaluates it.
+ *
+ * FREEBUFF WEB AND CLOUD ONLY. It is absent from FREEBUFF_MODELS and
+ * SUPPORTED_FREEBUFF_MODELS, so no CLI or Desktop build can select it and
+ * `isFreebuffSessionModelId` refuses it there; the browser surfaces reach it
+ * through FREEBUFF_WEB_MODELS. Unlike Muse Spark's narrow surface, that is a
+ * "prove it first" decision rather than a property of the model — see
+ * docs/freebuff-ox-alpha.md for what was measured and what would justify
+ * widening it.
+ *
+ * The id is OpenRouter's own slug, so it falls through to the default
+ * OpenRouter route with no provider-specific handler (same as Luna). Three
+ * things about it are not like the other rows served that way:
+ *
+ *  - IT IS FREE, AND THAT IS FENCED RATHER THAN TRUSTED — see
+ *    FREEBUFF_OX_ALPHA_MAX_PRICE. A stealth model's price is whatever an
+ *    anonymous host decides tomorrow, and this row sits in no session pool at
+ *    all, so an unnoticed repricing would be unmetered spend.
+ *  - REASONING IS MANDATORY (the endpoint reports `reasoning.mandatory`), and
+ *    the provider's own default effort is `max`. Measured on one debugging
+ *    prompt, n=4 per rung, 2026-08-20: `low` answered correctly in 409
+ *    completion tokens and 8.4s, `high` in 725 and 11.3s, `max` in 3,505 and
+ *    48.5s — with one of the four `max` samples truncated by a 4k token limit
+ *    mid-answer. So the row names its effort explicitly; leaving it unset opts
+ *    every turn into the slowest and most truncation-prone rung there is.
+ *  - Prompts and completions are RETAINED BY THE HOST and, per OpenRouter's
+ *    stealth-model terms, not used for training. That is neither case
+ *    `dataUse` was written for; see the row for how it is labelled.
+ */
+export const FREEBUFF_OX_ALPHA_MODEL_ID = 'stealth/ox-alpha'
+/**
+ * Price ceiling for Ox Alpha, USD per million tokens — ZERO, sent as
+ * OpenRouter's `provider.max_price`.
+ *
+ * Same mechanism as FREEBUFF_GPT_5_6_LUNA_MAX_PRICE and deliberately the
+ * opposite ceiling. Luna's sits ABOVE list to leave routing headroom; this one
+ * sits exactly AT a list price of zero, so the first endpoint that charges
+ * anything stops being routable at all.
+ *
+ * Both halves verified against the live API on 2026-08-20, because a fence
+ * nobody has watched fail is not a fence: a zero ceiling serves Ox Alpha
+ * normally, and the SAME ceiling on a priced model answers 404 "No endpoints
+ * found that satisfy the max price for this request". It fails closed, loudly,
+ * before the first billed token rather than after the invoice — which is the
+ * shape of bill this repo has already paid twice (the retired OpenRouter
+ * DeepSeek lane; the Kimi/Infron unit-price doubling).
+ *
+ * This guard is why the model can sit outside every session pool. Do not widen
+ * it to "just a little headroom" without giving the row a pool in the same
+ * change: the two are one decision.
+ */
+export const FREEBUFF_OX_ALPHA_MAX_PRICE = {
+  prompt: 0,
+  completion: 0,
+} as const
+
+/**
  * The user-pickable ladders, named like Desktop's THROUGH_XHIGH / NO_XHIGH so
  * the two catalogs read the same way.
  *
@@ -347,6 +423,11 @@ export const EFFORTS_THROUGH_MAX = [
  * probing.
  */
 const DEEPSEEK_V4_REASONING_EFFORTS = ['low', 'high', 'max'] as const
+/** Ox Alpha's native ladder, read off the endpoint's `supported_efforts`.
+ *  The same three rungs as DeepSeek V4 and, like it, no distinct medium — so
+ *  it is a separate constant rather than a shared one only because the two
+ *  providers are free to diverge. */
+const OX_ALPHA_REASONING_EFFORTS = ['low', 'high', 'max'] as const
 /**
  * The marker that turns a Muse Spark rate limit into a queued turn rather than
  * a failed one.
@@ -363,24 +444,29 @@ export const MUSE_SPARK_RATE_LIMITED_ERROR_CODE = 'muse_spark_rate_limited'
 /**
  * Where a rate-limited Muse Spark request goes instead of waiting.
  *
- * DeepSeek V4 Pro since 2026-08-12 (GPT-5.6 Luna before it), and the choice is
- * constrained rather than free on two counts:
+ * DeepSeek V4 Flash since 2026-08-18, when V4 Pro was paused for free mode (it
+ * held this from 2026-08-12, and GPT-5.6 Luna before that). The choice is
+ * constrained rather than free on two counts, and Flash satisfies both for the
+ * same reasons Pro did:
  *
  *  - The fallback must be a model the caller is ALREADY entitled to, or a rate
- *    limit would become a way to reach something they are not. Pro sits in the
+ *    limit would become a way to reach something they are not. Flash sits in the
  *    same shared daily premium pool as Muse Spark
- *    (FREEBUFF_WEB_PREMIUM_MODEL_IDS), so a rerouted request draws on exactly
- *    the quota the original would have.
+ *    (FREEBUFF_WEB_PREMIUM_MODEL_IDS) — it joined that pool the same day — so a
+ *    rerouted request draws on exactly the quota the original would have.
  *  - It should be the model we would recommend anyway, since the user never
- *    chose it: Pro is now DEFAULT_FREEBUFF_WEB_MODEL_ID, so a reroute lands on
+ *    chose it: Flash is now DEFAULT_FREEBUFF_WEB_MODEL_ID, so a reroute lands on
  *    the same model a new thread would have started on.
+ *
+ * Both bullets are why this had to move with the pause rather than after it: a
+ * fallback pointing at a paused model turns a queue overflow into a refusal.
  *
  * Being text-only costs this nothing: images reaching a Freebuff model that
  * cannot see pixels are converted to vision-model descriptions at the
  * completions layer (getFreebuffModelImageSupport gates it), so a rerouted turn
  * carrying an image still reads it.
  */
-export const MUSE_SPARK_FALLBACK_MODEL_ID = FREEBUFF_DEEPSEEK_V4_PRO_MODEL_ID
+export const MUSE_SPARK_FALLBACK_MODEL_ID = FREEBUFF_DEEPSEEK_V4_FLASH_MODEL_ID
 
 /**
  * How long a caller may be asked to wait before the request is rerouted.
@@ -399,7 +485,7 @@ export const MUSE_SPARK_FALLBACK_AFTER_MS = 10_000
  *  MUSE_SPARK_FALLBACK_MODEL_ID actually points at; a catalog invariant test
  *  checks the two agree. */
 export const MUSE_SPARK_FALLBACK_NOTICE =
-  'Falls back to DeepSeek V4 Pro if the queue is too long.'
+  'Falls back to DeepSeek V4 Flash if the queue is too long.'
 
 /** UI-only rollout switch. Backend support and free-mode allowlists remain
  *  wired even when these models are hidden from the Freebuff picker. */
@@ -410,12 +496,69 @@ export const FREEBUFF_ENABLE_STREAK_IN_UI = true
  *  limited access so the limited Freebuff UX can be exercised without an env
  *  var. */
 export const FREEBUFF_FORCE_LIMITED_MODE = false
-export const FREEBUFF_PREMIUM_SESSION_LIMIT = 6
-export const FREEBUFF_LIMITED_SESSION_LIMIT = 6
-/** Full-access Web/Cloud models outside the premium/referral pools. The CLI
- * keeps these models unlimited; browser surfaces cap fresh sessions to deter
- * automated project/session churn. */
-export const FREEBUFF_WEB_STANDARD_SESSION_LIMIT = 6
+/**
+ * Base premium sessions per Pacific day, before anything is earned.
+ *
+ * 5 → 4 when Levels shipped (`freebuff-levels.ts`), and the small size of that
+ * cut is the design. A free tier whose floor already hands out everything has
+ * nothing left to reward with — but a floor that COLLAPSES is a regression
+ * every existing user feels on the same afternoon, and no amount of "you can
+ * earn it back" reads as anything other than a takeaway. One session is what
+ * an honest account loses; Levels then take it to 7, which is more than
+ * anybody had before.
+ *
+ * Referral, streak, bounty and operator entitlement still add on top of this,
+ * unchanged.
+ */
+export const FREEBUFF_PREMIUM_SESSION_LIMIT = 4
+/**
+ * Limited-region base sessions per Pacific day.
+ *
+ * 6 → 3, the one genuinely large cut, and it is aimed rather than broad:
+ * `docs/freebuff-trust-levels.md` records that the brand-new-account /
+ * unsupported-region / often-VPN intersection is the exact shape of the
+ * reselling farms, and this is the pool they drain. A real developer abroad
+ * climbs straight back past where they started — Levels take this to 7 — while
+ * an account minted to be drained never earns a single rung.
+ */
+export const FREEBUFF_LIMITED_SESSION_LIMIT = 3
+
+/**
+ * What those two pools paid BEFORE Levels, and the revert lever.
+ *
+ * `FREEBUFF_LEVEL_SESSIONS=off` selects these instead of the reduced bases
+ * above, and suppresses the level bonus with them. The two halves have to move
+ * together: a reduced base with the ladder switched off is a pure takeaway,
+ * which is the one configuration this feature must never be able to land in.
+ * That is why the switch gates the whole change rather than just the bonus.
+ *
+ * Delete both, and the branch in `free-session/public-api.ts` that reads them,
+ * once Levels has been on long enough that rolling back is not a thing anyone
+ * would do.
+ */
+export const FREEBUFF_PRE_LEVELS_PREMIUM_SESSION_LIMIT = 5
+export const FREEBUFF_PRE_LEVELS_LIMITED_SESSION_LIMIT = 6
+/**
+ * There is no standard-model session limit, on any surface.
+ *
+ * `FREEBUFF_WEB_STANDARD_SESSION_LIMIT` used to live here at 6, capping fresh
+ * standard sessions on browser surfaces only — unlimited in CLI and Desktop,
+ * six a day in Web and Cloud. Removed on 2026-08-18, because a product whose
+ * central promise is "Freebuff is free" cannot have that promise be true on
+ * one surface and not another, with no way for a user to discover the
+ * difference except by hitting it.
+ *
+ * It was also close to redundant. `docs/freebuff-trust-levels.md` argues at
+ * length that session COUNT is the wrong thing to meter — starting a session
+ * costs nothing and an idle session costs nothing, while the traffic inside it
+ * is bounded four separate ways (`messagesPerDay`, `messagesPer5Hours`,
+ * `userMessagesPerDay`, and the daily spend ceiling). The churn it was aimed
+ * at is project creation, which has its own gate
+ * (`docs/freebuff-web-creation-gate.md`).
+ *
+ * Levels therefore scale only the two pools that are genuinely scarce: premium
+ * and the limited region. See `freebuff-levels.ts`.
+ */
 export const FREEBUFF_PREMIUM_SESSION_RESET_TIMEZONE = 'America/Los_Angeles'
 export const FREEBUFF_PREMIUM_SESSION_PERIOD = 'pacific_day'
 /** GLM 5.2 referral-reward session pool. Distinct from the shared premium
@@ -446,10 +589,6 @@ export const FREEBUFF_GLM_V52_SESSION_LENGTH_MS = 60 * 60 * 1000
 export const FREEBUFF_LIMITED_SESSION_RESET_TIMEZONE =
   FREEBUFF_PREMIUM_SESSION_RESET_TIMEZONE
 export const FREEBUFF_LIMITED_SESSION_PERIOD = FREEBUFF_PREMIUM_SESSION_PERIOD
-export const FREEBUFF_WEB_STANDARD_SESSION_RESET_TIMEZONE =
-  FREEBUFF_PREMIUM_SESSION_RESET_TIMEZONE
-export const FREEBUFF_WEB_STANDARD_SESSION_PERIOD =
-  FREEBUFF_PREMIUM_SESSION_PERIOD
 
 /**
  * Streak rewards. Once a user reaches a `FREEBUFF_STREAK_REWARD_INTERVAL_DAYS`
@@ -509,11 +648,23 @@ interface LocalTimeFormatOptions {
 }
 
 /** Full-access freebuff models that benefit from spawning the gemini-thinker
- *  subagent for deeper reasoning. Covers every full-access picker model except
- *  the two limited-tier ones (DeepSeek V4 Flash, MiMo 2.5). Used by the CLI to
- *  toggle the gemini-thinker spawnable + prompts based on the user's pick, and
- *  by the server to admit gemini-thinker child requests against a parent
- *  session bound to one of these models. */
+ *  subagent for deeper reasoning. Used by the CLI to toggle the gemini-thinker
+ *  spawnable + prompts based on the user's pick, and by the server to admit
+ *  gemini-thinker child requests against a parent session bound to one of
+ *  these models.
+ *
+ *  This used to be "every full-access picker model except the limited-tier
+ *  ones", and that rule no longer describes the list. DeepSeek V4 Flash left
+ *  the limited tier on 2026-08-18 and is now premium, yet it is deliberately
+ *  still OUT: a thinker child is an extra Gemini Pro call on top of the parent
+ *  turn, and Flash now carries the bulk of free-mode traffic. Adding it would
+ *  multiply exactly the cost the same day's changes were made to contain.
+ *  Membership is a cost decision now, not a tier one.
+ *
+ *  V4 Pro stays listed while paused. The check only ever runs against a row's
+ *  bound model, and no row can be bound to a paused model, so the entry is
+ *  inert — and it means the thinker comes back with Pro in one edit instead of
+ *  being forgotten. */
 export const FREEBUFF_GEMINI_THINKER_PARENT_MODELS = new Set<string>([
   FREEBUFF_DEEPSEEK_V4_PRO_MODEL_ID,
   FREEBUFF_MINIMAX_M3_MODEL_ID,
@@ -576,41 +727,34 @@ export const FREEBUFF_MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   // above while remaining an honest order of magnitude, where falling through
   // to the 131_072 default would summarize a million-token thread 8x early.
   [FREEBUFF_MUSE_SPARK_12_CONTRIBUTOR_MODEL_ID]: 1_000_000,
+  // OpenRouter publishes 1,048,576 for the single Ox Alpha endpoint. Entered as
+  // 1_000_000 for the same reason as the two above: a published number is not
+  // an observed rejection, and the asymmetry here punishes guessing high.
+  [FREEBUFF_OX_ALPHA_MODEL_ID]: 1_000_000,
 }
 
 /** Window assumed for any model missing from FREEBUFF_MODEL_CONTEXT_WINDOWS.
  *  Smaller than every window we have measured. */
 export const FREEBUFF_DEFAULT_CONTEXT_WINDOW = 131_072
 
-/** The "a better model exists" copy every superseded model points at, shared so
- *  the rows that carry it can't drift into different sentences. Two rows do
- *  today — MiniMax M3 and MiMo 2.5. (DeepSeek V4 Pro was the third until its
- *  08/13 GA build overtook Flash again; see DEEPSEEK_V4_PRO_MODEL.)
+/* Two supersedes notices lived here — FLASH_SUPERSEDES_NOTICE ("V4 Flash 07/31
+ * performs better for most tasks") and FLASH_RECOMMENDED_NOTICE ("V4 Flash
+ * 07/31 is the recommended pick") — and both were deleted on 2026-08-21 with
+ * their last referrers. The catalog now carries NO supersedes notice at all and
+ * no row is badged RECOMMENDED; ordering is the only steer left.
  *
- *  Names the DATED build. The wire id is undated and auto-updates, so the row a
- *  user is being steered TO is labelled "DeepSeek V4 Flash 07/31" in every
- *  picker (see DEEPSEEK_V4_FLASH_MODEL.displayName) — matching it exactly is
- *  what makes the notice point at something visible on screen rather than at a
- *  name nothing in the list carries.
+ * Worth reading in git before writing anything like them again, for two reasons
+ * that outlive the particular models:
  *
- *  Kept short on purpose: pickers render it as its own line, and in the CLI it
- *  is the longest line in the menu, so it sets the width of every card. */
-const FLASH_SUPERSEDES_NOTICE =
-  'DeepSeek V4 Flash 07/31 performs better for most tasks.'
-
-/** The same thing for the rows Pro overtook, which is currently GPT-5.6 Luna.
- *
- *  A SECOND notice rather than a reworded shared one, because the two point
- *  somewhere different for different reasons: Flash's notice steers off models
- *  that are dearer AND weaker, while against Luna the cost comparison does not
- *  cleanly favor either side (see FREEBUFF_WEB_DEEMPHASIZED_MODEL_IDS for the
- *  numbers). That is why Luna is superseded but not de-emphasized — the argument
- *  here is quality and speed alone.
- *
- *  Names the dated build, matching DEEPSEEK_V4_PRO_MODEL.displayName, so the row
- *  it steers to is one the user can see on screen. */
-const PRO_SUPERSEDES_NOTICE =
-  'DeepSeek V4 Pro 08/13 is smarter and faster.'
+ *  - BOTH EXPIRED WITHOUT ANYONE NOTICING. Each asserted Flash was the better
+ *    default. Flash became premium on 2026-08-18 and started closing for the
+ *    ten-hour peak window on 2026-08-21, so by the end the picker was steering
+ *    users toward a model that is asleep for part of every day.
+ *  - A NOTICE IS NOT JUST COPY. migrateSupersededFreebuffModelPreference
+ *    rewrites a SAVED pick on every load, so a stale notice does not merely
+ *    give bad advice — it silently moves users off the model they chose, on
+ *    every launch, with no action from them.
+ */
 
 /**
  * DeepSeek V4 Pro, on the 08/13 GA build (2026-08-12).
@@ -623,21 +767,41 @@ const PRO_SUPERSEDES_NOTICE =
  * API, 2026-08-12), and /v1/models lists exactly the two undated ids. So there
  * is nothing to plumb for a new build; what changes is what this row SAYS.
  *
- * Pricing is unchanged by the GA release ($0.435 in / $0.003625 cache read /
- * $0.87 out per M), so DEEPSEEK_V4_PRO_PRICING in web/src/llm-api/deepseek.ts
- * still holds.
+ * Pricing was unchanged by the GA release, but DeepSeek repriced the whole
+ * family at 16:00 UTC on 2026-08-16 and split it into peak and off-peak cards:
+ * $0.66 in / $0.022 cache read / $1.98 out per M off-peak, exactly double that
+ * at peak (01:00-04:00 and 06:00-10:00 UTC). DEEPSEEK_V4_PRO_PRICING in
+ * web/src/llm-api/deepseek.ts carries both.
  */
 const DEEPSEEK_V4_PRO_MODEL = {
   id: FREEBUFF_DEEPSEEK_V4_PRO_MODEL_ID,
   // Dated for the same reason Flash is: the wire id is undated and auto-updates,
   // so an undated label tells a returning user nothing changed when in fact the
   // GA build is a different model from the preview they formed an opinion about.
-  displayName: 'DeepSeek V4 Pro 08/13',
-  // Superlative on purpose, and it has to stay in step with Flash's: Pro is the
-  // recommended default, so the two DeepSeek rows are read against each other.
-  // "Smartest" vs Flash's "Smart & Fast" says which one is stronger and which
-  // one is the cheap, unlimited one — "Deep reasoning" said neither.
-  tagline: 'Smartest',
+  // UNDATED as of 2026-08-19, and that is a correction rather than a style
+  // change. The rule here is that a name must identify the build a user
+  // actually gets, and Pro stopped having one: the CrofAI lane serves the
+  // undated `deepseek-v4-pro` snapshot while the direct lane serves 08/13, and
+  // which one answers depends on the hour (see the peak-window gating in
+  // deepseek-router.ts). "08/13" was true of only one of those, so it promised
+  // a build we may not hand over.
+  displayName: 'DeepSeek V4 Pro',
+  // No longer a superlative. Pro is not the recommendation — it is the
+  // expensive row that a user may still choose — so the tagline describes it
+  // instead of ranking it. "Smartest" read as a recommendation the rest of the
+  // catalog no longer makes.
+  tagline: 'Deep reasoning',
+  // ALWAYS, as of 2026-08-21 — and this is the direct consequence of the lane
+  // move, not an independent loosening. Pro was closed 00:00-10:00 UTC because
+  // "DeepSeek doubles every rate inside that window"; it is now served by
+  // Cheaper Inference on a FLAT card with no peak rate to hide from. Leaving it
+  // closed would have kept a ten-hour blackout whose only stated justification
+  // no longer applied to it.
+  //
+  // The window did not disappear — it moved to V4 Flash, which is still served
+  // by lanes that reprice at peak. Pro is what Flash's traffic is meant to land
+  // on there, which is why this row has to be open exactly when that one is
+  // shut. Change one and you must change the other.
   availability: 'always',
   warning: FREEBUFF_AI_TRAINING_NOTICE,
   dataUse: 'training',
@@ -645,30 +809,26 @@ const DEEPSEEK_V4_PRO_MODEL = {
   multimodal: false,
   // DeepSeek's own documented default (thinking on, effort high,
   // api-docs.deepseek.com/guides/thinking_mode), sent explicitly so a
-  // provider-side default change cannot silently move Freebuff. Unlike Flash,
-  // Pro has no fallback cascade — it is served on the direct lane only
-  // (deepseek-router.ts runs its lanes for Flash alone), so this is the one
-  // route the value has to be right for.
+  // provider-side default change cannot silently move Freebuff.
   reasoningEffort: 'high',
-  // The 08/13 build maps low to a real low template, so Pro now offers the same
+  // Low maps to a real low template on these builds, so Pro offers the same
   // three rungs as Flash. See DEEPSEEK_V4_REASONING_EFFORTS.
   efforts: DEEPSEEK_V4_REASONING_EFFORTS,
   defaultEffort: 'high',
-  // NOT superseded, and not de-emphasized (FREEBUFF_WEB_DEEMPHASIZED_MODEL_IDS)
-  // as of the 08/13 GA build. Pro carried a "V4 Flash performs better" notice
-  // from 2026-07-31, when the re-post-trained Flash-0731 beat the Pro PREVIEW on
-  // agent work. GA reversed that on exactly the benchmarks this product is:
-  // Terminal Bench 2.1 72.1 → 87.9, DeepSWE 12.8 → 62.7, CyberGym 52.7 → 83.3,
-  // DSBench-Hard 31.1 → 67.2, with 80.6% on SWE-bench Verified. Steering users
-  // off it would now be steering them off the stronger model.
+  // NO `supersededBy` as of 2026-08-21, and its removal is the point rather
+  // than housekeeping. This row carried "V4 Flash is what we recommend",
+  // steering users off Pro on COST — it read cache at $0.022/M off-peak and
+  // $0.044/M at peak, several times Flash, out of the same shared pool.
   //
-  // Pro is now the DEFAULT on every surface (DEFAULT_FREEBUFF_MODEL_ID for
-  // CLI/Desktop, DEFAULT_FREEBUFF_WEB_MODEL_ID for Web/Cloud). It is ~3x Flash's
-  // input and ~3x its output price and draws on the daily premium pool, which is
-  // why that was not automatic — but the pool is metered in SESSIONS, so leading
-  // with Pro moves nobody's quota, and the surfaces step down to
-  // FALLBACK_FREEBUFF_MODEL_ID (Flash) once a user's pool is spent.
-  isNew: true,
+  // Both halves of that argument inverted on the same day. Pro reads cache at
+  // $0.002538/M FLAT on its new lane, and Flash is now the row that closes at
+  // peak. Pointing Pro at Flash would send users to a model that is asleep for
+  // ten hours precisely when this one is their best option — and because
+  // `migrateSupersededFreebuffModelPreference` rewrites a SAVED pick on every
+  // load, it would do that silently and repeatedly. That exact failure is
+  // documented on MIMO_V25_MODEL; this is the same trap pointing the other way.
+  // No `isNew`. The badge exists to pull attention to a row, which is the
+  // opposite of what this one should do now.
 } as const satisfies FreebuffModelOption
 
 const MIMO_V25_MODEL = {
@@ -682,16 +842,23 @@ const MIMO_V25_MODEL = {
   // Xiaomi exposes only disabled and high (enabled) for MiMo 2.5. Since the
   // product has no separate thinking on/off control, there is no depth ladder
   // to render here; low/medium/max would merely be compatibility aliases.
-  // Same price as Flash and outclassed by it, so there is no cost argument to
-  // weigh — just a better model. Note this is the limited tier's other pick and
-  // its only natively-multimodal one; steering off it is only reasonable
-  // because Flash reads images through the describe pipeline on every surface
-  // (server/images/describe.ts, server/chat/image-context.ts).
-  supersededBy: {
-    modelId: FREEBUFF_DEEPSEEK_V4_FLASH_MODEL_ID,
-    notice: FLASH_SUPERSEDES_NOTICE,
-    actionLabel: 'Switch to V4 Flash',
-  },
+  // NOT superseded as of 2026-08-18, and the reason is the whole point of the
+  // pause. The pointer to Flash rested on "same price, strictly better model,
+  // so there is no cost argument to weigh". Flash costing a premium session
+  // ended that: MiMo is now the only UNLIMITED row and the target of
+  // FALLBACK_FREEBUFF_MODEL_ID, so this row is precisely where a user lands
+  // when their premium pool is spent.
+  //
+  // Two things went wrong while the pointer was still here, and both are worse
+  // than a stale nudge:
+  //  - `migrateSupersededFreebuffModelPreference` rewrites a SAVED pick on
+  //    every load, so a user who deliberately chose the unlimited model was
+  //    silently moved onto the premium one at each launch.
+  //  - The picker nagged "switch to V4 Flash" on the very row it had just
+  //    stepped a spent user down to — advice they cannot take until tomorrow.
+  //
+  // Restore it together with Flash leaving FREEBUFF_PREMIUM_MODEL_IDS, not
+  // before: the argument returns only when Flash is free again.
 } as const satisfies FreebuffModelOption
 
 const DEEPSEEK_V4_FLASH_MODEL = {
@@ -700,14 +867,43 @@ const DEEPSEEK_V4_FLASH_MODEL = {
   // date a returning user sees the same name and assumes the same model. The
   // 0731 GA build is a different, re-post-trained model.
   displayName: 'DeepSeek V4 Flash 07/31',
-  // Stepped down from "Smartest & Fastest" when Pro took the recommendation on
-  // 2026-08-12: two rows cannot both claim the top. Flash is still the fastest
-  // thing here and the only unlimited one, which "Smart & Fast" keeps.
+  // "Smart & Fast" survived Flash becoming premium on 2026-08-18: it describes
+  // the model, and the one word in it that described the TIER ("unlimited") had
+  // already gone when Pro took the recommendation on 2026-08-12. The picker
+  // renders the premium group heading, so the tagline does not have to.
   tagline: 'Smart & Fast',
-  availability: 'always',
+  // CLOSED 00:00-10:00 UTC (5pm-3am Pacific) as of 2026-08-21, inheriting the
+  // window V4 Pro used to hold — see DEEPSEEK_EXPENSIVE_WINDOW_UTC. Flash is
+  // still served by lanes that double at peak while Pro moved to a flat card,
+  // so the row worth closing is now this one. The hour of lead-in is built into
+  // that window and matters for the same reason it always did: a session
+  // admitted just before peak keeps its model for a full hour.
+  //
+  // This row is DEFAULT_FREEBUFF_MODEL_ID, so closing it is a bigger deal than
+  // closing Pro was — a new user landing during the window gets the fallback
+  // below rather than the recommendation. That is the trade being made
+  // deliberately: ten hours on a cheap flat lane beats ten hours on a doubled
+  // one.
+  availability: 'off_peak_only',
+  // Peak traffic lands on V4 Pro, not on the unlimited row. Closing Flash is
+  // only worth doing if what replaces it is the cheaper model rather than the
+  // weaker one, and Pro is `availability: 'always'` precisely so it can take
+  // this. Both rows are premium, so a user redirected here spends the same
+  // pool they would have spent anyway.
+  unavailableFallback: FREEBUFF_DEEPSEEK_V4_PRO_MODEL_ID,
   warning: FREEBUFF_AI_TRAINING_NOTICE,
   dataUse: 'training',
-  premium: false,
+  // TEMPORARY (2026-08-18). Flash was the unlimited model every free account
+  // could run without touching the daily pool. It is metered by that pool now
+  // because it became the single largest driver of free-mode spend — the whole
+  // of DeepSeek's peak-hour repricing lands on it, and it carries far more
+  // traffic than any premium row. Unlimited is MiMo 2.5 while this holds.
+  //
+  // Reverting is this flag, its entry in FREEBUFF_PREMIUM_MODEL_IDS, and the
+  // FALLBACK_FREEBUFF_MODEL_ID / DEFAULT_FREEBUFF_MODEL_ID pair — all four move
+  // together or the catalog contradicts itself. See FREEBUFF_TIER_CHANGE_NOTICE
+  // for the copy that has to come down with them.
+  premium: true,
   multimodal: false,
   reasoningEffort: 'high',
   // The 07/31 build has native low/high/max prompt templates. Medium is not a
@@ -785,18 +981,23 @@ const MINIMAX_M3_MODEL = {
   dataUse: 'service',
   // M3 is served by Fireworks without provider-side training. Its `service`
   // data-use classification keeps it out of FREEBUFF_TRACED_MODEL_IDS.
+  // WITHDRAWN 2026-08-20 (FREEBUFF_PAUSED_FREE_MODEL_IDS). The row is kept
+  // here, not deleted: a paused model has to stay in SUPPORTED so the server
+  // still recognises the id and can coerce it. `premium` is now moot — nothing
+  // reaches a pool through a model that never survives admission — but it stays
+  // true so that restoring the row is one edit to the paused list rather than
+  // two that must agree.
   premium: true,
   multimodal: true,
   // MiniMax M3 supports adaptive thinking or disabled thinking, but no effort
   // levels. A depth picker would therefore be cosmetic.
-  // Flash overtook M3 on quality and is free rather than premium-pooled. M3
-  // stays selectable — it is still the no-AI-training pick and natively
-  // multimodal — but the picker says Flash is the better default.
-  supersededBy: {
-    modelId: FREEBUFF_DEEPSEEK_V4_FLASH_MODEL_ID,
-    notice: FLASH_SUPERSEDES_NOTICE,
-    actionLabel: 'Switch to V4 Flash',
-  },
+  // NO `supersededBy`. This was the last supersedes notice in the catalog and
+  // it went on 2026-08-21 with the rest: the picker no longer nudges anyone
+  // anywhere. Its claim had also expired twice over — it pointed at Flash as
+  // "free rather than premium-pooled" (Flash became premium on 2026-08-18) and
+  // as the better default (Flash now closes for ten hours a day). A nudge that
+  // survives the argument it was making is worse than none, because
+  // migrateSupersededFreebuffModelPreference acts on it silently.
 } as const satisfies FreebuffModelOption
 
 const GPT_5_6_LUNA_MODEL = {
@@ -829,11 +1030,6 @@ const GPT_5_6_LUNA_MODEL = {
   // dominate agent traffic, and dearer on fresh input and output (full table on
   // that constant). Steering on quality is honest; implying a settled price
   // difference in either direction would not be.
-  supersededBy: {
-    modelId: FREEBUFF_DEEPSEEK_V4_PRO_MODEL_ID,
-    notice: PRO_SUPERSEDES_NOTICE,
-    actionLabel: 'Switch to V4 Pro',
-  },
 } as const satisfies FreebuffModelOption
 
 const GLM_V52_MODEL = {
@@ -899,7 +1095,7 @@ const FABLE_5_MODEL = {
   // Not in FREEBUFF_PREMIUM_MODEL_IDS: the daily premium pool is shared across
   // its models and Fable is metered by its OWN global pool instead (see
   // FREEBUFF_LIMITED_OFFER_MODEL_IDS). The flag only marks it as scarce for the
-  // pickers' styling and for FREEBUFF_WEB_STANDARD_MODEL_IDS, which must not
+  // pickers' styling and for FREEBUFF_STANDARD_MODEL_IDS, which must not
   // absorb it.
   premium: true,
   multimodal: true,
@@ -937,6 +1133,61 @@ const MUSE_SPARK_12_CONTRIBUTOR_MODEL = {
   defaultEffort: FREEBUFF_MUSE_SPARK_REASONING_EFFORT,
 } as const satisfies FreebuffModelOption
 
+/**
+ * The Ox Alpha picker row. STANDARD rather than premium — metered by no session
+ * pool on any surface, which is what `!premium` means here
+ * (FREEBUFF_STANDARD_MODEL_IDS is derived by filtering on it).
+ *
+ * That is a reading of a $0 price and a measured ceiling, not an oversight of
+ * the rule the premium lists keep repeating. There is nothing to ration: the
+ * model costs nothing and the fence keeps it that way
+ * (FREEBUFF_OX_ALPHA_MAX_PRICE), and its host absorbed 300 concurrent requests,
+ * ~99k prompt tokens/sec and 1,800 requests at a sustained 10/s without a
+ * single 429 (docs/freebuff-ox-alpha.md). What a pool would really ration is
+ * our standing with that host, and no number in this file can tell us where
+ * that limit is — serving the model and watching it can, which is what the two
+ * browser surfaces are for here.
+ *
+ * `experimental` is doing real work on this row rather than decorating it. An
+ * anonymous host can reprice, rename or withdraw a stealth model with no
+ * notice, so the TEST badge is the only promise about it we can actually keep.
+ */
+const OX_ALPHA_MODEL = {
+  id: FREEBUFF_OX_ALPHA_MODEL_ID,
+  displayName: 'Ox Alpha',
+  // Names the property a user picks this row FOR. "Free" would not distinguish
+  // it — every row in this catalog is free to the user — and naming the host
+  // is impossible, which is the whole point of a stealth model.
+  tagline: '1M context',
+  availability: 'always',
+  // NOT the AI-training notice, and the gap between the two is the point. The
+  // stealth terms say the host keeps prompts and completions and does not train
+  // on them, so `dataUse` stays 'service' — that field is what
+  // FREEBUFF_TRACED_MODEL_IDS keys off, and claiming a training grant we were
+  // not given would be wrong in the direction that changes behavior. The
+  // warning still says the thing a user wants before pasting a private repo
+  // into a provider whose name nobody will tell them.
+  //
+  // NOTE this is the one row where a warning does not imply `dataUse:
+  // 'training'`. The invariant test asserting they move together scopes itself
+  // to SUPPORTED_FREEBUFF_MODELS (the CLI/Desktop catalog), which this is
+  // deliberately not in; ox-alpha.test.ts pins the exception so it reads as a
+  // decision rather than as drift.
+  warning: 'Anonymous provider retains prompts',
+  dataUse: 'service',
+  premium: false,
+  // text + image + video in, text out.
+  multimodal: true,
+  // See FREEBUFF_OX_ALPHA_MODEL_ID for the measurement behind this. The
+  // provider's own default is `max`, which is 4x the tokens and 4x the latency
+  // of `high` for no better answer.
+  reasoningEffort: 'high',
+  efforts: OX_ALPHA_REASONING_EFFORTS,
+  defaultEffort: 'high',
+  experimental: true,
+  isNew: true,
+} as const satisfies FreebuffModelOption
+
 export const SUPPORTED_FREEBUFF_MODELS = [
   DEEPSEEK_V4_PRO_MODEL,
   MINIMAX_M3_MODEL,
@@ -960,21 +1211,176 @@ export const SUPPORTED_FREEBUFF_MODELS = [
 // untouched.
 // Order is the order shown in every picker: the recommended default leads, the
 // unlimited fallback it steps down to follows, then the rest of the full-access
-// grid. V4 Pro took the lead on 2026-08-12 (see DEFAULT_FREEBUFF_MODEL_ID); the
-// previous Flash-first order went stale with that flip.
+// grid.
+//
+// DeepSeek V4 Pro is PAUSED for free mode (2026-08-18) and left this list — the
+// row is gone from every picker. It stays in SUPPORTED_FREEBUFF_MODELS on
+// purpose: released clients hold their catalog in the binary and keep asking for
+// it, and an id the server does not RECOGNISE cannot be coerced, only refused.
+// Recognising it is what lets admission substitute (see
+// FREEBUFF_PAUSED_FREE_MODEL_IDS) instead of wedging those clients the way
+// #1801 wedged the limited tier.
 export const FREEBUFF_MODELS = [
+  // FIRST as of 2026-08-21, reversing the "last on purpose" placement it held
+  // while it was the expensive row. Pro now reads cache at $0.002538/M FLAT —
+  // the cheapest premium row we serve — and it is the row that stays open when
+  // V4 Flash closes for the ten-hour peak window. A model that is both the
+  // cheapest and the only one always available should not be the one a user has
+  // to scroll past.
+  //
+  // Ordering is now the ONLY steer in this list. The supersedes notices are all
+  // gone and nothing is badged RECOMMENDED, so position is what says "start
+  // here" — which means changing this order is a product decision, not a tidy-up.
   DEEPSEEK_V4_PRO_MODEL,
   DEEPSEEK_V4_FLASH_MODEL,
   GPT_5_6_LUNA_MODEL,
-  MINIMAX_M3_MODEL,
   ...(FREEBUFF_ENABLE_MIMO_MODELS_IN_UI ? [MIMO_V25_MODEL] : []),
 ] as const satisfies readonly FreebuffModelOption[]
 
+// Flash joined this list on 2026-08-18 (TEMPORARY — see
+// DEEPSEEK_V4_FLASH_MODEL.premium). Pro never left it for long: it was pulled
+// from the catalog entirely that day and restored on 2026-08-19, because both
+// monitoring its cost and routing its provider require it to serve traffic.
+// What changed instead is that nothing recommends it — see its supersededBy and
+// its place at the end of FREEBUFF_MODELS.
 export const FREEBUFF_PREMIUM_MODEL_IDS = [
-  FREEBUFF_MINIMAX_M3_MODEL_ID,
-  FREEBUFF_DEEPSEEK_V4_PRO_MODEL_ID,
+  FREEBUFF_DEEPSEEK_V4_FLASH_MODEL_ID,
   FREEBUFF_GPT_5_6_LUNA_MODEL_ID,
+  FREEBUFF_DEEPSEEK_V4_PRO_MODEL_ID,
 ] as const
+
+/**
+ * Per-user daily ceilings on INDIVIDUAL premium models, on top of — not instead
+ * of — the shared premium pool.
+ *
+ * A pool per entry, NOT one pool shared between them: two models capped at one
+ * session each is two sessions, and folding them together would silently halve
+ * both. The shared premium pool still meters every one of these as well, so a
+ * capped session costs a user their scarce allowance AND a premium unit.
+ *
+ * Why the expensive rows and not the cheap ones: five premium sessions spent
+ * entirely on V4 Pro and five spent on MiMo are the same number and wildly
+ * different bills. The pool counts sessions; only this expresses price. Flash
+ * is deliberately absent — it is the recommended default, and capping the model
+ * most users are steered onto would push them off the catalog's cheapest
+ * competent row after a single hour. Flash fills whatever the pool has left.
+ *
+ * A TABLE rather than a constant per model, because this is the lever that gets
+ * pulled under cost pressure and it should be one line to add a row, one number
+ * to change a limit, and nothing at all to change in a client — the label ships
+ * to installed CLIs and Desktops over the wire (see FreebuffSessionRateLimit).
+ */
+export const FREEBUFF_PER_MODEL_SESSION_CAPS: Readonly<
+  Record<string, { limit: number; pool: string; poolLabel: string }>
+> = {
+  // V4 Pro came out on 2026-08-21 and should stay out: it moved to a flat
+  // $0.002538/M cache read, which is the cheapest premium row we serve. Capping
+  // the cheap row is what the table exists NOT to do.
+  //
+  // Luna is capped at TWO — half the shared premium pool, not all of it — and
+  // the number is a comparison rather than a budget. At $0.008/M cache read it
+  // is ~3x Pro's, so a pool spent entirely on Luna costs several times the same
+  // pool spent on Pro. Two lets a user run it alongside the cheaper row instead
+  // of choosing between them, while a full four would make the expensive row
+  // the default way to spend the day.
+  //
+  // Anything added here is automatically a FIXED pool (no streak, referral or
+  // grant may raise it) and automatically counts ADMISSIONS rather than session
+  // units. The second is not optional — units floor at 0.1, so a unit-counted
+  // "2 a day" is really 20 a day. That was a real prod bug on 2026-08-20.
+  //
+  // Flash was never here and still should not be: it is the recommended
+  // default, and capping the row most users are steered onto would push them
+  // off the catalog's cheapest competent option after a single hour.
+  [FREEBUFF_GPT_5_6_LUNA_MODEL_ID]: {
+    limit: 2,
+    pool: 'luna',
+    poolLabel: 'Luna',
+  },
+}
+
+/** Whether `model` carries a ceiling of its own beyond the shared pool. */
+export function getFreebuffPerModelSessionCap(
+  model: string | null | undefined,
+): { limit: number; pool: string; poolLabel: string } | undefined {
+  if (!model) return undefined
+  return FREEBUFF_PER_MODEL_SESSION_CAPS[model]
+}
+
+export const FREEBUFF_DEEPSEEK_SESSION_PERIOD = FREEBUFF_PREMIUM_SESSION_PERIOD
+export const FREEBUFF_DEEPSEEK_SESSION_RESET_TIMEZONE =
+  FREEBUFF_PREMIUM_SESSION_RESET_TIMEZONE
+export const FREEBUFF_DEEPSEEK_SESSION_WINDOW_HOURS =
+  FREEBUFF_PREMIUM_SESSION_WINDOW_HOURS
+
+/**
+ * Models free mode no longer runs, but still RECOGNISES.
+ *
+ * This is not a picker-only retirement (FREEBUFF_WEB_RETIRED_PICKER_MODEL_IDS
+ * is that, and is deliberately empty) — nothing here is served to anyone. It is
+ * the opposite problem: a paused model must stay a known id so the server can
+ * SUBSTITUTE for it.
+ *
+ * An id dropped from SUPPORTED entirely is one `isFreebuffSessionModelId` says
+ * nothing about, so the coercion in `resolveFreebuffSessionModelForAccessTier`
+ * never runs and the request is simply refused. Every installed client holding
+ * that pick then retries forever, because the pick comes from the catalog
+ * compiled into its binary and no server change reaches it — measured at 2.5x
+ * admissions and 91% of sessions ending at the 0.1-unit floor when the limited
+ * tier hit exactly this on 2026-08-18 (#1801).
+ *
+ * So: out of every picker, out of every quota list, still recognised, and
+ * coerced to the tier's default at admission and at the session gate.
+ *
+ * EMPTY as of 2026-08-19. V4 Pro was the only entry, for one day, and came
+ * back because monitoring its cost and routing its provider both need it to
+ * serve traffic — it is de-recommended instead (see its supersededBy).
+ *
+ * The machinery stays. It is the tested answer to a question that keeps coming
+ * up under cost pressure, and the expensive way to learn it is the one already
+ * paid for in #1801: the coercion has to exist BEFORE a model is taken away,
+ * because the clients that need it are the ones already installed.
+ */
+export const FREEBUFF_PAUSED_FREE_MODEL_IDS: readonly string[] = [
+  // Withdrawn from free mode entirely on 2026-08-20. It reached $213/hr — the
+  // largest single line on the bill — and is not worth that at any tier.
+  //
+  // PAUSED rather than deleted, which is the difference between withdrawing a
+  // model and breaking the clients that still ask for it. Every released CLI and
+  // Desktop holds this id in its compiled-in catalog and will keep sending it;
+  // an id the server does not RECOGNISE cannot be coerced, only refused, and a
+  // refusal here is the retry loop that cost the limited tier 2.5x its
+  // admissions in #1801. Listed here it stays recognised, is coerced to the
+  // fallback at admission, and is served to nobody.
+  FREEBUFF_MINIMAX_M3_MODEL_ID,
+]
+
+/**
+ * What a caller asking for a withdrawn model is told.
+ *
+ * Names the model it asked for and what to use instead — the client that sends
+ * this id is a released binary whose picker still lists it, so "unavailable"
+ * alone leaves the user staring at a row that looks fine and does not work.
+ */
+export function freebuffWithdrawnModelMessage(id: string): string {
+  const model = SUPPORTED_FREEBUFF_MODELS.find((m) => m.id === id)
+  const name = model?.displayName ?? id
+  const replacement =
+    SUPPORTED_FREEBUFF_MODELS.find((m) => m.id === DEFAULT_FREEBUFF_MODEL_ID)
+      ?.displayName ?? DEFAULT_FREEBUFF_MODEL_ID
+  return `${name} is no longer available in Freebuff. We recommend using ${replacement} instead.`
+}
+
+/** Suffix-tolerant like the other model predicates, so a dated provider
+ *  snapshot of a paused model cannot slip past the pause. */
+export function isFreebuffPausedFreeModelId(
+  id: string | null | undefined,
+): boolean {
+  if (!id) return false
+  return FREEBUFF_PAUSED_FREE_MODEL_IDS.some((modelId) =>
+    freebuffModelIdMatches(id, modelId),
+  )
+}
 
 // ---------------------------------------------------------------------------
 // Limited-offer models
@@ -1034,6 +1440,10 @@ export const FREEBUFF_LIMITED_OFFER_SESSION_WINDOW_HOURS =
 /** Freebuff Web-only picker/support set: the CLI/Desktop catalog plus the
  *  earned GLM 5.2 row. */
 export const FREEBUFF_WEB_MODELS = [
+  // First because it is the row we are trying to put traffic on, and because
+  // being unmetered makes it the one a user can always reach. The TEST badge is
+  // what keeps that placement honest.
+  OX_ALPHA_MODEL,
   MUSE_SPARK_12_CONTRIBUTOR_MODEL,
   GLM_V52_MODEL,
   ...FREEBUFF_MODELS,
@@ -1094,20 +1504,32 @@ export function isFreebuffWebSelectableModelId(
 export const FREEBUFF_WEB_PREMIUM_MODEL_IDS = [
   ...FREEBUFF_PREMIUM_MODEL_IDS,
   // Metered by the web premium pool like every other god-only row. Being in
-  // SOME pool is the point: FREEBUFF_WEB_STANDARD_MODEL_IDS is derived by
+  // SOME pool is the point: FREEBUFF_STANDARD_MODEL_IDS is derived by
   // filtering `!premium`, so a premium model left out of here would be metered
   // by no pool at all rather than by a stricter one.
   FREEBUFF_KIMI_K3_ECO_MODEL_ID,
   // Not here for cost — Muse Spark Contributor is cheaper per token than the
   // Standard pool's models. The premium pool is what bounds how many users sit
   // inside its 60 RPM team-wide ceiling at once, and being in SOME pool is
-  // mandatory: FREEBUFF_WEB_STANDARD_MODEL_IDS is derived by filtering
+  // mandatory: FREEBUFF_STANDARD_MODEL_IDS is derived by filtering
   // `!premium`, so a premium model left out of here is metered by no pool.
   FREEBUFF_MUSE_SPARK_12_CONTRIBUTOR_MODEL_ID,
 ] as const
 
-/** Full-access Web/Cloud models sharing the browser-only standard daily pool. */
-export const FREEBUFF_WEB_STANDARD_MODEL_IDS = Object.freeze(
+/**
+ * Full-access models outside the premium and referral pools — i.e. the ones a
+ * full-access account may use without a session quota at all, on every
+ * surface.
+ *
+ * Derived by filtering `!premium` over the public catalog, which is why the
+ * premium lists above insist that every premium model appear in SOME pool: a
+ * premium model left out of them lands in here and becomes unlimited.
+ *
+ * Named `WEB_STANDARD` until 2026-08-18, when the browser-only session pool it
+ * was named after was removed; the list itself is unchanged and is now the
+ * catalog invariant several tests assert against.
+ */
+export const FREEBUFF_STANDARD_MODEL_IDS = Object.freeze(
   FREEBUFF_WEB_ALL_MODELS.filter((model) => !model.premium).map(
     (model) => model.id,
   ),
@@ -1181,6 +1603,13 @@ export const FREEBUFF_MODEL_HEADER = 'x-freebuff-model'
  *  the request authenticates as the Freebuff Web service account; browser and
  *  normal API callers must not be able to select another user's session row. */
 export const FREEBUFF_ACTING_USER_HEADER = 'x-freebuff-acting-user-id'
+/** Trusted server-to-server companion to the acting-user header: the Freebuff
+ *  Web/Cloud proxy sets it to '1' after verifying, server-side, that the
+ *  acting account holds the god/admin role on Freebuff Web. Like the
+ *  acting-user header it is honored only when the request authenticates as
+ *  the Freebuff Web service account; from any other caller it is ignored, so
+ *  forging it buys nothing. */
+export const FREEBUFF_PRIVILEGED_USER_HEADER = 'x-freebuff-privileged-user'
 /** Trusted Freebuff Web/Cloud session-proxy hint. Keeps the normal CLI GET
  * response compact while letting the browser model picker request zero-usage
  * quota snapshots so it can render accurate "N of M sessions" labels. */
@@ -1252,67 +1681,64 @@ export type FreebuffWebPremiumModelId =
   (typeof FREEBUFF_WEB_PREMIUM_MODEL_IDS)[number]
 
 /** What new freebuff users see selected in the CLI and Desktop pickers, and the
- *  model their "RECOMMENDED" hero opens on. DeepSeek V4 Pro 08/13 as of
- *  2026-08-12, taking over from DeepSeek V4 Flash, which held it from
- *  2026-07-31 when the re-post-trained Flash-0731 beat the Pro PREVIEW on agent
- *  work. The 08/13 GA build reversed that on the benchmarks a coding CLI runs
- *  (the numbers are on DEEPSEEK_V4_PRO_MODEL), so both surfaces now lead with
- *  it — as the browser ones already did (DEFAULT_FREEBUFF_WEB_MODEL_ID).
+ *  model their "RECOMMENDED" hero opens on. DeepSeek V4 Flash 07/31 as of
+ *  2026-08-18, taking back the lead it held until 2026-08-12, because V4 Pro —
+ *  which took it on the strength of the 08/13 GA build — is paused for free mode
+ *  (FREEBUFF_PAUSED_FREE_MODEL_IDS). Flash is the strongest row free mode still
+ *  runs, so it leads again by default rather than by re-argued merit.
  *
- *  It is PREMIUM, which the Flash default was not, so it draws on the shared
- *  daily pool and that pool CAN run dry. Surfaces that know the live quota must
- *  step down to FALLBACK_FREEBUFF_MODEL_ID once it is spent —
- *  getRecommendedFreebuffModelId does that for the picker hero, Desktop's
- *  availableFreebuffDefault for an unpicked tab — or the default becomes a
- *  model whose next send fails admission. Both kept that machinery from the
- *  pre-2026-07-31 premium default, so this is a flip, not new plumbing.
+ *  It is PREMIUM as of the same day, which it was NOT the last time it held this
+ *  slot, so the machinery below is now load-bearing for it too: the shared daily
+ *  pool CAN run dry, and surfaces that know the live quota must step down to
+ *  FALLBACK_FREEBUFF_MODEL_ID once it is spent — getRecommendedFreebuffModelId
+ *  for the picker hero, Desktop's availableFreebuffDefault for an unpicked tab —
+ *  or the default becomes a model whose next send fails admission.
  *
  *  Still three separate constants: this one, DEFAULT_FREEBUFF_WEB_MODEL_ID and
  *  FALLBACK_FREEBUFF_MODEL_ID (what callers needing a guaranteed-available id
  *  for resolution / auto-fallbacks should use). The first two name the same
- *  model today and have diverged before; the third is now genuinely a different
+ *  model today and have diverged before; the third is genuinely a different
  *  model rather than the same one under two names.
  *
- *  It carries the AI-training notice like the Flash default did, so pickers
- *  using it must render the model's `warning`. */
+ *  It carries the AI-training notice, so pickers using it must render the
+ *  model's `warning`. */
 export const DEFAULT_FREEBUFF_MODEL_ID: FreebuffModelId =
   FREEBUFF_DEEPSEEK_V4_PRO_MODEL_ID
 
 /** What new Freebuff Web/Cloud users see selected in the browser pickers, and
- *  the model a new Cloud thread starts on. DeepSeek V4 Pro 08/13 as of
- *  2026-08-12, taking over from GPT-5.6 Luna (which held it from 2026-08-04).
+ *  the model a new Cloud thread starts on. DeepSeek V4 Pro as of 2026-08-21.
  *
- *  A browser build is the workload where model quality shows up most — it is
- *  one long agentic run against a live sandbox, and a wrong turn early costs
- *  the whole first project, which 51% of Web users never come back from. The
- *  Pro 08/13 GA build is the strongest agentic model in this catalog, which is
- *  what that workload is, so it leads the browser surfaces and Luna carries a
- *  switch-to-Pro notice (see GPT_5_6_LUNA_MODEL.supersededBy).
+ *  A STARTING POSITION, not an endorsement — nothing in the catalog is badged
+ *  RECOMMENDED any more. It is Pro because a default has to be joinable and Pro
+ *  is the only premium row open at every hour: V4 Flash now closes for the
+ *  ten-hour peak window, and a default that is unavailable for part of every
+ *  day is a default that fails admission for the users least able to diagnose
+ *  it.
  *
- *  ONE KNOWN COST OF THIS CHOICE, deliberate rather than overlooked: Pro is
- *  `dataUse: 'training'` while Luna was `service`, so the model a brand-new user
- *  lands on now DOES carry the AI-training notice. Every picker already renders
- *  `warning` for the default, so it is disclosed — but it is a real change to
- *  what a first-time user sees.
+ *  A browser build is the workload where model quality shows up most: one long
+ *  agentic run against a live sandbox, where a wrong turn early costs the whole
+ *  first project, which 51% of Web users never come back from. That argument
+ *  picked Pro and it has not changed — Pro is simply not available to spend on
+ *  right now, so this falls to the strongest row free mode still runs.
  *
- *  Spend is NOT among the costs, which is why this is not the extravagant choice
- *  it looks like next to Luna's headline $0.10 input: browser turns re-send their
- *  whole prefix every step, so cache reads are ~98% of the tokens, and Pro reads
- *  cache at $0.003625/M against Luna's $0.010/M. See
- *  FREEBUFF_WEB_DEEMPHASIZED_MODEL_IDS for the full table and where the
- *  break-even sits. Either way the daily premium pool is counted in SESSIONS, so
- *  nobody's quota moves.
+ *  The cost half had ALREADY collapsed before the pause, which is why this is a
+ *  smaller loss than it looks. Browser turns re-send their whole prefix every
+ *  step, so cache reads are ~98% of tokens; Pro read cache at $0.003625/M
+ *  against Luna's $0.010/M until DeepSeek's 16:00 UTC 2026-08-16 repricing put
+ *  it at $0.022/M off-peak and $0.044/M at peak — 2.2x to 4.4x DEARER than Luna
+ *  on the dominant term, on top of fresh input and output. See
+ *  FREEBUFF_WEB_DEEMPHASIZED_MODEL_IDS for the table.
  *
- *  It is premium, so it draws on the shared daily pool. Surfaces that know the
- *  live quota must step down to FALLBACK_FREEBUFF_MODEL_ID once that pool is
- *  spent (getRecommendedFreebuffWebModelId does this for the hero picker, and
- *  the model selector coerces a spent default) — otherwise the default becomes
- *  a model whose next send fails admission.
+ *  Flash keeps the AI-training notice Pro carried, so the disclosure a
+ *  first-time user sees is unchanged. It is premium as of 2026-08-18, so it
+ *  still draws on the shared daily pool and the step-down to
+ *  FALLBACK_FREEBUFF_MODEL_ID stays load-bearing (getRecommendedFreebuffWebModelId
+ *  for the hero picker; the model selector coerces a spent default) — otherwise
+ *  the default becomes a model whose next send fails admission.
  *
  *  Kept as its own constant from DEFAULT_FREEBUFF_MODEL_ID (CLI/Desktop) so the
- *  browser surfaces can steer independently. They name the same model as of
- *  2026-08-12, and diverged as recently as 2026-08-04 → 2026-08-12 (Flash on
- *  the CLI, Luna in the browser). */
+ *  browser surfaces can steer independently. They name the same model today and
+ *  diverged as recently as 2026-08-04 → 2026-08-12. */
 export const DEFAULT_FREEBUFF_WEB_MODEL_ID: FreebuffWebModelId =
   FREEBUFF_DEEPSEEK_V4_PRO_MODEL_ID
 
@@ -1335,20 +1761,27 @@ export const DEFAULT_FREEBUFF_WEB_MODEL_ID: FreebuffWebModelId =
  *  Muting only pays for itself on a group of rows, so add entries back in
  *  pairs or not at all.
  *
- *  GPT-5.6 Luna is superseded (by Pro) and deliberately NOT muted, because the
- *  cost half genuinely does not resolve. Per M, read off OpenRouter 2026-08-12:
+ *  GPT-5.6 Luna is superseded (by Pro) and deliberately NOT muted. The cost
+ *  half of that call used to be genuinely unresolvable; DeepSeek's 16:00 UTC
+ *  2026-08-16 repricing resolved it the other way. Per M — Luna read off
+ *  OpenRouter 2026-08-12, Pro from DeepSeek's published card:
  *
- *                fresh input   cache read   output
- *    V4 Pro         $0.435      $0.003625   $0.870
- *    Luna           $0.100      $0.010      $0.600
+ *                    fresh input   cache read   output
+ *    V4 Pro off-peak    $0.660       $0.022      $1.980
+ *    V4 Pro peak        $1.320       $0.044      $3.960
+ *    Luna               $0.100       $0.010      $0.600
  *
- *  Pro is 2.76x CHEAPER on cache reads — the term that dominates an agent
- *  workload, where re-sent prefixes are ~98% of tokens — while being 4.35x
- *  dearer on fresh input and 1.45x dearer on output. Break-even on the input
- *  term alone is a ~98.1% cache-hit rate, so which model is cheaper depends on
- *  the hit rate and on how output-heavy the traffic is. "Materially more
- *  expensive" is a claim neither row can carry, and muting is reserved for rows
- *  that clearly can. */
+ *  Pro was 2.76x cheaper than Luna on cache reads — the term that dominates an
+ *  agent workload, where re-sent prefixes are ~98% of tokens. It is now 2.2x
+ *  dearer off-peak and 4.4x dearer at peak, and it was already dearer on fresh
+ *  input and output. So Pro is now dearer than Luna on every term in every
+ *  window, and "materially more expensive" is a claim that has moved onto the
+ *  OTHER row.
+ *
+ *  This list is still EMPTY and Pro is still the Web default — muting is a
+ *  product-steering decision and the repricing alone should not silently flip
+ *  it. But the numbers that justified both no longer say what they said; this
+ *  is the note for whoever revisits it. */
 export const FREEBUFF_WEB_DEEMPHASIZED_MODEL_IDS: readonly FreebuffModelId[] =
   []
 
@@ -1362,17 +1795,40 @@ export function isFreebuffWebDeemphasizedModelId(
 }
 
 /** Always-available fallback used when the requested model can't be served
- *  right now (unknown id, deployment hours closed, etc.). Kept distinct from
- *  DEFAULT_FREEBUFF_MODEL_ID so a new user's "preferred default" can be the
- *  smartest model without auto-flipping anyone to a closed serverless model. */
+ *  right now (unknown id, deployment hours closed, premium pool spent). Kept
+ *  distinct from DEFAULT_FREEBUFF_MODEL_ID so a new user's "preferred default"
+ *  can be the smartest model without auto-flipping anyone to a closed
+ *  serverless model.
+ *
+ *  MUST BE NON-PREMIUM. This is the id every surface steps down TO when the
+ *  daily premium pool runs dry, so a premium value here is a step-down onto a
+ *  model that fails admission for exactly the user it was meant to rescue — a
+ *  loop, not a fallback. That is why it moved off Flash on 2026-08-18 the same
+ *  hour Flash became premium: the two edits are one change, and restoring
+ *  either alone re-creates the loop.
+ *
+ *  MiMo 2.5 is now the only unlimited row in the catalog, so it is both this
+ *  fallback and LIMITED_FREEBUFF_MODEL_ID. Those coinciding is a consequence of
+ *  the pause, not a rule — keep them separate constants. */
 export const FALLBACK_FREEBUFF_MODEL_ID: FreebuffModelId =
-  FREEBUFF_DEEPSEEK_V4_FLASH_MODEL_ID
+  FREEBUFF_MIMO_V25_MODEL_ID
 
+/**
+ * The limited tier's catalog, and the model an out-of-tier or stale pick is
+ * coerced to. MiMo 2.5 alone since 2026-08-18: DeepSeek V4 Flash 07/31 was this
+ * tier's default until DeepSeek repriced the V4 family on 2026-08-16 (see
+ * DEEPSEEK_V4_PRO_MODEL), and it is the tier's highest-volume model, so pausing
+ * it here is what keeps these sessions free.
+ *
+ * A PAUSE, NOT A RETIREMENT. Flash stays in SUPPORTED_FREEBUFF_MODELS,
+ * FREEBUFF_MODELS and FALLBACK_FREEBUFF_MODEL_ID, so full access is unaffected
+ * and restoring it is re-adding the id here (and to
+ * FREEBUFF_WEB_GEO_EXEMPT_MODEL_IDS) plus dropping
+ * FREEBUFF_PAUSED_MODEL_NOTICE from the pickers.
+ */
 export const LIMITED_FREEBUFF_MODEL_ID: FreebuffModelId =
   FREEBUFF_MIMO_V25_MODEL_ID
-export const LIMITED_FREEBUFF_MODEL_IDS = [
-  FREEBUFF_MIMO_V25_MODEL_ID,
-] as const
+export const LIMITED_FREEBUFF_MODEL_IDS = [FREEBUFF_MIMO_V25_MODEL_ID] as const
 export const LIMITED_FREEBUFF_MODELS = LIMITED_FREEBUFF_MODEL_IDS.map(
   (modelId) => SUPPORTED_FREEBUFF_MODELS.find((model) => model.id === modelId)!,
 )
@@ -1415,7 +1871,29 @@ export const FREEBUFF_MAX_CONCURRENT_PROJECTS = 1
  *  runtime) mints its own project row, so a couple of failed first builds
  *  locked someone out for the day with nothing to show for it. 10 is high
  *  enough that only automation reaches it. */
-export const FREEBUFF_WEB_LIMITED_PROJECT_DAILY_LIMIT = 10
+/** Per-day cap on new Web projects a user may create, in EVERY region.
+ *
+ *  Was 10 and limited-region only until 2026-08-19, when the Daytona US quota
+ *  saturated (498/500 vCPU, 996/1000 GiB). Measured against a full day of
+ *  traffic at the time — 1,893 user-owned creations across 1,484 users, mean
+ *  1.3 — a cap of 5 would have blocked 41 creations (2.2%) across 11 users,
+ *  and the single heaviest account created 14. So this bounds the worst case
+ *  rather than reclaiming capacity; the routing change that moved
+ *  limited-region desktops to Nodepod is what actually moved the number.
+ *
+ *  Override per deployment with FREEBUFF_WEB_PROJECT_DAILY_LIMIT. */
+export const FREEBUFF_WEB_PROJECT_DAILY_LIMIT = 5
+
+/** How many of a user's sandboxes may be running at once. A sandbox counts as
+ *  open while its project has an agent run in flight or has proven presence
+ *  inside Daytona's 10-minute auto-stop window.
+ *
+ *  Set to the highest concurrency any single account was actually observed
+ *  holding on 2026-08-19 (2, across just 12 of ~1,485 daily-active owners), so
+ *  it binds nobody today and only stops that number growing.
+ *
+ *  Override per deployment with FREEBUFF_WEB_MAX_OPEN_SANDBOXES. */
+export const FREEBUFF_WEB_MAX_OPEN_SANDBOXES = 2
 
 /** Per-day cap on blank ("plan a custom stack") Cloud projects, which unlike
  *  connect-repo need no GitHub App install and each boot a full-size VM. Same
@@ -1440,10 +1918,25 @@ export const FREEBUFF_CLOUD_BLANK_PROJECT_DAILY_LIMIT = 10
 export const FREEBUFF_CLOUD_PLANNER_TURN_LIMIT = 12
 
 /** Models available to limited-region Freebuff Web users. They share the
- * limited-region session pool; every other model remains geo-gated. */
+ * limited-region session pool; every other model remains geo-gated.
+ *
+ * Flash left this list with LIMITED_FREEBUFF_MODEL_IDS — restore it in both or
+ * neither, since FREEBUFF_WEB_LIMITED_MODEL_IDS is the union of the two.
+ *
+ * Ox Alpha is the first entry that is here and NOT in
+ * LIMITED_FREEBUFF_MODEL_IDS, and the split is the point rather than an
+ * oversight: that list is the CLI/Desktop limited catalog (it maps over
+ * SUPPORTED_FREEBUFF_MODELS and reaches the CLI picker, the home FAQ and the
+ * README), while this one is the browser surfaces'. A Web/Cloud-only model can
+ * therefore reach limited regions without appearing anywhere it cannot run.
+ *
+ * Being here costs the limited tier nothing extra. That tier is metered by
+ * REGION, not by model — every limited session draws on the same
+ * FREEBUFF_LIMITED_SESSION_LIMIT pool whichever row it picks — so this widens
+ * what those users can choose without widening how much they get. */
 export const FREEBUFF_WEB_GEO_EXEMPT_MODEL_IDS = [
-  FREEBUFF_DEEPSEEK_V4_FLASH_MODEL_ID,
   FREEBUFF_MIMO_V25_MODEL_ID,
+  FREEBUFF_OX_ALPHA_MODEL_ID,
 ] as const
 
 export function isFreebuffWebGeoExemptModelId(
@@ -1477,7 +1970,8 @@ export function isFreebuffWebModelAllowedForLimitedTier(
 }
 
 /** Coerce a limited-tier Freebuff Web selection (premium ids, stale
- * localStorage values) to the allowed default (DeepSeek V4 Flash). */
+ * localStorage values — including a Flash pick saved before that model was
+ * paused for this tier) to LIMITED_FREEBUFF_MODEL_ID. */
 export function resolveFreebuffWebModelForLimitedTier(
   id: string | null | undefined,
 ): string {
@@ -1496,7 +1990,7 @@ export function getFreebuffModelsForAccessTier(
 /** The model the CLI/Desktop picker highlights as the "recommended" hero so a
  *  new user can start with one Enter press without scanning the full list. Full
  *  access → DEFAULT_FREEBUFF_MODEL_ID (DeepSeek V4 Pro 08/13 — the strongest
- *  agentic model in the catalog); limited → the always-available flash model.
+ *  agentic model in the catalog); limited → LIMITED_FREEBUFF_MODEL_ID.
  *
  *  Pro is premium, so ALWAYS pass `premiumExhausted` from the live quota
  *  snapshot: the hero flips to the unlimited DeepSeek Flash once the daily pool
@@ -1512,8 +2006,8 @@ export function getRecommendedFreebuffModelId(
 }
 
 /** The Web/Cloud counterpart of getRecommendedFreebuffModelId: full access →
- *  DEFAULT_FREEBUFF_WEB_MODEL_ID (GPT-5.6 Luna); limited → the
- *  always-available flash model. `premiumExhausted` flips the hero to the
+ *  DEFAULT_FREEBUFF_WEB_MODEL_ID (GPT-5.6 Luna); limited →
+ *  LIMITED_FREEBUFF_MODEL_ID. `premiumExhausted` flips the hero to the
  *  unlimited flash model so the recommended pick is always joinable. */
 export function getRecommendedFreebuffWebModelId(
   accessTier: FreebuffAccessTier | null | undefined,
@@ -1578,12 +2072,29 @@ export function isFreebuffSessionModelAllowedForAccessTier(
   accessTier: FreebuffAccessTier | null | undefined,
 ): boolean {
   if (!model) return false
+  // A paused model is allowed to NO tier. Checked ahead of everything else
+  // because the pause is the whole point: it is still a recognised session id
+  // (see FREEBUFF_PAUSED_FREE_MODEL_IDS), so every other branch here would
+  // happily admit it.
+  if (isFreebuffPausedFreeModelId(model)) return false
   if (accessTier !== 'limited') return isFreebuffSessionModelId(model)
   // See isGlmRedeemableAtLimitedTier: GLM's limited-tier gate is the quota
   // pool (bounty grants only), not this allowlist.
+  //
+  // The UNION of both limited catalogs, for the same reason the full-access
+  // branch above takes the union of both full catalogs: session admission is
+  // shared by CLI, Desktop, Web and Cloud, so it must accept every row ANY of
+  // them may legitimately offer. Reading only the CLI/Desktop list
+  // (LIMITED_FREEBUFF_MODEL_IDS) is what it did until Ox Alpha, which was
+  // harmless only while the two lists happened to agree — the moment a
+  // browser-only row reaches limited regions, that version offers a picker row
+  // whose first send fails admission with session_model_mismatch.
+  //
+  // Widening WHAT a limited user may pick, not how much: the limited pool is
+  // keyed on the tier rather than the model.
   return (
     isGlmRedeemableAtLimitedTier(model) ||
-    LIMITED_FREEBUFF_MODEL_IDS.some((modelId) => modelId === model)
+    FREEBUFF_WEB_LIMITED_MODEL_IDS.some((modelId) => modelId === model)
   )
 }
 
@@ -1666,6 +2177,12 @@ export function resolveFreebuffSessionModelForAccessTier(
       ? (id as SupportedFreebuffModelId)
       : LIMITED_FREEBUFF_MODEL_ID
   }
+  // NOTE: a withdrawn model does NOT resolve here. It used to coerce silently
+  // to the fallback, which kept clients running but left a user who picked it
+  // watching a different model answer with no explanation. Admission now
+  // REFUSES it with `model_unavailable` and a message naming the replacement
+  // (see freebuffWithdrawnModelMessage). That refusal is deliberately not
+  // session-ending, so the client shows the message instead of re-admitting.
   if (isSupportedFreebuffModelId(id)) return id
   return resolveFreebuffWebModel(id, {
     includeGodOnly: options.includeGodOnly ?? true,
@@ -1774,6 +2291,63 @@ export function isFreebuffGpt56LunaModelId(
   id: string | null | undefined,
 ): boolean {
   return freebuffModelIdMatches(id, FREEBUFF_GPT_5_6_LUNA_MODEL_ID)
+}
+
+/**
+ * Models that may ONLY be served to the Freebuff Web service account — i.e. to
+ * turns issued by the Freebuff Web / Cloud runner itself, never to a caller
+ * holding an ordinary API key.
+ *
+ * This is the surface gate with teeth. Every other thing that keeps a model off
+ * a surface is a client-side fact: a model absent from FREEBUFF_MODELS is one
+ * no shipped CLI build renders, which stops our users and nobody else. A
+ * hand-written caller posts whatever agent id and model id it likes, and the
+ * free-mode allowlist happily confirms that `base3-free-ox-alpha` may run Ox
+ * Alpha — because it may, when WE are the ones asking.
+ *
+ * The service account is the one claim in a free-mode request that cannot be
+ * forged. `codebuff_metadata.surface` is self-reported and is ignored for
+ * everyone else precisely because it is (see docs/unified-usage-tracking.md);
+ * the API key that authenticates the runner is held server-side. So "Web and
+ * Cloud only" is expressed as "authenticated as the runner", which is the same
+ * statement made in the only terms an attacker cannot restate.
+ *
+ * ONLY OX ALPHA IS LISTED, deliberately. Muse Spark and Kimi K3 Eco are also
+ * browser-only and would also pass this gate in normal operation, but they are
+ * metered by the premium pool, so a third-party caller reaching one spends a
+ * quota that runs out. Ox Alpha is metered by NOTHING and costs nothing to
+ * serve, which makes it the single most attractive target in the catalog for a
+ * reselling proxy — the one row where "they can only take four sessions a day"
+ * is not a backstop. Add the others here too if that ever stops being the
+ * distinction; the check is per-model on purpose.
+ *
+ * Enforced in web/src/app/api/v1/chat/completions/_post.ts, next to the
+ * free-mode agent+model allowlist. That is where inference is actually spent,
+ * so a caller who somehow admits a session still cannot run a single turn on it.
+ */
+export const FREEBUFF_SERVICE_ONLY_MODEL_IDS = [
+  FREEBUFF_OX_ALPHA_MODEL_ID,
+] as const
+
+/** Whether `id` may only be served to the Freebuff Web service account. Matches
+ *  dated builds for the same reason the price fence does: a variant that slips
+ *  past this predicate is the same model with the gate off. */
+export function isFreebuffServiceOnlyModelId(
+  id: string | null | undefined,
+): boolean {
+  return FREEBUFF_SERVICE_ONLY_MODEL_IDS.some((modelId) =>
+    freebuffModelIdMatches(id, modelId),
+  )
+}
+
+/** Whether `id` names Ox Alpha, including any dated build of it. Consumed by
+ *  the OpenRouter lane, which attaches the zero-price fence to exactly these
+ *  requests — a dated variant that slipped past this predicate would be the
+ *  same model with no fence on it. */
+export function isFreebuffOxAlphaModelId(
+  id: string | null | undefined,
+): boolean {
+  return freebuffModelIdMatches(id, FREEBUFF_OX_ALPHA_MODEL_ID)
 }
 
 /** The catalog's reasoning effort for the requested model, tolerating dated
@@ -2002,6 +2576,40 @@ export function getFreebuffModelSupersededBy(
 }
 
 /**
+ * Why a row cannot be picked right now, in the reader's own clock — or
+ * undefined when it can.
+ *
+ * The pickers had a label for deployment hours and nothing for anything else,
+ * so a model closed for any OTHER reason looked completely normal: selectable,
+ * checkmarked, and refused only at send time. That is exactly what V4 Pro's
+ * peak-hour window did — correctly closed at 2am Pacific and indistinguishable
+ * from open.
+ *
+ * LOCAL TIME is the whole point. DeepSeek publishes its peak in UTC, so the
+ * window a user lives in (5pm-3am Pacific) shares no digits with the one we
+ * store. "Closed 00:00-10:00 UTC" asks someone at 2am to do timezone
+ * arithmetic before they can tell whether the product is broken.
+ */
+export function getFreebuffModelUnavailableLabel(
+  id: string,
+  now: Date = new Date(),
+  options: LocalTimeFormatOptions = {},
+): string | undefined {
+  if (isFreebuffSessionModelAvailable(id, now)) return undefined
+  const model =
+    SUPPORTED_FREEBUFF_MODELS.find((candidate) => candidate.id === id) ??
+    getFreebuffWebModel(id)
+  if (model.availability === 'off_peak_only') {
+    return `Back at ${formatLocalTime(
+      deepSeekExpensiveWindowEndsAt(now),
+      now,
+      options,
+    )}`
+  }
+  return getFreebuffDeploymentAvailabilityLabel(now, options)
+}
+
+/**
  * The model a saved preference should be steered to, or null to keep it.
  *
  * Applied EVERY time a surface reads its remembered pick, so each new
@@ -2101,7 +2709,30 @@ export function isFreebuffModelAvailable(
 ): boolean {
   const model = SUPPORTED_FREEBUFF_MODELS.find((m) => m.id === id)
   if (!model) return false
-  return model.availability === 'always' || isFreebuffDeploymentHours(now)
+  return isAvailableAt(model.availability, now)
+}
+
+/**
+ * The ONE reading of `availability`, shared by the picker's joinability check
+ * and the server's admission check.
+ *
+ * They were separate, and the picker's copy only knew 'always' and deployment
+ * hours — so `off_peak_only` fell through to a window that has nothing to do
+ * with it. That was right only by coincidence: DeepSeek's peak and our staffing
+ * hours happen to overlap at some times of day and not others, so V4 Pro would
+ * have shown as pickable during the expensive window whenever the two disagreed,
+ * and been refused on send.
+ *
+ * A picker that can disagree with admission is worse than one that is simply
+ * wrong, because the disagreement only surfaces after the user commits.
+ */
+function isAvailableAt(
+  availability: FreebuffModelOption['availability'],
+  now: Date,
+): boolean {
+  if (availability === 'always') return true
+  if (availability === 'off_peak_only') return !isDeepSeekExpensiveWindow(now)
+  return isFreebuffDeploymentHours(now)
 }
 
 export function isFreebuffSessionModelAvailable(
@@ -2111,7 +2742,11 @@ export function isFreebuffSessionModelAvailable(
   const model =
     SUPPORTED_FREEBUFF_MODELS.find((candidate) => candidate.id === id) ??
     getFreebuffWebModel(id)
-  return model.availability === 'always' || isFreebuffDeploymentHours(now)
+  // Same reading as the picker's joinability check, deliberately — see
+  // isAvailableAt. `off_peak_only` is the ten hours DeepSeek charges double
+  // (00:00-10:00 UTC), a different window from `deployment_hours`, which tracks
+  // OUR staffing rather than an upstream rate card.
+  return isAvailableAt(model.availability, now)
 }
 
 export function resolveAvailableFreebuffModel(
@@ -2119,7 +2754,20 @@ export function resolveAvailableFreebuffModel(
   now: Date = new Date(),
 ): FreebuffModelId {
   const resolved = resolveFreebuffModel(id)
-  return isFreebuffModelAvailable(resolved, now)
-    ? resolved
-    : FALLBACK_FREEBUFF_MODEL_ID
+  if (isFreebuffModelAvailable(resolved, now)) return resolved
+  // A closed row may name where its traffic should go instead — V4 Flash sends
+  // its peak hours to V4 Pro. Checked for availability itself rather than
+  // trusted, so a chain of closed rows can never strand a pick; anything
+  // unresolvable still lands on the unlimited fallback.
+  const declared = (
+    SUPPORTED_FREEBUFF_MODELS as readonly FreebuffModelOption[]
+  ).find((candidate) => candidate.id === resolved)?.unavailableFallback
+  if (
+    declared &&
+    isFreebuffModelId(declared) &&
+    isFreebuffModelAvailable(declared, now)
+  ) {
+    return declared
+  }
+  return FALLBACK_FREEBUFF_MODEL_ID
 }


### PR DESCRIPTION
## Summary

Updates the pinned upstream snapshots and fallback registry table to match the current CodebuffAI/codebuff main branch.

## Changes

- **Pinned snapshots**: Updated `testdata/upstream/free-agents.ts` and `freebuff-models.ts` to latest upstream
- **Fallback table**: Added `base2-free-ox-alpha` agent with `stealth/ox-alpha` model
- **Root agent mapping**: Added `stealth/ox-alpha → base2-free-ox-alpha` to `fallbackRootByModel`
- **Test**: Updated `expectedFallback` to include the new model

## Upstream changes captured

- Ox Alpha model added (`base2-free-ox-alpha`, `base3-free-ox-alpha`)
- MiniMax M3 withdrawn from free mode (`FREEBUFF_PAUSED_FREE_MODEL_IDS`)
- V4 Pro moved to first position in `FREEBUFF_MODELS` (always available, cheapest premium)
- Flash falls back to V4 Pro during peak hours
- `CLOUD_PLANNER/BUILD_MODEL_ID` changed to `FALLBACK_FREEBUFF_MODEL_ID` (mimo)

## Testing

- [x] `TestFallbackParityWithPinnedUpstream` passes
- [x] `TestConcurrentAccess` passes
- [x] `TestFallbackMap` passes
- [x] Full test suite passes (`env -u AUTH_TOKENS -u ADMIN_TOKEN go test ./...`)

Closes #154