### PR TITLE
fix: eliminate proxy-fanout signal that triggers free_mode_run_fanout refusal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build-ui:
 	cd frontend && npm run build
 
 build-proxy:
-	go build -o $(BIN_DIR)/$(BINARY_NAME) ./cmd/freebuff-proxy
+	go build -tags dashboard -o $(BIN_DIR)/$(BINARY_NAME) ./cmd/freebuff-proxy
 
 build: build-ui build-proxy
 
@@ -27,7 +27,7 @@ dev-ui:
 	cd frontend && npm run dev
 
 dev-proxy:
-	go run ./cmd/freebuff-proxy
+	go run -tags dashboard ./cmd/freebuff-proxy
 
 clean:
 	rm -rf $(BIN_DIR)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,7 +21,7 @@ tasks:
   build:proxy:
     desc: Compile the Go proxy binary
     cmds:
-      - go build -o bin/freebuff-proxy{{exeExt}} ./cmd/freebuff-proxy
+      - go build -tags dashboard -o bin/freebuff-proxy{{exeExt}} ./cmd/freebuff-proxy
 
   test:
     desc: Run the hermetic Go test suite
@@ -48,7 +48,7 @@ tasks:
   dev:
     desc: Run proxy server
     cmds:
-      - go run ./cmd/freebuff-proxy
+      - go run -tags dashboard ./cmd/freebuff-proxy
 
   dev:ui:
     desc: Run frontend Vite dev server on port 5173

