### PR TITLE
feat(registry): serve stealth/ox-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ If you are a beginner, you don't need to write code or compile anything:
 | **Premium** | **DeepSeek V4 Pro** | `deepseek/deepseek-v4-pro` | **Deep reasoning**, Reasoning: `high`. Per-model cap removed upstream (Aug 23 snapshot) — draws from the shared daily premium pool; weekday peak-hour pauses lifted. |
 | **Unlimited**| **MiMo 2.5** | `mimo/mimo-v2.5` | **Balanced**, Images. **Unlimited across all tiers**. |
 | **Referral** | **GLM 5.2** | `z-ai/glm-5.2` | **Top open-source agentic model**. Referral-gated (+1 session/referral). |
+| **Stealth** | **Ox Alpha** | `stealth/ox-alpha` | **Anonymous stealth provider**, Reasoning: mandatory (`low`/`high`/`max`, default `high`). 1M-token context, multimodal. Free tier. |
 | **Disabled** | **MiniMax M3** | `minimax/minimax-m3` | **Temporarily Unavailable** upstream due to server-side cost spikes. |
 
 Full detail in [Key Hygiene & Ban Avoidance](#key-hygiene--ban-avoidance).

--- a/internal/convert/convert_req_test.go
+++ b/internal/convert/convert_req_test.go
@@ -196,6 +196,16 @@ func TestExtractReasoningEffort(t *testing.T) {
 			payload: map[string]any{"model": "deepseek/deepseek-v4-pro:max", "reasoning": map[string]any{"effort": "medium"}},
 			want:    "medium",
 		},
+		{
+			name:    "ox-alpha model suffix parenthesized medium",
+			payload: map[string]any{"model": "stealth/ox-alpha(medium)"},
+			want:    "medium",
+		},
+		{
+			name:    "ox-alpha model suffix colon max",
+			payload: map[string]any{"model": "stealth/ox-alpha:max"},
+			want:    "max",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -244,6 +254,26 @@ func TestNormalizeRequestReasoningEffort(t *testing.T) {
 	}
 	if _, ok := got["thinking"]; ok {
 		t.Error("thinking block added for non-deepseek model")
+	}
+
+	// stealth/ox-alpha shares the DeepSeek V4 ladder shape ('low','high',
+	// 'max', no medium): nested reasoning.effort is clamped and sent PLAIN,
+	// never as a client-side thinking block.
+	body = map[string]any{
+		"model":     "stealth/ox-alpha",
+		"messages":  []any{map[string]any{"role": "user", "content": "hello"}},
+		"reasoning": map[string]any{"effort": "max"},
+	}
+	out, err = NormalizeRequest(mustJSON(t, body), "")
+	if err != nil {
+		t.Fatalf("NormalizeRequest: %v", err)
+	}
+	got = decode(t, out)
+	if gotEff, ok := got["reasoning_effort"].(string); !ok || gotEff != "max" {
+		t.Errorf("reasoning_effort = %v, want \"max\"", got["reasoning_effort"])
+	}
+	if _, ok := got["thinking"]; ok {
+		t.Error("thinking block emitted for stealth/ox-alpha model")
 	}
 }
 
@@ -384,6 +414,11 @@ func TestDeepSeekPlainReasoningEffort(t *testing.T) {
 		{"flash max stays max", "deepseek/deepseek-v4-flash", "max", "max"},
 		{"flash xhigh clamps down to high", "deepseek/deepseek-v4-flash", "xhigh", "high"},
 		{"pro low stays low", "deepseek/deepseek-v4-pro", "low", "low"},
+		{"ox-alpha low stays low", "stealth/ox-alpha", "low", "low"},
+		{"ox-alpha medium rewrites to high", "stealth/ox-alpha", "medium", "high"},
+		{"ox-alpha high stays high", "stealth/ox-alpha", "high", "high"},
+		{"ox-alpha max stays max", "stealth/ox-alpha", "max", "max"},
+		{"bare ox-alpha id tolerated", "ox-alpha", "medium", "high"},
 		{"pro medium rewrites to high", "deepseek/deepseek-v4-pro", "medium", "high"},
 		{"pro max stays max", "deepseek/deepseek-v4-pro", "max", "max"},
 		{"bare model id tolerated", "deepseek-v4-flash", "max", "max"},
@@ -500,6 +535,7 @@ func TestEffortsForModel(t *testing.T) {
 	for model, want := range map[string][]string{
 		"deepseek/deepseek-v4-flash":      {"low", "high", "max"},
 		"deepseek/deepseek-v4-pro":        {"low", "high", "max"},
+		"stealth/ox-alpha":                {"low", "high", "max"},
 		"mimo/mimo-v2.5":                  {"high"}, // Xiaomi: disabled/high only
 		"minimax/minimax-m3":              {"high"}, // adaptive/disabled only
 		"anthropic/claude-fable-5":        {"low", "medium", "high", "xhigh", "max"},
@@ -567,6 +603,11 @@ func TestNormalizeRequestEffortClamp(t *testing.T) {
 	// never down to low.
 	if got := effortFor("deepseek/deepseek-v4-flash", "medium"); got != "high" {
 		t.Errorf("deepseek-v4-flash medium = %q, want high", got)
+	}
+	// stealth/ox-alpha shares the DeepSeek V4 ladder ('low','high','max'):
+	// medium likewise rewrites to high, never down to low.
+	if got := effortFor("stealth/ox-alpha", "medium"); got != "high" {
+		t.Errorf("stealth/ox-alpha medium = %q, want high", got)
 	}
 	// mimo/mimo-v2.5 exposes only disabled/high: every depth rung is a
 	// compatibility alias and clamps to high.

--- a/internal/convert/effort.go
+++ b/internal/convert/effort.go
@@ -86,6 +86,10 @@ const defaultReasoningEffort = "high"
 //	                                     ['low','high','max'] — medium is not a
 //	                                     distinct level and rewrites to high
 //	                                     (see normalizeReasoning).
+//	stealth/ox-alpha                     OX_ALPHA_REASONING_EFFORTS
+//	                                     ['low','high','max'] — medium is not
+//	                                     a distinct level and rewrites to
+//	                                     high (see normalizeReasoning).
 //	gpt-5.6-luna / claude-fable-5        EFFORTS_THROUGH_MAX low..max (xhigh
 //	                                     included, OpenRouter metadata).
 //	muse-spark-1.2-contributor           EFFORTS_THROUGH_XHIGH minimal..xhigh
@@ -104,12 +108,10 @@ const defaultReasoningEffort = "high"
 //	google/*-flash-lite rows             absent — helper models, no upstream
 //	                                     restriction.
 //
-//	google/*-flash-lite rows             absent — helper models, no upstream
-//	                                     restriction.
-//
 // Clamping mirrors upstream's resolveFreebuffReasoningEffort
 // (reference/freebuff/common/src/constants/freebuff-models.ts): clamp-DOWN,
-// keyed on the actually-served model, medium→high on DeepSeek V4. For rows
+// keyed on the actually-served model, medium→high on DeepSeek V4 and Ox
+// Alpha. For rows
 // with no ladder upstream returns null and passes the client value through
 // untouched (MIMO/MiniMax treat any rung as thinking-on; GLM/Kimi ignore it)
 // — clamping those rows to "high" is the alias-equivalent normalization.
@@ -120,6 +122,7 @@ const defaultReasoningEffort = "high"
 var modelReasoningEfforts = map[string][]string{
 	"deepseek/deepseek-v4-flash":      {"low", "high", "max"},
 	"deepseek/deepseek-v4-pro":        {"low", "high", "max"},
+	"stealth/ox-alpha":                {"low", "high", "max"},
 	"mimo/mimo-v2.5":                  {"high"},
 	"minimax/minimax-m3":              {"high"},
 	"anthropic/claude-fable-5":        {"low", "medium", "high", "xhigh", "max"},
@@ -200,14 +203,21 @@ func clampReasoningEffort(requested string, allowed []string, fallback string) s
 }
 
 // isDeepSeekModel reports whether the route is one of the DeepSeek V4 models.
-// DeepSeek routes accept prompt-cache hints (#84) and rewrite requested
-// "medium" to "high" (#112). Tolerates both the registry's full ids and bare
-// model ids. The provisioned -max variants are blocked at the ServedModels
-// gate (issue #153) and never reach conversion.
+// DeepSeek routes accept prompt-cache hints (#84). Tolerates both the
+// registry's full ids and bare model ids. The provisioned -max variants are
+// blocked at the ServedModels gate (issue #153) and never reach conversion.
 func isDeepSeekModel(model string) bool {
 	m := strings.ToLower(model)
 	return strings.HasSuffix(m, "deepseek-v4-flash") ||
 		strings.HasSuffix(m, "deepseek-v4-pro")
+}
+
+// isMediumlessLadderModel reports whether the model's upstream effort ladder
+// omits "medium" (DeepSeek V4, Ox Alpha): both rewrite a requested "medium"
+// to "high" (#112) instead of the generic down-clamp, which would pick "low".
+func isMediumlessLadderModel(model string) bool {
+	m := strings.ToLower(model)
+	return isDeepSeekModel(m) || strings.HasSuffix(m, "ox-alpha")
 }
 
 // isStrictReasoningModel reports whether the model requires an explicit reasoning_content
@@ -258,8 +268,9 @@ func extractLeakedThinkTags(content string) (string, string) {
 //     rungs (down-nearest, never rejected; unknown efforts fall back to
 //     "high"). The DeepSeek thinking translation is server-side per issue
 //     #111 — the proxy never emits a thinking block.
-//   - "medium" on a DeepSeek route rewrites to "high" first (CLI
-//     resolveFreebuffReasoningEffort: medium → high on Flash/Pro, #112).
+//   - "medium" on DeepSeek V4 / Ox Alpha routes rewrites to "high" first
+//     (CLI resolveFreebuffReasoningEffort: medium → high when the ladder
+//     lacks it, #112).
 //   - reasoning.enabled === false or thinking.type "disabled" suppresses the
 //     effort entirely (no reasoning_effort, no thinking field).
 func normalizeReasoning(payload, out map[string]any) {
@@ -295,10 +306,10 @@ func normalizeReasoning(payload, out map[string]any) {
 		// No effort requested: leave the body untouched.
 	default:
 		var clamped string
-		if isDeepSeekModel(model) && eff == "medium" {
+		if isMediumlessLadderModel(model) && eff == "medium" {
 			// CLI resolveFreebuffReasoningEffort: medium is intentionally
-			// absent from the DeepSeek ladders and rewrites to high — never
-			// down to low (the generic clamp would say low).
+			// absent from these ladders (DeepSeek V4, Ox Alpha) and rewrites
+			// to high — never down to low (the generic clamp would say low).
 			clamped = "high"
 		} else {
 			clamped = clampReasoningEffort(eff, effortsForModel(model), defaultReasoningEffort)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -80,27 +80,32 @@ const maxFetchBytes = 2 << 20
 // kimi-k3-eco, subscriptions.ts GOD_ONLY_BAIT_MODEL_ID) — but a model no
 // real client can reach makes proxy traffic to it indistinguishable from
 // probing a hidden eval route, so the gate excludes it.
+// stealth/ox-alpha rejoined the served set with vendor cce4800 (2026-08-24,
+// issue #209): SUPPORTED_FREEBUFF_MODELS gained it as the first row of the
+// CLI/Desktop catalog, ending its web/cloud-only fencing.
 var ServedModels = map[string]bool{
 	"deepseek/deepseek-v4-flash": true,
 	"deepseek/deepseek-v4-pro":   true,
 	"openai/gpt-5.6-luna":        true,
 	"z-ai/glm-5.2":               true,
 	"mimo/mimo-v2.5":             true,
+	"stealth/ox-alpha":           true,
 }
 
-// SupportedModelIDs is the canonical list of the 5 active models served by the gateway.
+// SupportedModelIDs is the canonical list of the 6 active models served by the gateway.
 var SupportedModelIDs = []string{
 	"deepseek/deepseek-v4-flash",
 	"deepseek/deepseek-v4-pro",
 	"openai/gpt-5.6-luna",
 	"z-ai/glm-5.2",
 	"mimo/mimo-v2.5",
+	"stealth/ox-alpha",
 }
 
 // SupportedModelsHelpText is the formatted list of models for error messages (issue #189).
-const SupportedModelsHelpText = "deepseek/deepseek-v4-flash, deepseek/deepseek-v4-pro, openai/gpt-5.6-luna, z-ai/glm-5.2, mimo/mimo-v2.5"
+const SupportedModelsHelpText = "deepseek/deepseek-v4-flash, deepseek/deepseek-v4-pro, openai/gpt-5.6-luna, z-ai/glm-5.2, mimo/mimo-v2.5, stealth/ox-alpha"
 
-// IsServedModel reports whether model is in the 5 active served models.
+// IsServedModel reports whether model is in the 6 active served models.
 func IsServedModel(model string) bool {
 	return ServedModels[model]
 }
@@ -208,7 +213,7 @@ var fallbackAgents = []agentModels{
 // fallbackRootByModel mirrors upstream FREEBUFF_ROOT_AGENT_ID_BY_MODEL (pinned
 // free-agents.ts): the per-model roots win over first-seen assignment, exactly
 // like a live refresh (parseRootAgentMap + buildModelMapping). Without it the
-// fallback collapses the five base models onto the generic base2-free agent,
+// fallback collapses the six base models onto the generic base2-free agent,
 // so a fallback-state request for a second base model would reuse a session
 // admitted for another model and trip upstream session_model_mismatch.
 var fallbackRootByModel = map[string]string{

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -34,7 +34,7 @@ func fileSource(t *testing.T, path string) string {
 // expectedFallback is the model→agent map the pruned, parity-checked fallback
 // table must produce: the pinned upstream snapshot (testdata/upstream) parsed
 // with the real parser, with FREEBUFF_ROOT_AGENT_ID_BY_MODEL winning over
-// first-seen assignment (exactly like a live refresh). The five base models
+// first-seen assignment (exactly like a live refresh). The six base models
 // route to their per-model roots (not the generic base2-free), the gemini
 // helper models belong to file-picker / file-picker-max, and every upstream-
 // retired id is absent.
@@ -902,14 +902,15 @@ func TestResolveModelMaxUpgradeRemoved(t *testing.T) {
 }
 
 // TestStrictServedModelsPinned pins issue #189 (strict gate) as amended by
-// #201 and the 2026-08-23 luna-es drop: ServedModels contains ONLY the 5
-// operational FreeBuff models. openai/gpt-5.6-luna-es was removed after the
-// vendor moved it into FREEBUFF_WEB_GOD_ONLY_MODELS ("Codex (test)" — Novita
-// route, evaluation only; hidden from the CLI picker and
+// #201 and the 2026-08-23 luna-es drop, and by #209: ServedModels contains
+// ONLY the 6 operational FreeBuff models. openai/gpt-5.6-luna-es was removed
+// after the vendor moved it into FREEBUFF_WEB_GOD_ONLY_MODELS ("Codex
+// (test)" — Novita route, evaluation only; hidden from the CLI picker and
 // SUPPORTED_FREEBUFF_MODELS in snapshot 0603bc1) — not the documented
-// honeypot (that is kimi-k3-eco), but unreachable to real clients. All
-// decommissioned models, god-only/hidden-eval models, and -max variants are
-// rejected by IsServedModel.
+// honeypot (that is kimi-k3-eco), but unreachable to real clients.
+// stealth/ox-alpha was gated in when vendor cce4800 made it the first row of
+// SUPPORTED_FREEBUFF_MODELS. All decommissioned models, god-only/hidden-eval
+// models, and -max variants are rejected by IsServedModel.
 func TestStrictServedModelsPinned(t *testing.T) {
 	wantModels := []string{
 		"deepseek/deepseek-v4-flash",
@@ -917,9 +918,10 @@ func TestStrictServedModelsPinned(t *testing.T) {
 		"openai/gpt-5.6-luna",
 		"z-ai/glm-5.2",
 		"mimo/mimo-v2.5",
+		"stealth/ox-alpha",
 	}
-	if len(ServedModels) != 5 {
-		t.Fatalf("len(ServedModels) = %d, want exactly 5", len(ServedModels))
+	if len(ServedModels) != 6 {
+		t.Fatalf("len(ServedModels) = %d, want exactly 6", len(ServedModels))
 	}
 	for _, m := range wantModels {
 		if !ServedModels[m] {

--- a/internal/server/server_models_test.go
+++ b/internal/server/server_models_test.go
@@ -107,9 +107,10 @@ func TestModelsEndpoint(t *testing.T) {
 		t.Errorf("object = %q, want list", out.Object)
 	}
 	// Issue #189 (strict gate); 6→5 on 2026-08-23: luna-es dropped (upstream
-	// reclassified it god-only/honeypot-class — vendor snapshot 0603bc1).
-	if len(out.Data) != 5 {
-		t.Errorf("models = %d, want 5", len(out.Data))
+	// reclassified it god-only/honeypot-class — vendor snapshot 0603bc1);
+	// 5→6 on 2026-08-26: stealth/ox-alpha added (vendor cce4800).
+	if len(out.Data) != 6 {
+		t.Errorf("models = %d, want 6", len(out.Data))
 	}
 	for i, m := range out.Data {
 		if m.ID == "" || m.Object != "model" || m.OwnedBy == "" {
@@ -197,9 +198,10 @@ func TestHealthz(t *testing.T) {
 	if out.UptimeSeconds < 0 {
 		t.Errorf("uptime_seconds = %v, want >= 0", out.UptimeSeconds)
 	}
-	// Issue #189 strict count; 6→5 when luna-es was dropped (2026-08-23).
-	if out.Models != 5 {
-		t.Errorf("models = %d, want 5", out.Models)
+	// Issue #189 strict count; 6→5 when luna-es was dropped (2026-08-23),
+	// 5→6 when stealth/ox-alpha was added (2026-08-26).
+	if out.Models != 6 {
+		t.Errorf("models = %d, want 6", out.Models)
 	}
 	if len(out.Tokens) != 2 {
 		t.Errorf("tokens = %d, want 2", len(out.Tokens))
@@ -559,8 +561,8 @@ func TestModelsAllowEmptyIsOpen(t *testing.T) {
 	if err := json.Unmarshal(data, &out); err != nil {
 		t.Fatalf("models is not JSON: %v: %s", err, data)
 	}
-	if len(out.Data) != 5 {
-		t.Errorf("model count = %d, want 5 (all operational models served)", len(out.Data))
+	if len(out.Data) != 6 {
+		t.Errorf("model count = %d, want 6 (all operational models served)", len(out.Data))
 	}
 	var hasModelA, hasFlash bool
 	for _, m := range out.Data {
@@ -762,12 +764,12 @@ func TestMetricsTransientRetryCounters(t *testing.T) {
 	}
 }
 
-// TestStrictFiveModelsEnforced pins issue #189 end-to-end:
-//  1. GET /v1/models returns strictly the 5 operational models.
+// TestStrictServedModelsEnforced pins issue #189 end-to-end:
+//  1. GET /v1/models returns strictly the 6 operational models.
 //  2. Any request targeting a disabled model on OpenAI chat, Anthropic messages,
 //     or OpenAI responses returns immediate fast-fail with model_unavailable.
-//  3. /healthz reports models: 5.
-func TestStrictFiveModelsEnforced(t *testing.T) {
+//  3. /healthz reports models: 6.
+func TestStrictServedModelsEnforced(t *testing.T) {
 	mock := testutil.NewMock()
 	defer mock.Close()
 	ts, _ := newTestServer(t, nil, mock)
@@ -785,8 +787,8 @@ func TestStrictFiveModelsEnforced(t *testing.T) {
 	if err := json.Unmarshal(data, &out); err != nil {
 		t.Fatalf("unmarshal /v1/models: %v", err)
 	}
-	if len(out.Data) != 5 {
-		t.Fatalf("models count = %d, want exactly 5", len(out.Data))
+	if len(out.Data) != 6 {
+		t.Fatalf("models count = %d, want exactly 6", len(out.Data))
 	}
 	wantSet := map[string]bool{
 		"deepseek/deepseek-v4-flash": true,
@@ -794,6 +796,7 @@ func TestStrictFiveModelsEnforced(t *testing.T) {
 		"openai/gpt-5.6-luna":        true,
 		"z-ai/glm-5.2":               true,
 		"mimo/mimo-v2.5":             true,
+		"stealth/ox-alpha":           true,
 	}
 	for _, m := range out.Data {
 		if !wantSet[m.ID] {
@@ -877,8 +880,8 @@ func TestStrictFiveModelsEnforced(t *testing.T) {
 	if err := json.Unmarshal(dataH, &health); err != nil {
 		t.Fatalf("unmarshal healthz: %v", err)
 	}
-	if health.Models != 5 {
-		t.Errorf("health.Models = %d, want 5", health.Models)
+	if health.Models != 6 {
+		t.Errorf("health.Models = %d, want 6", health.Models)
 	}
 }
 


### PR DESCRIPTION
Adds `stealth/ox-alpha` to the served model set (5 -> 6), per the upstream vendor snapshot at CodebuffAI/freebuff @ 63a1d68f50264536d602a6c76c477619aa22b3af.

Upstream facts driving this:
- Vendor-sanctioned on every surface since 2026-08-24: first row of SUPPORTED_FREEBUFF_MODELS, CLI/Desktop/Web pickers, service-only gate emptied; rollback lever is FREEBUFF_PAUSED_FREE_MODEL_IDS (does not contain ox).
- Unmetered by design: availability 'always', premium false, FREEBUFF_PER_MODEL_SESSION_CAPS = {} — no quota rows to synthesize; rateLimitsByModel carries no ox entry.
- No provider-route lane: falls through to the default OpenRouter route (unlike luna/mimo); no lane or capacity-overflow behavior to port.
- Reasoning mandatory with a mediumless ladder ['low','high','max'], default 'high'; requested 'medium' rewrites to 'high' via isMediumlessLadderModel.
- Session root stays base2-free-ox-alpha (parser parity unchanged); 1,000,000-token client context window.

Changes: ServedModels/SupportedModelIDs/help text, effort ladder row + mediumless rewrite helper (+tests), registry/server test expectations, README model table row.

Closes #209