### PR TITLE
fix(pool): better session handling, model stickiness, and concurrent admission deduplication

### DIFF
--- a/internal/pool/acquire.go
+++ b/internal/pool/acquire.go
@@ -58,6 +58,30 @@ func (p *Pool) Acquire(ctx context.Context, model string) (*Lease, error) {
 	// from the round-robin start (cold path), exactly like the historical
 	// linear failover. When no token is hot the order is unchanged.
 	order, quotaLimited := p.acquireOrder(toks, start, model)
+
+	// Issue #191: when an admission for this model is already in-flight on a
+	// different token, override the cold ordering so concurrent requests land
+	// on the same token and park on the existing single-flight refreshCh
+	// instead of creating a competing session.
+	p.admissionsMu.Lock()
+	admittingToken, isAdmitting := p.admissions[model]
+	if !isAdmitting {
+		// No leader yet — register this goroutine as the admission leader
+		// for this model so any concurrent cold request will follow us.
+		p.admissions[model] = 0 // placeholder; will be updated in the token loop
+	} else if admittingToken >= 0 {
+		// An existing admission is in progress on admittingToken — pin
+		// the cold ordering to that token so we park on its single-flight.
+		reordered := make([]int, 0, len(order))
+		reordered = append(reordered, admittingToken)
+		for _, idx := range order {
+			if idx != admittingToken {
+				reordered = append(reordered, idx)
+			}
+		}
+		order = reordered
+	}
+	p.admissionsMu.Unlock()
 	var errs []string
 	var waiting []*session.WaitingRoomError
 	var rateLimited []*upstream.RateLimitError
@@ -185,12 +209,21 @@ func (p *Pool) Acquire(ctx context.Context, model string) (*Lease, error) {
 		// capacity the acquire waits (the caller's deadline surfaces as
 		// 503). The permit is held only for the admission call, never
 		// across the upstream chat.
+		p.admissionsMu.Lock()
+		if p.admissions == nil {
+			p.admissions = make(map[string]int)
+		}
+		// Update the pre-registered leader slot with the actual token index.
+		p.admissions[model] = idx
+		p.admissionsMu.Unlock()
+
 		permit, err := p.gate.acquire(ctx, model)
 		if err != nil {
-			// Context expired while waiting for a create slot: the caller's
-			// deadline surfaces as 503 (wait-or-503). The pass is aborted —
-			// the ctx is done, so trying further tokens would only repeat
-			// the same wait.
+			p.admissionsMu.Lock()
+			if p.admissions != nil && p.admissions[model] == idx {
+				delete(p.admissions, model)
+			}
+			p.admissionsMu.Unlock()
 			return nil, err
 		}
 		sessionStart := time.Now()
@@ -205,6 +238,11 @@ func (p *Pool) Acquire(ctx context.Context, model string) (*Lease, error) {
 		}
 		instanceID, err := tok.session.EnsureSessionForModel(ctx, model)
 		permit.Release()
+		p.admissionsMu.Lock()
+		if p.admissions != nil && p.admissions[model] == idx {
+			delete(p.admissions, model)
+		}
+		p.admissionsMu.Unlock()
 		phasetiming.FromContext(ctx).Since(phasetiming.SessionRefreshMS, sessionStart)
 		if err != nil {
 			if errors.Is(err, upstream.ErrAuthRejected) {
@@ -419,6 +457,12 @@ func (p *Pool) Acquire(ctx context.Context, model string) (*Lease, error) {
 		p.lastActive = time.Now()
 		p.idleFinished = false
 		p.lastActiveMu.Unlock()
+		p.lastTokenMu.Lock()
+		if p.lastTokenByModel == nil {
+			p.lastTokenByModel = make(map[string]int)
+		}
+		p.lastTokenByModel[effectiveModel] = idx
+		p.lastTokenMu.Unlock()
 		return &Lease{Token: idx, Model: effectiveModel, AgentID: effectiveAgentID, Run: run, SessionInstanceID: instanceID,
 			entry: tok, AcquiredAt: time.Now()}, nil
 	}
@@ -557,10 +601,18 @@ func (p *Pool) acquireOrder(toks *[]*tokenEntry, start int, model string) ([]int
 		return true
 	}
 
-	// Issue #155 & Model Stickiness: Token prioritization order:
-	// 1. Matching Hot: tokens with active session for the EXACT model (0 cost reuse).
-	// 2. Cold Tokens: tokens with no active session (fresh session, avoids 0.1 switch penalty).
-	// 3. Mismatched Hot: tokens with active session for a DIFFERENT model (switching costs 0.1 quota).
+	p.lastTokenMu.Lock()
+	lastUsedToken, hasLastUsed := p.lastTokenByModel[model]
+	p.lastTokenMu.Unlock()
+
+	p.admissionsMu.Lock()
+	admittingToken, isAdmitting := p.admissions[model]
+	p.admissionsMu.Unlock()
+
+	// Issue #155 & #191: Model Stickiness and Session Preservation:
+	// 1. Matching Hot: tokens with active/usable session (or in-flight admission) for the model.
+	// 2. Cold Tokens: tokens with no active session (fresh session, avoids switch penalty).
+	// 3. Mismatched Hot: tokens with active session for a DIFFERENT model.
 	var matchingHot []int
 	var coldTokens []int
 	var mismatchedHot []int
@@ -572,10 +624,11 @@ func (p *Pool) acquireOrder(toks *[]*tokenEntry, start int, model string) ([]int
 		}
 		tok := (*toks)[idx]
 		snap := tok.session.Snapshot()
-		hasLive := snap.Status == "active" && !snap.ExpiresAt.IsZero() && snap.ExpiresAt.After(time.Now())
+		isAdm := isAdmitting && idx == admittingToken
+		hasLive := snap.Usable() || snap.Refreshing || isAdm
 
 		if hasLive {
-			if snap.Model == model {
+			if snap.MatchesModel(model) || isAdm {
 				matchingHot = append(matchingHot, idx)
 			} else {
 				mismatchedHot = append(mismatchedHot, idx)
@@ -585,18 +638,41 @@ func (p *Pool) acquireOrder(toks *[]*tokenEntry, start int, model string) ([]int
 		}
 	}
 
-	// Sort matchingHot by smallest remaining quota first (issue #85).
+	// Sort matchingHot:
+	// 1. In-flight refreshing/admitting tokens rank first so concurrent requests park on single-flight refreshCh.
+	// 2. Known positive remaining quota: smallest remaining quota first (drain account closest to limit first).
+	// 3. Equal/unknown quota: prefer last-used token for this model (session stickiness for multi-turn chats).
+	// 4. Stable token index preference (lower index first) to avoid round-robin ping-pong across accounts.
 	sort.SliceStable(matchingHot, func(i, j int) bool {
 		a, b := matchingHot[i], matchingHot[j]
-		aKnown, aRem, _ := quotaRemaining((*toks)[a], model)
-		bKnown, bRem, _ := quotaRemaining((*toks)[b], model)
+		tokA, tokB := (*toks)[a], (*toks)[b]
+		snapA, snapB := tokA.session.Snapshot(), tokB.session.Snapshot()
+
+		isAdmA := snapA.Refreshing || (isAdmitting && a == admittingToken)
+		isAdmB := snapB.Refreshing || (isAdmitting && b == admittingToken)
+		if isAdmA != isAdmB {
+			return isAdmA
+		}
+
+		aKnown, aRem, _ := quotaRemaining(tokA, model)
+		bKnown, bRem, _ := quotaRemaining(tokB, model)
 		if aKnown != bKnown {
 			return aKnown
 		}
-		if aKnown {
+		if aKnown && aRem != bRem {
 			return aRem < bRem
 		}
-		return false
+
+		if hasLastUsed {
+			if a == lastUsedToken && b != lastUsedToken {
+				return true
+			}
+			if b == lastUsedToken && a != lastUsedToken {
+				return false
+			}
+		}
+
+		return a < b
 	})
 
 	order := make([]int, 0, len(*toks))

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -271,6 +271,18 @@ type Pool struct {
 	unfitMu sync.Mutex
 	unfit   map[unfitKey]unfitEntry
 
+	// lastTokenByModel tracks the token index last successfully acquired for
+	// each model (model stickiness / multi-turn session preservation).
+	// Guarded by lastTokenMu.
+	lastTokenMu      sync.Mutex
+	lastTokenByModel map[string]int
+
+	// admissions tracks in-flight session admissions per model across the pool
+	// (issue #191: prevents concurrent requests from creating duplicate sessions
+	// on different tokens for the same model). Guarded by admissionsMu.
+	admissionsMu sync.Mutex
+	admissions   map[string]int
+
 	// store persists session state across restarts (SESSION_PERSIST); nil
 	// disables. Injected by the caller (main) via SetSessionStore so there
 	// is exactly one store shared by pooled and bridge entries.
@@ -333,7 +345,7 @@ func New(cfg *config.Config, clients []*upstream.Client, sessions []*session.Man
 		return nil, fmt.Errorf("pool: %d sessions for %d tokens", len(sessions), len(cfg.AuthTokens))
 	}
 
-	p := &Pool{reg: reg, logger: slog.Default(), bridge: make(map[string]*bridgeEntry), unfit: make(map[unfitKey]unfitEntry), bridgeCreateGate: make(chan struct{}, 4)}
+	p := &Pool{reg: reg, logger: slog.Default(), bridge: make(map[string]*bridgeEntry), unfit: make(map[unfitKey]unfitEntry), bridgeCreateGate: make(chan struct{}, 4), lastTokenByModel: make(map[string]int), admissions: make(map[string]int)}
 	p.cfg.Store(cfg)
 	p.msgsPerToken = make([][]time.Time, len(cfg.AuthTokens))
 	p.spendPerToken = make([]*spendLedger, len(cfg.AuthTokens))

--- a/internal/pool/scarce.go
+++ b/internal/pool/scarce.go
@@ -34,7 +34,7 @@ func (e *ScarceSessionError) Error() string {
 // model with more than scarceSwitchLead remaining — a request for a different
 // model must not evict or switch away from it.
 func scarceHeld(snap session.SessionSnapshot, requested string, scarce map[string]bool) bool {
-	if snap.Status != "active" || snap.Model == "" || snap.Model == requested {
+	if !snap.Usable() || snap.Model == "" || snap.MatchesModel(requested) {
 		return false
 	}
 	if !scarce[snap.Model] {
@@ -47,7 +47,7 @@ func scarceHeld(snap session.SessionSnapshot, requested string, scarce map[strin
 // model with any remaining lifetime (greater than 0). Used by bridge idle
 // eviction and shutdown teardown to keep the session alive.
 func scarceActive(snap session.SessionSnapshot, scarce map[string]bool) bool {
-	if snap.Status != "active" || snap.Model == "" {
+	if !snap.Usable() || snap.Model == "" {
 		return false
 	}
 	if !scarce[snap.Model] {

--- a/internal/pool/session_handling_test.go
+++ b/internal/pool/session_handling_test.go
@@ -135,9 +135,10 @@ func TestAcquireConcurrentColdAdmissionSharesSingleFlight(t *testing.T) {
 				errors.Add(1)
 				return
 			}
-			if lease.Token == 0 {
+			switch lease.Token {
+			case 0:
 				token0Count.Add(1)
-			} else if lease.Token == 1 {
+			case 1:
 				token1Count.Add(1)
 			}
 			p.LeaseRelease(lease)

--- a/internal/pool/session_handling_test.go
+++ b/internal/pool/session_handling_test.go
@@ -1,0 +1,216 @@
+// session_handling_test.go — regression tests for Issue #191 (better session handling,
+// model stickiness, concurrent admission deduplication, and grace drain reuse).
+package pool
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"freebuff-proxy/internal/testutil"
+)
+
+// TestAcquireScarceModelSessionStickiness verifies Issue #191:
+// When multiple tokens are configured, multi-turn requests for a scarce model
+// (e.g. deepseek/deepseek-v4-pro) must stick to the active session on Token 0
+// and must NOT trigger a second session creation on Token 1.
+func TestAcquireScarceModelSessionStickiness(t *testing.T) {
+	mock0 := testutil.NewMock()
+	defer mock0.Close()
+	mock1 := testutil.NewMock()
+	defer mock1.Close()
+
+	p := newTestPool(t, mock0, mock1)
+	const scarceModel = "deepseek/deepseek-v4-pro"
+
+	// Request 1: cold pool admits scarce session on Token 0.
+	lease1, err := p.Acquire(context.Background(), scarceModel)
+	if err != nil {
+		t.Fatalf("first acquire failed: %v", err)
+	}
+	if lease1.Token != 0 {
+		t.Fatalf("first lease token = %d, want 0", lease1.Token)
+	}
+	p.LeaseRelease(lease1)
+
+	if mock0.SessionCreates != 1 {
+		t.Fatalf("mock0 session creates = %d, want 1", mock0.SessionCreates)
+	}
+	if mock1.SessionCreates != 0 {
+		t.Fatalf("mock1 session creates = %d, want 0", mock1.SessionCreates)
+	}
+
+	// Requests 2..6: successive turns for the same scarce model must reuse Token 0.
+	for i := range 5 {
+		lease, err := p.Acquire(context.Background(), scarceModel)
+		if err != nil {
+			t.Fatalf("turn %d acquire failed: %v", i+2, err)
+		}
+		if lease.Token != 0 {
+			t.Errorf("turn %d landed on token %d, want token 0 (model stickiness)", i+2, lease.Token)
+		}
+		p.LeaseRelease(lease)
+	}
+
+	// Token 1 must never have had a session created.
+	if mock1.SessionCreates != 0 {
+		t.Errorf("mock1 session creates = %d, want 0 (scarce session must not leak to second token)", mock1.SessionCreates)
+	}
+	if mock0.SessionCreates != 1 {
+		t.Errorf("mock0 session creates = %d, want 1 (session reused across all turns)", mock0.SessionCreates)
+	}
+}
+
+// TestAcquireMatchingHotSessionStickinessEqualQuota verifies that when multiple tokens
+// both hold active matching sessions with equal/unknown quota, successive requests stick
+// to the last used token instead of round-robin ping-ponging across accounts on every turn.
+func TestAcquireMatchingHotSessionStickinessEqualQuota(t *testing.T) {
+	mock0 := testutil.NewMock()
+	defer mock0.Close()
+	mock1 := testutil.NewMock()
+	defer mock1.Close()
+
+	p := newTestPool(t, mock0, mock1)
+
+	// Pre-admit active sessions for modelA on BOTH tokens.
+	toks := p.toks.Load()
+	if _, err := (*toks)[0].session.EnsureSessionForModel(context.Background(), modelA); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (*toks)[1].session.EnsureSessionForModel(context.Background(), modelA); err != nil {
+		t.Fatal(err)
+	}
+
+	// First acquire lands on a token and records it as last-used.
+	first, err := p.Acquire(context.Background(), modelA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chosenToken := first.Token
+	p.LeaseRelease(first)
+
+	// Successive acquires must stick to the chosen token (no ping-pong).
+	for i := range 6 {
+		lease, err := p.Acquire(context.Background(), modelA)
+		if err != nil {
+			t.Fatalf("acquire %d failed: %v", i+1, err)
+		}
+		if lease.Token != chosenToken {
+			t.Errorf("acquire %d landed on token %d, want %d (stickiness with equal quota)", i+1, lease.Token, chosenToken)
+		}
+		p.LeaseRelease(lease)
+	}
+}
+
+// TestAcquireConcurrentColdAdmissionSharesSingleFlight verifies that when multiple
+// concurrent requests arrive for the same model on a cold pool, they share the single
+// in-flight session admission on the leader token rather than firing duplicate session creates
+// across multiple tokens.
+func TestAcquireConcurrentColdAdmissionSharesSingleFlight(t *testing.T) {
+	mock0 := testutil.NewMock()
+	defer mock0.Close()
+	mock1 := testutil.NewMock()
+	defer mock1.Close()
+
+	// Add a slight delay to mock0 session create so the concurrent request lands while refreshing.
+	mock0.SessionCreateDelay = 100 * time.Millisecond
+
+	p := newTestPool(t, mock0, mock1)
+	const scarceModel = "deepseek/deepseek-v4-pro"
+
+	var wg sync.WaitGroup
+	var errors atomic.Int32
+	var token0Count atomic.Int32
+	var token1Count atomic.Int32
+
+	// Launch 4 concurrent acquires for the same scarce model.
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			lease, err := p.Acquire(context.Background(), scarceModel)
+			if err != nil {
+				errors.Add(1)
+				return
+			}
+			if lease.Token == 0 {
+				token0Count.Add(1)
+			} else if lease.Token == 1 {
+				token1Count.Add(1)
+			}
+			p.LeaseRelease(lease)
+		}()
+	}
+
+	wg.Wait()
+
+	if errors.Load() > 0 {
+		t.Fatalf("%d concurrent acquires failed", errors.Load())
+	}
+	if mock0.SessionCreates != 1 {
+		t.Errorf("mock0 session creates = %d, want 1 (single-flight admission)", mock0.SessionCreates)
+	}
+	if mock1.SessionCreates != 0 {
+		t.Errorf("mock1 session creates = %d, want 0 (competing session must not be created)", mock1.SessionCreates)
+	}
+	if token1Count.Load() != 0 {
+		t.Errorf("token 1 leases = %d, want 0", token1Count.Load())
+	}
+	if token0Count.Load() != 4 {
+		t.Errorf("token 0 leases = %d, want 4", token0Count.Load())
+	}
+}
+
+// TestAcquireReusesGraceDrainSession verifies that a token whose session is past its
+// nominal expiresAt but still within the 30-minute grace drain window is recognized as
+// matchingHot and reused, avoiding unnecessary fresh session admissions on other tokens.
+func TestAcquireReusesGraceDrainSession(t *testing.T) {
+	mock0 := testutil.NewMock()
+	defer mock0.Close()
+	mock1 := testutil.NewMock()
+	defer mock1.Close()
+
+	p := newTestPool(t, mock0, mock1)
+
+	// Admit an initial session on Token 0.
+	lease, err := p.Acquire(context.Background(), modelA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.LeaseRelease(lease)
+
+	if mock0.SessionCreates != 1 {
+		t.Fatalf("mock0 session creates = %d, want 1", mock0.SessionCreates)
+	}
+
+	// Manually set Token 0's session to be in grace drain (past expiresAt, but before gracePeriodEndsAt).
+	toks := p.toks.Load()
+	now := time.Now()
+	(*toks)[0].session.SetSessionStateForTest(
+		"active",
+		"inst-grace-test",
+		modelA,
+		now.Add(-2*time.Minute), // expired 2m ago
+		now.Add(25*time.Minute), // 25m grace remaining
+	)
+
+	// Acquire again for modelA: Token 0's grace session should be reused.
+	lease2, err := p.Acquire(context.Background(), modelA)
+	if err != nil {
+		t.Fatalf("acquire during grace drain failed: %v", err)
+	}
+	if lease2.Token != 0 {
+		t.Errorf("lease token = %d, want 0 (grace drain session must be prioritized)", lease2.Token)
+	}
+	if lease2.SessionInstanceID != "inst-grace-test" {
+		t.Errorf("lease instance = %q, want inst-grace-test", lease2.SessionInstanceID)
+	}
+	p.LeaseRelease(lease2)
+
+	// Token 1 must remain untouched (0 creates).
+	if mock1.SessionCreates != 0 {
+		t.Errorf("mock1 session creates = %d, want 0", mock1.SessionCreates)
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -470,7 +470,9 @@ type SessionSnapshot struct {
 	Model         string
 	QueuePosition int
 	QueueDepth    int
-	// CountryCode is the admitted session's country ("" when absent).
+	// Refreshing reports whether a session admission or pre-emptive re-admit
+	// is currently in flight for this manager.
+	Refreshing         bool
 	CountryCode        string
 	CountryBlockReason string
 	// ActiveUsersForIP is the last known distinct-user count on the token's
@@ -532,6 +534,7 @@ func (m *Manager) Snapshot() SessionSnapshot {
 			}
 		}
 		return SessionSnapshot{
+			Refreshing:   m.refreshing,
 			QuotaByModel: quota,
 			GlmPromo:     m.savedGlmPromo,
 		}
@@ -558,6 +561,7 @@ func (m *Manager) Snapshot() SessionSnapshot {
 		Model:              m.state.model,
 		QueuePosition:      m.state.position,
 		QueueDepth:         m.state.queueDepth,
+		Refreshing:         m.refreshing,
 		CountryCode:        m.state.countryCode,
 		CountryBlockReason: m.state.countryBlockReason,
 		ActiveUsersForIP:   m.state.activeUsersForIP,
@@ -569,6 +573,24 @@ func (m *Manager) Snapshot() SessionSnapshot {
 		GlmPromo:           m.state.glmPromo,
 		Standing:           m.state.standing,
 	}
+}
+
+// Usable reports whether the session can serve a chat right now:
+// an active session until expiresAt-5s (the reference safety margin), or
+// any session that holds an instance id within its grace drain window.
+func (s SessionSnapshot) Usable() bool {
+	if s.InstanceID == "" {
+		return false
+	}
+	if s.Status == "active" && !s.ExpiresAt.IsZero() && time.Now().Before(s.ExpiresAt.Add(-expiryMargin)) {
+		return true
+	}
+	return !s.GracePeriodEndsAt.IsZero() && time.Now().Before(s.GracePeriodEndsAt)
+}
+
+// MatchesModel reports whether the session matches model (empty model matches any).
+func (s SessionSnapshot) MatchesModel(model string) bool {
+	return model == "" || s.Model == "" || s.Model == model
 }
 
 // HasGlmEntitlement reports whether the session snapshot holds an active
@@ -752,4 +774,17 @@ func (m *Manager) ClearQueued() bool {
 		return true
 	}
 	return false
+}
+
+// SetSessionStateForTest sets cached session state for tests across packages.
+func (m *Manager) SetSessionStateForTest(status, instanceID, model string, expiresAt, graceEndsAt time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.commit(&cachedState{
+		status:            status,
+		instanceID:        instanceID,
+		model:             model,
+		expiresAt:         expiresAt,
+		gracePeriodEndsAt: graceEndsAt,
+	})
 }


### PR DESCRIPTION
## Summary

Fixes #191 — when multiple tokens are configured, consecutive requests for the same model could trigger duplicate session admissions on different tokens, wasting session slots.

## Problem

The  cold path round-robins across tokens for each  call. When two requests for the same scarce model (e.g. ) arrive concurrently on a cold pool, each computes a different token order (different round-robin start), lands on a different cold token, and fires separate  calls — burning daily session slots on both tokens instead of sharing one.

Additionally, sessions in grace drain (past  but within 30-minute grace) were misclassified as cold, and sessions with empty  were mismatched even though they can serve any model.

## Changes

- **SessionSnapshot**: Add `Refreshing` field, `Usable()`, and `MatchesModel()` helpers so `acquireOrder` correctly recognizes grace-drain sessions and in-flight admissions as hot.
- **acquireOrder**: Prioritize in-flight refreshing/admitting tokens first. Tie-break by last-used token for multi-turn stickiness and stable index to prevent round-robin ping-ponging.
- **Pool**: Track `lastTokenByModel` and `admissions` (in-flight session creates per model). When a concurrent cold request arrives while an admission is in-flight, pin its ordering to the leader token so it parks on the leader's single-flight.
- **scarceHeld/scarceActive**: Use `snap.Usable()` instead of raw `snap.Status == "active"`.
- **Tests**: 4 new regression tests covering scarce-model stickiness, equal-quota hot-session stickiness, concurrent cold admission single-flight, and grace-drain session reuse.

## Verification

- Full hermetic suite passes (`go test ./cmd/... ./internal/...` — 20/20 packages green).
- `gofmt -l cmd internal` clean.
- Race detector blocked by known Windows TSan allocation issue (CI Linux enforces -race).