--- a/internal/pool/acquire.go
+++ b/internal/pool/acquire.go
@@ -120,7 +120,8 @@ func (p *Pool) leaseFromOrder(ctx context.Context, model string, agentID string,
 	var countryBlocked []*upstream.CountryBlockedError
 	var modelLimited []*upstream.LimitedIpError
 	var dailyLimited []*upstream.RateLimitError
-	var scarceUntil []time.Time
+	var scarceUntil time.Time
+	var scarceModel string
 	scarceSet := scarceModelSet(cfg.ScarceSessionModels)
 	for _, idx := range order {
 		if err := ctx.Err(); err != nil {
@@ -215,11 +216,15 @@ func (p *Pool) leaseFromOrder(ctx context.Context, model string, agentID string,
 		// active scarce session (pro/luna) with > 1 minute remaining, do not
 		// switch away from it to serve a different model — that would burn
 		// the irreplaceable 1-session/day allocation.
-		if scarceHeld(tok.session.Snapshot(), model, scarceSet) {
-			exp := tok.session.Snapshot().ExpiresAt
-			scarceUntil = append(scarceUntil, exp)
-			errs = append(errs, fmt.Sprintf("%s: scarce session (%s) in use until %s", name, tok.session.Snapshot().Model, exp.Format(time.RFC3339)))
-			p.logger.Debug("pool: token skipped (scarce session in use)", "token", idx+1, "model", tok.session.Snapshot().Model, "until", exp.Format(time.RFC3339))
+		if snap := tok.session.Snapshot(); scarceHeld(snap, model, scarceSet) {
+			exp := snap.ExpiresAt
+			// Remember the session that expires first: it is the one the
+			// caller can retry against, and its model names the refusal.
+			if scarceModel == "" || exp.Before(scarceUntil) {
+				scarceUntil, scarceModel = exp, snap.Model
+			}
+			errs = append(errs, fmt.Sprintf("%s: scarce session (%s) in use until %s", name, snap.Model, exp.Format(time.RFC3339)))
+			p.logger.Debug("pool: token skipped (scarce session in use)", "token", idx+1, "model", snap.Model, "until", exp.Format(time.RFC3339))
 			continue
 		}
 
@@ -565,14 +570,8 @@ func (p *Pool) leaseFromOrder(ctx context.Context, model string, agentID string,
 	if len(ipCapped) > 0 {
 		return nil, ipCapped[0]
 	}
-	if len(scarceUntil) > 0 {
-		earliest := scarceUntil[0]
-		for _, t := range scarceUntil[1:] {
-			if t.Before(earliest) {
-				earliest = t
-			}
-		}
-		return nil, &ScarceSessionError{Model: model, ExpiresAt: earliest}
+	if scarceModel != "" {
+		return nil, &ScarceSessionError{Model: scarceModel, ExpiresAt: scarceUntil}
 	}
 	if len(waiting) > 0 {
 		wr := bestWaitingRoom(waiting)

--- a/internal/pool/bridge.go
+++ b/internal/pool/bridge.go
@@ -93,8 +93,8 @@ func (p *Pool) AcquireBridge(ctx context.Context, clientToken, model string) (*L
 	}
 	// Issue #155: scarce-model session protection in bridge mode.
 	scarceSet := scarceModelSet(cfg.ScarceSessionModels)
-	if scarceHeld(entry.session.Snapshot(), model, scarceSet) {
-		return nil, &ScarceSessionError{Model: model, ExpiresAt: entry.session.Snapshot().ExpiresAt}
+	if snap := entry.session.Snapshot(); scarceHeld(snap, model, scarceSet) {
+		return nil, &ScarceSessionError{Model: snap.Model, ExpiresAt: snap.ExpiresAt}
 	}
 
 	// Issue #155: quota-exhaustion fallback in bridge mode.

--- a/internal/pool/pool_acquire_test.go
+++ b/internal/pool/pool_acquire_test.go
@@ -538,7 +538,11 @@ func TestUnknownModel(t *testing.T) {
 	}
 }
 
-func TestStartPrewarmsAndShutdownDrains(t *testing.T) {
+// TestStartDoesNotFanOutAndShutdownDrains pins the free_mode_run_fanout
+// root cause: Start must NOT open a run per registry agent per token at boot
+// (that fleet is the "proxy fanout" shape upstream refuses), and the runs a
+// real lease does create must still FINISH on shutdown.
+func TestStartDoesNotFanOutAndShutdownDrains(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	ids := make([]string, 100)
@@ -552,17 +556,29 @@ func TestStartPrewarmsAndShutdownDrains(t *testing.T) {
 	p.Start(ctx)
 	defer cancel()
 
-	// Prewarm runs in the background: wait until every registry agent has a
-	// STARTed run.
-	agentCount := len(p.regAgentIDs(t))
-	eventually(t, "prewarm of all agents", func() bool {
-		return len(mock.StartedRunsSnapshot()) >= agentCount
-	})
+	// No request has arrived, so no run may exist upstream. The registry
+	// carries several agents; a fleet prewarm would show up here.
+	if agents := len(p.regAgentIDs(t)); agents < 2 {
+		t.Fatalf("registry agents = %d, want >= 2 for this to prove anything", agents)
+	}
+	if started := mock.StartedRunsSnapshot(); len(started) != 0 {
+		t.Fatalf("STARTed runs at boot = %d, want 0 (no agent-fleet fanout)", len(started))
+	}
+
+	// One lease starts exactly the run it needs, and shutdown drains it.
+	lease, err := p.Acquire(context.Background(), modelA)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	p.LeaseRelease(lease)
+	if started := mock.StartedRunsSnapshot(); len(started) != 1 {
+		t.Errorf("STARTed runs after one Acquire = %d, want 1", len(started))
+	}
 
 	p.Shutdown(context.Background())
 
 	eventually(t, "shutdown drain FINISHes", func() bool {
-		return len(mock.FinishedRunsSnapshot()) >= agentCount
+		return len(mock.FinishedRunsSnapshot()) >= 1
 	})
 	for _, f := range mock.FinishedRunsSnapshot() {
 		if f.Status != "completed" {

--- a/internal/pool/pool_lifecycle.go
+++ b/internal/pool/pool_lifecycle.go
@@ -1,4 +1,4 @@
-// pool_lifecycle.go — background-job lifecycle: prewarm, the maintain
+// pool_lifecycle.go — background-job lifecycle: the maintain
 // rotation loop (rotate aged runs, advance queued sessions), and the
 // session-liveness poll schedule (gap #2).
 package pool
@@ -47,17 +47,23 @@ const (
 // is still mid-admission when the park happens (see RemoveLastToken).
 const retiredDrainGrace = 2 * time.Minute
 
-// Start launches the background jobs: a best-effort prewarm of every
-// registry agent across every token (so the first request does not pay the
-// START latency) and the 60s maintain loop (rotate aged runs + advance
-// queued sessions). Both stop when ctx is canceled; Pool.Shutdown cancels.
+// Start launches the 60s maintain loop (rotate aged runs + advance queued
+// sessions). It stops when ctx is canceled; Pool.Shutdown cancels.
+//
+// It deliberately does NOT prewarm a run per registry agent per token any
+// more. That boot fleet held ~one concurrent agent run per served model on a
+// single free account, which is exactly the "proxy fanout" shape upstream
+// counts as ban-grade evidence (upstream
+// common/src/constants/freebuff-spend-ceilings.ts) and refuses with
+// free_mode_run_fanout — a refusal the reference proxies that keep one run
+// per (token, agent) never see. Runs START lazily on first use (Acquire),
+// so dropping the fleet costs the first request its START latency and
+// nothing else.
 func (p *Pool) Start(ctx context.Context) {
 	p.once.Do(func() {
-		agentIDs := p.reg.AgentIDs()
 		runCtx, cancel := context.WithCancel(ctx)
 		p.cancel = cancel
-		p.wg.Add(2)
-		go p.prewarm(runCtx, agentIDs)
+		p.wg.Add(1)
 		go p.maintainLoop(runCtx)
 	})
 }
@@ -166,19 +172,6 @@ func (p *Pool) endIdleSessions(ctx context.Context, cfg *config.Config, toks *[]
 func (p *Pool) sweepIdleSessions(ctx context.Context, cfg *config.Config, toks *[]*tokenEntry) {
 	if p.trySweepIdleSessions(cfg) {
 		p.endIdleSessions(ctx, cfg, toks)
-	}
-}
-
-// prewarm starts a run for every agent on every token, best-effort, bounded
-// by the request timeout.
-func (p *Pool) prewarm(ctx context.Context, agentIDs []string) {
-	defer p.wg.Done()
-	toks := p.toks.Load()
-	for i, tok := range *toks {
-		preCtx, cancel := context.WithTimeout(ctx, p.cfg.Load().RequestTimeout)
-		tok.runs.Prewarm(preCtx, agentIDs)
-		cancel()
-		p.logger.Debug("pool: prewarm done", "token", i+1, "agents", len(agentIDs))
 	}
 }
 

--- a/internal/pool/scarce.go
+++ b/internal/pool/scarce.go
@@ -22,6 +22,8 @@ const scarceSwitchLead = time.Minute
 // Surfaced as 503 Service Unavailable with Retry-After matching the earliest
 // expiry time.
 type ScarceSessionError struct {
+	// Model is the scarce model the HELD session runs, not the model that
+	// was requested — that one is in the request log line.
 	Model     string
 	ExpiresAt time.Time
 }

--- a/internal/pool/scarce_test.go
+++ b/internal/pool/scarce_test.go
@@ -103,8 +103,9 @@ func TestAcquireScarceSessionProtection(t *testing.T) {
 	if !errors.As(err, &scse) {
 		t.Fatalf("expected errors.As ScarceSessionError, got %T: %v", err, err)
 	}
-	if scse.Model != "deepseek/deepseek-v4-flash" {
-		t.Errorf("scse.Model = %q, want deepseek/deepseek-v4-flash", scse.Model)
+	// The error names the HELD session's model, not the requested one.
+	if scse.Model != "openai/gpt-5.6-luna" {
+		t.Errorf("scse.Model = %q, want openai/gpt-5.6-luna", scse.Model)
 	}
 }
 

--- a/internal/registry/parse.go
+++ b/internal/registry/parse.go
@@ -210,6 +210,28 @@ func parseAgentModels(text string, resolver *constantResolver) []agentModels {
 	return agents
 }
 
+// retiredRootOverrides pins a model whose parsed root upstream retired
+// server-side. FREEBUFF_ROOT_AGENT_ID_BY_MODEL — the only root map this text
+// parser can read — still names base2-free-luna for Luna, and base2-free-luna
+// is still in the upstream agent allowlist, but the backend now rejects a Luna
+// turn on it with free_mode_legacy_luna_agent ("Retired Luna agent — start a
+// new conversation"). That code classifies as ErrSessionInvalid, so the
+// recovery path re-admits onto the same dead root until the retry budget is
+// gone and the client sees 502.
+//
+// Upstream's own Web and CLI clients send base3-free-luna
+// (FREEBUFF_{WEB,CLI}_BASE3_AGENT_ID_BY_MODEL). Those rows, and their
+// allowlist entries, are derived through an Object.fromEntries spread the
+// parser cannot evaluate, so a live refresh never sees them.
+//
+// ponytail: a one-model override, not a base3 map parser — one model is
+// retired, not the catalog. Revisit if the upstream
+// FREEBUFF_BASE3_HARNESS_DISABLED kill switch routes base2 back on, or if a
+// second model starts returning a retired-agent code.
+var retiredRootOverrides = map[string]string{
+	"openai/gpt-5.6-luna": "base3-free-luna",
+}
+
 // buildModelMapping merges the root map (wins) with first-seen agent→models
 // assignment, in entry order, and returns the model→agent map plus sorted
 // model list.
@@ -223,6 +245,14 @@ func buildModelMapping(agentModels []agentModels, rootAgentByModel map[string]st
 			if _, ok := modelToAgent[model]; !ok {
 				modelToAgent[model] = entry.agent
 			}
+		}
+	}
+	// Applied after both sources so the live-refresh and offline-fallback
+	// paths (both call this function) agree. Only remaps a model the sources
+	// already serve — an override never invents a catalog row.
+	for model, agent := range retiredRootOverrides {
+		if _, ok := modelToAgent[model]; ok {
+			modelToAgent[model] = agent
 		}
 	}
 	allModels := make([]string, 0, len(modelToAgent))

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -39,8 +39,10 @@ func fileSource(t *testing.T, path string) string {
 // helper models belong to file-picker / file-picker-max, and every upstream-
 // retired id is absent.
 var expectedFallback = map[string]string{
-	"minimax/minimax-m3":              "base2-free-minimax-m3",
-	"openai/gpt-5.6-luna":             "base2-free-luna",
+	"minimax/minimax-m3": "base2-free-minimax-m3",
+	// base2-free-luna is retired upstream (free_mode_legacy_luna_agent);
+	// retiredRootOverrides remaps it — see parse.go.
+	"openai/gpt-5.6-luna":             "base3-free-luna",
 	"deepseek/deepseek-v4-pro":        "base2-free-deepseek",
 	"deepseek/deepseek-v4-flash":      "base2-free-deepseek-flash",
 	"mimo/mimo-v2.5":                  "base2-free-mimo",

--- a/internal/registry/retired_root_test.go
+++ b/internal/registry/retired_root_test.go
@@ -1,0 +1,33 @@
+package registry
+
+import "testing"
+
+// Luna's base2 root is retired upstream (free_mode_legacy_luna_agent); every
+// path that resolves a root must hand out base3-free-luna instead.
+func TestRetiredRootOverrideAppliesToBothPaths(t *testing.T) {
+	// Offline fallback path.
+	fallback := New(nil, nil)
+	fallback.LoadFallback()
+	got, err := fallback.AgentForModel("openai/gpt-5.6-luna")
+	if err != nil {
+		t.Fatalf("fallback AgentForModel: %v", err)
+	}
+	if got != "base3-free-luna" {
+		t.Errorf("fallback root = %q, want base3-free-luna", got)
+	}
+
+	// Live-parse path: the parsed root map still names the retired agent.
+	modelToAgent, _ := buildModelMapping(
+		[]agentModels{{agent: "base2-free", models: []string{"openai/gpt-5.6-luna"}}},
+		map[string]string{"openai/gpt-5.6-luna": "base2-free-luna"},
+	)
+	if modelToAgent["openai/gpt-5.6-luna"] != "base3-free-luna" {
+		t.Errorf("parsed root = %q, want base3-free-luna", modelToAgent["openai/gpt-5.6-luna"])
+	}
+
+	// An override never invents a model the sources do not serve.
+	modelToAgent, _ = buildModelMapping(nil, map[string]string{"mimo/mimo-v2.5": "base2-free-mimo"})
+	if _, ok := modelToAgent["openai/gpt-5.6-luna"]; ok {
+		t.Error("override invented a catalog row for an unserved model")
+	}
+}

--- a/internal/runs/runs.go
+++ b/internal/runs/runs.go
@@ -637,6 +637,7 @@ func (m *RunManager) rotate(ctx context.Context, agentID string) error {
 						RunID:          pr.RunID,
 						StartedAt:      pr.StartedAt,
 						TraceSessionID: pr.TraceSessionID,
+						ClientID:       resumedClientID(pr.ClientID),
 						Requests:       pr.Requests,
 					}
 					flight.err = nil
@@ -683,7 +684,14 @@ func (m *RunManager) rotate(ctx context.Context, agentID string) error {
 		traceSessionID := newTraceSessionID()
 		slog.Debug("runs: run started", "agent_id", agentID, "run_id", runID, "trace_session_id", traceSessionID)
 
-		newRun := &Run{AgentID: agentID, RunID: runID, StartedAt: time.Now(), TraceSessionID: traceSessionID}
+		newRun := &Run{
+			AgentID:        agentID,
+			RunID:          runID,
+			StartedAt:      time.Now(),
+			TraceSessionID: traceSessionID,
+			// One client id for the whole run (CLI: one promptId per prompt).
+			ClientID: upstream.NewClientID(),
+		}
 		oldRun := m.runs[agentID]
 		m.runs[agentID] = newRun
 		if oldRun != nil {

--- a/internal/runs/steps.go
+++ b/internal/runs/steps.go
@@ -46,6 +46,15 @@ type Run struct {
 	// randomUUID; reference/proxy-freebuff lib/runs.js:43-46).
 	TraceSessionID string
 
+	// ClientID is codebuff_metadata["client_id"], minted once per run and
+	// repeated by every chat call of that run. The CLI mints it once per
+	// prompt (run.ts:722 `promptId`, handed to the agent loop as
+	// `clientSessionId` at run.ts:822 and reused by every LLM step), so a
+	// FRESH id per chat call made one run_id fan out across N client ids —
+	// the shape upstream refuses as free_mode_run_fanout. Persisted with the
+	// run so a restart resumes the id instead of splitting the run.
+	ClientID string
+
 	// StepCount is the run's 1-based per-chat-call step counter, stamped
 	// as codebuff_metadata["llm_step_number"] (issue #113, CLI parity:
 	// run-agent-step.ts increments per step). Atomic: chatAttempt
@@ -160,6 +169,7 @@ func (m *RunManager) cloneRun(run *Run) *Run {
 		StartedAt:      run.StartedAt,
 		Requests:       run.Requests,
 		TraceSessionID: run.TraceSessionID,
+		ClientID:       run.ClientID,
 		Status:         run.Status,
 		Steps:          append([]upstream.RunStep(nil), run.Steps...),
 		stepTotal:      run.stepTotal,
@@ -183,6 +193,7 @@ func (m *RunManager) persistRun(run *Run) {
 		RunID:          run.RunID,
 		AgentID:        run.AgentID,
 		TraceSessionID: run.TraceSessionID,
+		ClientID:       run.ClientID,
 		StartedAt:      startedAt,
 		Requests:       requests,
 	})
@@ -247,4 +258,14 @@ func (m *RunManager) ReleaseAbandoned(run *Run) {
 	// other re-enqueuer, and after a drain there may be no next tick (P1).
 	// enqueueFinish dedupes against a job already in the queue.
 	m.enqueueFinish(run)
+}
+
+// resumedClientID keeps a resumed run's persisted client id, minting a fresh
+// one only for a run persisted before the field existed. Returning "" instead
+// would send no client_id at all, which is a shape the CLI never produces.
+func resumedClientID(persisted string) string {
+	if persisted != "" {
+		return persisted
+	}
+	return upstream.NewClientID()
 }

--- a/internal/server/engine.go
+++ b/internal/server/engine.go
@@ -537,6 +537,9 @@ func (s *Server) chatAttempt(
 		RunID:             lease.Run.RunID,
 		SessionInstanceID: lease.SessionInstanceID,
 		TraceSessionID:    lease.Run.TraceSessionID,
+		// One client_id for the whole run: a fresh draw per call is the
+		// free_mode_run_fanout shape (see injectEnvelope).
+		ClientID: lease.Run.ClientID,
 		// D1: the request's correlation id, threaded to the upstream
 		// client so its do()/retry log lines share the server's req_id.
 		RequestID: st.reqID,

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -93,6 +93,8 @@ func defaultHintForCode(code, message string) string {
 		return "Retired Luna agent — new session required, retry immediately."
 	case code == "free_mode_rate_limited" || strings.Contains(lowerMsg, "free_mode_rate_limited"):
 		return "Free-tier sliding window rate limit (30m). Wait for Retry-After or retry with backoff."
+	case code == "free_mode_run_fanout" || strings.Contains(lowerMsg, "free_mode_run_fanout"):
+		return "Upstream refused the account's concurrent agent runs (proxy-fanout signal). Honor Retry-After; run fewer parallel requests per token, or add another token."
 	case code == "free_mode_capacity_deferred" || strings.Contains(lowerMsg, "free_mode_capacity_deferred"):
 		return "Free tier at capacity — request deferred. Honor Retry-After (approx 2s for 30m window, 10s default) before retrying."
 	case code == "account_banned" || strings.Contains(lowerMsg, "banned"):
@@ -208,6 +210,12 @@ func (s *Server) writeError(w http.ResponseWriter, r *http.Request, err error, m
 			// #133: upstream peak-hours pricing window — bounded cooldown,
 			// not a quota lock.
 			code = "peak_hours"
+		case "free_mode_run_fanout":
+			// Upstream concurrent-run/fanout refusal: 429 + bounded
+			// Retry-After so the client backs off and the next request
+			// lands on another token — never the dead 502 the generic
+			// UpstreamError branch used to write.
+			code = "free_mode_run_fanout"
 		}
 		message, retryAfter = rle.Error(), rle.RetryAfter
 		resetAt, window = rle.ResetAt, rle.Window

--- a/internal/server/server_chat_test.go
+++ b/internal/server/server_chat_test.go
@@ -681,3 +681,36 @@ func TestChatModelIPLimitedConcurrentRefusals(t *testing.T) {
 		t.Errorf("upstream requests = %d, want %d (prime baseline; guard refusals never reach upstream)", got, before)
 	}
 }
+
+// TestChatRunFanoutSurfaced429 is the end-to-end contract for the
+// free_mode_run_fanout refusal Finn hit as a turn-killing
+// 502 upstream_unavailable: the exact observed upstream body must reach the
+// client as 429 free_mode_run_fanout + a bounded Retry-After, and the mock
+// must see exactly ONE chat call — re-POSTing into an anti-fanout refusal is
+// what feeds upstream's ban-grade sweep counter.
+func TestChatRunFanoutSurfaced429(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	var chatCalls atomic.Int32
+	mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
+		chatCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"error":"free_mode_run_fanout","message":"Free mode request rejected."}`)
+	}
+	ts, _ := newTestServerCfg(t, nil, nil, mock)
+
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (never the 502 that killed the turn): %s", resp.StatusCode, data)
+	}
+	if ra := resp.Header.Get("Retry-After"); ra != "60" {
+		t.Errorf("Retry-After = %q, want 60 (FanoutCooldown default)", ra)
+	}
+	if !strings.Contains(string(data), `"code":"free_mode_run_fanout"`) {
+		t.Errorf("body missing free_mode_run_fanout code: %s", data)
+	}
+	if got := chatCalls.Load(); got != 1 {
+		t.Errorf("upstream chat calls = %d, want 1 (never re-POST into a fanout refusal)", got)
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -277,10 +277,11 @@ func TestChatStream(t *testing.T) {
 			t.Errorf("upstream body missing %s: %s", want, recorded)
 		}
 	}
-	// #80+#103: trace_session_id is minted once per run and threaded through
-	// the envelope; client_id is a FRESH random 13-char base36 draw per chat
-	// call — never the sess:/run:-prefixed shapes the server fingerprints as
-	// a proxy.
+	// #80+#103: trace_session_id and client_id are BOTH minted once per run
+	// and threaded through the envelope (a per-call client_id draw is the
+	// free_mode_run_fanout shape — see TestChatClientIDStableAcrossRun).
+	// client_id keeps the SDK-faithful 13-char base36 form, never the
+	// sess:/run:-prefixed shapes the server fingerprints as a proxy.
 	if !strings.Contains(recorded, `"trace_session_id":"`) {
 		t.Errorf("upstream body missing trace_session_id: %s", recorded)
 	}
@@ -617,4 +618,52 @@ func TestClientCancelBeforeFirstByteAbandonsRun(t *testing.T) {
 		return mock.AbortDetected.Load()
 	})
 	<-errCh
+}
+
+// TestChatClientIDStableAcrossRun is the wiring guard for the
+// free_mode_run_fanout fix: two chat requests served by the same lease/run
+// must carry the SAME codebuff_metadata.client_id, because the CLI mints it
+// once per prompt and repeats it on every LLM step (run.ts:722/822,
+// llm.ts:117). A fresh draw per call made one run_id fan out across N client
+// ids, which upstream refuses.
+func TestChatClientIDStableAcrossRun(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	ts, _ := newTestServer(t, nil, mock)
+
+	body := []byte(`{"model":"` + modelA + `","messages":[{"role":"user","content":"hi"}],"stream":false}`)
+	for i := 0; i < 2; i++ {
+		resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", body, nil)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("request %d status = %d, want 200: %s", i+1, resp.StatusCode, data)
+		}
+	}
+
+	recorded := mock.RecordedChatBodies
+	if len(recorded) < 2 {
+		t.Fatalf("recorded chat bodies = %d, want 2", len(recorded))
+	}
+	meta := func(raw string) (clientID, runID string) {
+		var sent struct {
+			Metadata struct {
+				ClientID string `json:"client_id"`
+				RunID    string `json:"run_id"`
+			} `json:"codebuff_metadata"`
+		}
+		if err := json.Unmarshal([]byte(raw), &sent); err != nil {
+			t.Fatalf("body not JSON: %v", err)
+		}
+		return sent.Metadata.ClientID, sent.Metadata.RunID
+	}
+	id1, run1 := meta(recorded[0])
+	id2, run2 := meta(recorded[1])
+	if run1 != run2 {
+		t.Fatalf("run_id = %q then %q; this test needs both calls on one run", run1, run2)
+	}
+	if !regexp.MustCompile(`^[a-z0-9]{13}$`).MatchString(id1) {
+		t.Errorf("client_id = %q, want 13-char base36", id1)
+	}
+	if id1 != id2 {
+		t.Errorf("client_id = %q then %q on run %q, want one id per run (fanout shape otherwise)", id1, id2, run1)
+	}
 }

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -54,11 +54,15 @@ type persistedQuota struct {
 // (issue #40): a restart resumes the run id without re-START. Keyed per
 // token (hash) and agent, alongside the session state.
 type PersistedRun struct {
-	RunID          string    `json:"run_id"`
-	AgentID        string    `json:"agent_id"`
-	TraceSessionID string    `json:"trace_session_id"`
-	StartedAt      time.Time `json:"started_at"`
-	Requests       int       `json:"requests"`
+	RunID          string `json:"run_id"`
+	AgentID        string `json:"agent_id"`
+	TraceSessionID string `json:"trace_session_id"`
+	// ClientID is the run's codebuff_metadata["client_id"]. Additive: an old
+	// file parses with "" and the run manager mints a fresh id, which only
+	// costs that resumed run one client-id change.
+	ClientID  string    `json:"client_id,omitempty"`
+	StartedAt time.Time `json:"started_at"`
+	Requests  int       `json:"requests"`
 }
 
 type storeFile struct {

--- a/internal/upstream/auth_wave6_test.go
+++ b/internal/upstream/auth_wave6_test.go
@@ -16,15 +16,20 @@ import (
 	"freebuff-proxy/internal/testutil"
 )
 
-// --- #103: fresh random client_id per chat call -----------------------------
+// --- #103 / free_mode_run_fanout: client_id is PER RUN ----------------------
 
-// TestInjectEnvelopeFreshRandomClientID verifies #103: client_id is a FRESH
-// random SDK-faithful base36 draw per chat call — never the sess:/run:-
-// prefixed shapes the server fingerprints as a proxy, never wf- prefixed,
-// and never stable across calls. trace_session_id stays per run and
-// freebuff_instance_id stays per session.
-func TestInjectEnvelopeFreshRandomClientID(t *testing.T) {
-	out, err := injectEnvelope([]byte(`{"model":"m"}`), "free", ChatOptions{RunID: "run-1", SessionInstanceID: "inst-9", TraceSessionID: "trace-abc"})
+// TestInjectEnvelopeClientIDPerRun pins the client_id scope. The CLI mints it
+// once per prompt (run.ts:722 promptId -> run.ts:822 clientSessionId ->
+// llm.ts:117 client_id) and every LLM step of that run repeats it, so the
+// envelope must REPEAT ChatOptions.ClientID rather than draw a fresh id per
+// call: N ids under one run_id is the fanout shape upstream refuses with
+// free_mode_run_fanout. The shape stays SDK-faithful and unprefixed, and an
+// empty ClientID still falls back to a well-shaped draw.
+func TestInjectEnvelopeClientIDPerRun(t *testing.T) {
+	base36 := regexp.MustCompile(`^[a-z0-9]{13}$`)
+	const runClientID = "abc123def4567"
+
+	out, err := injectEnvelope([]byte(`{"model":"m"}`), "free", ChatOptions{RunID: "run-1", SessionInstanceID: "inst-9", TraceSessionID: "trace-abc", ClientID: runClientID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,14 +38,8 @@ func TestInjectEnvelopeFreshRandomClientID(t *testing.T) {
 		t.Fatal(err)
 	}
 	md := sent["codebuff_metadata"].(map[string]any)
-	clientID, _ := md["client_id"].(string)
-	if !regexp.MustCompile(`^[a-z0-9]{13}$`).MatchString(clientID) {
-		t.Errorf("client_id = %q, want a 13-char base36 draw", clientID)
-	}
-	for _, prefix := range []string{"sess:", "run:", "wf-"} {
-		if strings.HasPrefix(clientID, prefix) {
-			t.Errorf("client_id = %q, must not carry the %q prefix (proxy fingerprint)", clientID, prefix)
-		}
+	if md["client_id"] != runClientID {
+		t.Errorf("client_id = %v, want the run's id %q repeated", md["client_id"], runClientID)
 	}
 	if md["trace_session_id"] != "trace-abc" {
 		t.Errorf("trace_session_id = %v, want trace-abc (per run)", md["trace_session_id"])
@@ -49,20 +48,21 @@ func TestInjectEnvelopeFreshRandomClientID(t *testing.T) {
 		t.Errorf("freebuff_instance_id = %v, want inst-9 (per session)", md["freebuff_instance_id"])
 	}
 
-	// A second call with the SAME run AND session must draw a DIFFERENT id.
-	out2, err := injectEnvelope([]byte(`{"model":"m"}`), "free", ChatOptions{RunID: "run-1", SessionInstanceID: "inst-9"})
+	// The SECOND call of the same run must carry the SAME id — this is the
+	// regression that produced free_mode_run_fanout.
+	out2, err := injectEnvelope([]byte(`{"model":"m"}`), "free", ChatOptions{RunID: "run-1", SessionInstanceID: "inst-9", ClientID: runClientID})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := json.Unmarshal(out2, &sent); err != nil {
 		t.Fatal(err)
 	}
-	md2 := sent["codebuff_metadata"].(map[string]any)
-	if id2, _ := md2["client_id"].(string); id2 == clientID {
-		t.Errorf("client_id = %q on a second call, want a fresh draw per call", id2)
+	if got := sent["codebuff_metadata"].(map[string]any)["client_id"]; got != runClientID {
+		t.Errorf("client_id on the run's second call = %v, want %q (one client_id per run)", got, runClientID)
 	}
 
-	// No instance id (disabled session): still a fresh unprefixed draw.
+	// No ClientID supplied (admin smoke ping, bridge callers): fall back to a
+	// fresh SDK-faithful draw, never a prefixed proxy fingerprint.
 	out3, err := injectEnvelope([]byte(`{"model":"m"}`), "free", ChatOptions{RunID: "run-3"})
 	if err != nil {
 		t.Fatal(err)
@@ -70,9 +70,29 @@ func TestInjectEnvelopeFreshRandomClientID(t *testing.T) {
 	if err := json.Unmarshal(out3, &sent); err != nil {
 		t.Fatal(err)
 	}
-	md3 := sent["codebuff_metadata"].(map[string]any)
-	if id3, _ := md3["client_id"].(string); !regexp.MustCompile(`^[a-z0-9]{13}$`).MatchString(id3) || strings.HasPrefix(id3, "run:") {
-		t.Errorf("client_id without instance = %q, want fresh unprefixed 13-char base36", id3)
+	fallback, _ := sent["codebuff_metadata"].(map[string]any)["client_id"].(string)
+	if !base36.MatchString(fallback) {
+		t.Errorf("fallback client_id = %q, want a 13-char base36 draw", fallback)
+	}
+	for _, prefix := range []string{"sess:", "run:", "wf-"} {
+		if strings.HasPrefix(fallback, prefix) {
+			t.Errorf("client_id = %q, must not carry the %q prefix (proxy fingerprint)", fallback, prefix)
+		}
+	}
+}
+
+// TestNewClientIDIsPerRunDraw pins that the run manager's generator produces
+// distinct SDK-faithful ids — one per run, not one per process.
+func TestNewClientIDIsPerRunDraw(t *testing.T) {
+	base36 := regexp.MustCompile(`^[a-z0-9]{13}$`)
+	a, b := NewClientID(), NewClientID()
+	for _, id := range []string{a, b} {
+		if !base36.MatchString(id) {
+			t.Errorf("NewClientID = %q, want 13-char base36", id)
+		}
+	}
+	if a == b {
+		t.Error("NewClientID returned the same id twice; runs must not share one")
 	}
 }
 

--- a/internal/upstream/chat.go
+++ b/internal/upstream/chat.go
@@ -29,6 +29,11 @@ type ChatOptions struct {
 	// CLI (run.ts: previousRun?.traceSessionId ?? randomUUID). Injected as
 	// codebuff_metadata["trace_session_id"] when set.
 	TraceSessionID string
+	// ClientID is codebuff_metadata["client_id"], minted once per run by the
+	// run manager and repeated by every chat call of that run (CLI: one
+	// promptId per prompt, run.ts:722/822). Empty falls back to a fresh draw
+	// so callers without a run manager still send a well-shaped id.
+	ClientID string
 	// StepNumber is the 1-based per-run agent step counter (CLI parity:
 	// llm_step_number is merged on every chat call, String(n);
 	// reference/freebuff agent-runtime run-agent-step.ts:1175-1177).
@@ -246,17 +251,24 @@ func injectEnvelope(body []byte, costMode string, opts ChatOptions) ([]byte, err
 
 	ensureCliSystemMarker(payload)
 
-	// client_id is a FRESH random SDK-faithful draw per chat call — never
-	// the sess:/run:-prefixed shapes the server fingerprints as a proxy
-	// (#103; reference/freebuff run.ts:646
-	// Math.random().toString(36).substring(2,15), cf-worker-signals.ts
-	// ^wf-[a-z0-9]{8}$). trace_session_id remains per run (minted once by
-	// the run manager, reused across the run's requests; run.ts:
-	// previousRun?.traceSessionId ?? randomUUID, proxy-freebuff
-	// lib/runs.js:43-46) and freebuff_instance_id stays per session.
+	// client_id is minted ONCE PER RUN and repeated here — never a fresh
+	// draw per chat call. The CLI mints it once per prompt (run.ts:722
+	// `const promptId = Math.random().toString(36).substring(2,15)`, handed
+	// to the agent loop as `clientSessionId` at run.ts:822 and stamped on
+	// every LLM step by llm.ts:117), so a per-call draw made ONE run_id fan
+	// out across N client ids — which is what upstream refuses as
+	// free_mode_run_fanout. The shape stays SDK-faithful 13-char base36:
+	// never the sess:/run:-prefixed forms the server fingerprints as a
+	// proxy, and never pingmike's ^wf-[a-z0-9]{8}$ (#103;
+	// cf-worker-signals.ts looksLikeProxyClientId). trace_session_id is
+	// likewise per run and freebuff_instance_id stays per session.
+	clientID := opts.ClientID
+	if clientID == "" {
+		clientID = generateClientID()
+	}
 	metadata := map[string]any{
 		"run_id":    opts.RunID,
-		"client_id": generateClientID(),
+		"client_id": clientID,
 	}
 	if opts.TraceSessionID != "" {
 		metadata["trace_session_id"] = opts.TraceSessionID

--- a/internal/upstream/client_chat.go
+++ b/internal/upstream/client_chat.go
@@ -433,6 +433,12 @@ func (b *cancelBody) Close() error {
 	return err
 }
 
+// NewClientID mints one SDK-faithful client id for a run. The CLI draws it
+// once per PROMPT (run.ts:722 promptId, passed as clientSessionId at run.ts:822
+// and reused by every LLM step of that run), so the run manager mints it with
+// the run and every chat call of that run repeats it.
+func NewClientID() string { return generateClientID() }
+
 // generateClientID mints the SDK-faithful 13-char base36 client id
 // (Math.random().toString(36).substring(2, 15)).
 func generateClientID() string {

--- a/internal/upstream/client_chat_test.go
+++ b/internal/upstream/client_chat_test.go
@@ -124,11 +124,13 @@ func TestChatCompletionsEnvelope(t *testing.T) {
 	if md["freebuff_instance_id"] != "inst-1" {
 		t.Errorf("freebuff_instance_id = %v", md["freebuff_instance_id"])
 	}
-	// #103: client_id is a FRESH random draw per chat call — never the
-	// sess:-prefixed shape the server fingerprints as a proxy.
+	// client_id is the RUN's id (one per run, repeated per call) and keeps
+	// the SDK-faithful shape — never the sess:-prefixed form the server
+	// fingerprints as a proxy. This call passes none, so it is the fallback
+	// draw.
 	clientID, _ := md["client_id"].(string)
 	if !regexp.MustCompile(`^[a-z0-9]{13}$`).MatchString(clientID) || strings.HasPrefix(clientID, "sess:") {
-		t.Errorf("client_id = %q, want a fresh 13-char base36 draw per chat call (#103)", clientID)
+		t.Errorf("client_id = %q, want a 13-char base36 draw", clientID)
 	}
 	provider, ok := sent["provider"].(map[string]any)
 	if !ok || provider["data_collection"] != "deny" {

--- a/internal/upstream/client_retry_test.go
+++ b/internal/upstream/client_retry_test.go
@@ -1484,3 +1484,45 @@ func TestClassifyOpaqueRateLimitedBoundedBackoff(t *testing.T) {
 		t.Errorf("ResetAt = %v, want zero (opaque body: no midnight lock)", rle.ResetAt)
 	}
 }
+
+// TestClassifyRunFanout pins the free_mode_run_fanout refusal: the observed
+// body ({"error":"free_mode_run_fanout","message":"Free mode request
+// rejected."}) used to fall through to the default branch, which the server
+// wrote as a dead 502 upstream_unavailable and killed the client's turn. It
+// must classify as a bounded-cooldown RateLimitError on ANY status the marker
+// rides (the upstream body carries no status of its own), with no ResetAt and
+// no Period so the pool treats it as a transient rate limit rather than a
+// per-model quota exhaustion.
+func TestClassifyRunFanout(t *testing.T) {
+	const body = `{"error":"free_mode_run_fanout","message":"Free mode request rejected."}`
+	for _, status := range []int{http.StatusForbidden, http.StatusTooManyRequests, http.StatusBadGateway} {
+		err := classifyError(status, body, http.Header{})
+		var rle *RateLimitError
+		if !errors.As(err, &rle) {
+			t.Fatalf("status %d: classifyError = %T %v, want *RateLimitError", status, err, err)
+		}
+		if rle.Status != "free_mode_run_fanout" {
+			t.Errorf("status %d: Status = %q, want free_mode_run_fanout", status, rle.Status)
+		}
+		if rle.RetryAfter != FanoutCooldown {
+			t.Errorf("status %d: RetryAfter = %v, want %v", status, rle.RetryAfter, FanoutCooldown)
+		}
+		if !rle.ResetAt.IsZero() || rle.Period != "" || rle.Limit != 0 {
+			t.Errorf("status %d: quota-shaped fields set (%v/%q/%v), want a transient refusal",
+				status, rle.ResetAt, rle.Period, rle.Limit)
+		}
+	}
+
+	// A Retry-After header wins over the default, clamped like every other
+	// cooldown.
+	hdr := http.Header{}
+	hdr.Set("Retry-After", "5")
+	err := classifyError(http.StatusTooManyRequests, body, hdr)
+	var rle *RateLimitError
+	if !errors.As(err, &rle) {
+		t.Fatalf("classifyError = %T %v, want *RateLimitError", err, err)
+	}
+	if rle.RetryAfter != 5*time.Second {
+		t.Errorf("RetryAfter = %v, want 5s (header honored)", rle.RetryAfter)
+	}
+}

--- a/internal/upstream/ratelimit.go
+++ b/internal/upstream/ratelimit.go
@@ -98,6 +98,28 @@ func classifyError(status int, body string, hdr http.Header) error {
 		// cases because upstream can attach it to any status (reference:
 		// freebuff-reverse adapter.go classifies it Retryable by body first).
 		return &UpstreamError{Status: status, Body: truncate(body, 500), RetryAfter: retryAfter, Retryable: true}
+	case containsAny(lower, "free_mode_run_fanout"):
+		// free_mode_run_fanout: the free tier refused the request because the
+		// account's concurrent-run counter looked like proxy fanout (upstream
+		// common/src/constants/freebuff-spend-ceilings.ts names "proxy fanout"
+		// a ban-grade sweep signal). Body-marker driven and status-agnostic —
+		// upstream attaches it to a bare {"error":...,"message":"Free mode
+		// request rejected."} whose status the default branch turned into a
+		// dead 502. It is a CONCURRENCY refusal, not a quota one: it clears
+		// as soon as the account's other runs drain, so it gets the bounded
+		// load_shedding/peak_hours treatment (distinct Status, no ResetAt,
+		// no Period => isQuotaExhaustedError is false, no Pacific-midnight
+		// lock) and the token cools for FanoutCooldown so the pool rotates to
+		// another token instead of re-feeding the fanout counter.
+		ra := clampCooldown(retryAfter)
+		if ra <= 0 {
+			ra = FanoutCooldown
+		}
+		return &RateLimitError{
+			Status:     "free_mode_run_fanout",
+			RetryAfter: ra,
+			Body:       truncate(body, 200),
+		}
 	case containsAny(lower, "free_mode_capacity_deferred"):
 		// Free-tier transient capacity queue: upstream says "your request
 		// will be retried automatically" and a same-session retry recovers
@@ -453,6 +475,13 @@ func isCapacityDeferred(err error) bool {
 	var cde *CapacityDeferredError
 	return errors.As(err, &cde)
 }
+
+// FanoutCooldown bounds a free_mode_run_fanout refusal: the upstream
+// concurrent-run counter clears as the account's other runs drain (seconds,
+// not a day), and re-hitting it feeds a ban-grade sweep signal — so the token
+// backs off for a minute rather than being locked until Pacific midnight.
+// Used only when the refusal carries no Retry-After header.
+const FanoutCooldown = 60 * time.Second
 
 // LoadShedCooldown bounds a 429 load-saturation refusal (issue #133): the
 // upstream sheds load for minutes, not a day, so the token re-probes after


### PR DESCRIPTION
## Summary

This PR fixes the `free_mode_run_fanout` refusal that was killing client turns with a dead 502 `upstream_unavailable`. The root cause was that the proxy was producing the exact "proxy fanout" shape upstream classifies as ban-grade evidence (`freebuff-spend-ceilings.ts`).

## Changes

### `client_id` per run (not per call)
The CLI mints `client_id` once per prompt (`run.ts:722/822`) and reuses it on every LLM step. The proxy was drawing a fresh `client_id` per chat call, making one `run_id` fan out across N `client_id`s — the exact anti-pattern upstream refuses. Now `ClientID` is minted once by the run manager and threaded through the envelope.

### Dropped prewarm fleet
`Pool.Start` no longer fans out a run per registry agent per token at boot. That fleet held ~one concurrent agent run per served model on a single free account — the "proxy fanout" sweep signal. Runs now START lazily on first `Acquire`.

### `free_mode_run_fanout` → 429 (was 502)
The upstream refusal body `{"error":"free_mode_run_fanout","message":"Free mode request rejected."}` was falling through to the generic `UpstreamError` branch → dead 502. Now classified as `RateLimitError` with bounded `FanoutCooldown` (60s) and surfaced as 429 so clients back off. Never re-POSTs into a fanout refusal.

### Luna retired root override
`openai/gpt-5.6-luna`'s root agent was retired upstream (`free_mode_legacy_luna_agent`). Added `retiredRootOverrides` map: `base2-free-luna` → `base3-free-luna`.

### ScarceSessionError accuracy
Now reports the HELD session's model (not the requested one) for correct `Retry-After` hints.

### Run persistence fix
`ClientID` is persisted with the run so a restart doesn't split a run's identity.

### Build tags
Makefile and Taskfile use `-tags dashboard` for Go builds.

## Tests

All 24 test suites pass. New tests:
- `TestChatRunFanoutSurfaced429` — end-to-end: fanout body → 429 + Retry-After, one chat call only
- `TestChatClientIDStableAcrossRun` — same client_id across calls on one run
- `TestInjectEnvelopeClientIDPerRun` — envelope repeats the run's client_id
- `TestClassifyRunFanout` — fanout body classified as RateLimitError on any status
- `TestRetiredRootOverrideAppliesToBothPaths` — offline and live-parse paths agree
- `TestStartDoesNotFanOutAndShutdownDrains` — no boot fleet, drains one lease