### PR TITLE
fix(server): surface upstream coercion and annotate limited-tier models

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -391,8 +391,8 @@ func defaultRawConfig() rawConfig {
 		CORSAllowedOrigin:                "*",         // browser clients reach /v1/* cross-origin by default
 		RequestJitter:                    "",          // "" = disabled (unset → SAFE_MODE preset may fill)
 		CLIVersion:                       "0.10.7",
-		TransientRetries:                 nil,   // nil = 1 (one retry after a transient transport failure; 0 disables)
-		SessionPersist:                   true,  // session persistence on by default: restart resumes unexpired sessions
+		TransientRetries:                 nil,  // nil = 1 (one retry after a transient transport failure; 0 disables)
+		SessionPersist:                   true, // session persistence on by default: restart resumes unexpired sessions
 		SessionStateFile:                 ".freebuff-session-state.json",
 		HTTP2Upstream:                    true,        // h2 ALPN matches real browsers (reference proxy-freebuff USE_HTTP2 default '1'); HTTP2_UPSTREAM=false forces h1 (#51)
 		SessionCreateMaxParallelGlobal:   ptrInt(128), // #86: concurrent session admissions cap

--- a/backend/internal/dashboard/events_test.go
+++ b/backend/internal/dashboard/events_test.go
@@ -3,14 +3,14 @@ package dashboard
 import (
 	"bufio"
 	"encoding/json"
+	"freebuff-proxy/backend/internal/config"
+	"freebuff-proxy/backend/internal/pool"
+	"freebuff-proxy/backend/internal/registry"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
-	"freebuff-proxy/backend/internal/config"
-	"freebuff-proxy/backend/internal/pool"
-	"freebuff-proxy/backend/internal/registry"
 )
 
 // TestHandleEventsStreamInitialSnapshotAndPing verifies the SSE endpoint:

--- a/backend/internal/modelcat/catalog.go
+++ b/backend/internal/modelcat/catalog.go
@@ -99,6 +99,16 @@ const DefaultModelID = "z-ai/glm-5.3-flash"
 // be mimo, never the premium picker lead.
 const FallbackModelID = "mimo/mimo-v2.5"
 
+// LimitedModelID mirrors upstream LIMITED_FREEBUFF_MODEL_ID: the model
+// guaranteed available on the limited tier.
+const LimitedModelID = "mimo/mimo-v2.5"
+
+// IsLimitedTierAllowed reports whether the model is available on the limited tier
+// without requiring special referral grants.
+func IsLimitedTierAllowed(id string) bool {
+	return id == LimitedModelID
+}
+
 // Glm52ModelID is the referral-reward model, metered by its own promo pool
 // rather than the shared premium pool.
 const Glm52ModelID = "z-ai/glm-5.2"

--- a/backend/internal/pool/bridge_cache.go
+++ b/backend/internal/pool/bridge_cache.go
@@ -398,6 +398,7 @@ func (p *Pool) BridgeSnapshot() []BridgeTokenSnapshot {
 			Locked:        e.locked.Load(),
 			CooldownUntil: cooldownUntil,
 			SessionActive: sess.Status == "active",
+			AccessTier:    sess.AccessTier,
 			Model:         model,
 			QuotaByModel:  quotaByModel,
 			SpendDay:      float64(spend.Day),

--- a/backend/internal/pool/pool.go
+++ b/backend/internal/pool/pool.go
@@ -157,6 +157,9 @@ type TokenSnapshot struct {
 	// annotation and healthz.
 	CountryCode        string
 	CountryBlockReason string
+	// AccessTier is the upstream access tier from the last session admission
+	// ("full", "limited", "free"); "" until reported.
+	AccessTier string `json:"access_tier,omitempty"`
 	// SessionActiveUsersForIP is the last known distinct-user count on the
 	// token's egress IP (upstream activeUsersForIp); zero when the session
 	// response did not carry it.

--- a/backend/internal/pool/snapshot.go
+++ b/backend/internal/pool/snapshot.go
@@ -18,6 +18,7 @@ type BridgeTokenSnapshot struct {
 	CooldownUntil time.Time                        `json:"cooldown_until"`
 	SessionActive bool                             `json:"session_active"`
 	Model         string                           `json:"model"`
+	AccessTier    string                           `json:"access_tier,omitempty"`
 	QuotaByModel  map[string]session.QuotaSnapshot `json:"quota_by_model,omitempty"`
 	// PremiumQuota mirrors TokenSnapshot's premium view (quota_tracker.go).
 	// Nil when the bridge entry has no premium quota.
@@ -161,6 +162,7 @@ func (p *Pool) Snapshot() []TokenSnapshot {
 			SessionRemainingSeconds: sessionRemaining,
 			CountryCode:             countryCode,
 			CountryBlockReason:      countryReason,
+			AccessTier:              ss.AccessTier,
 			SessionActiveUsersForIP: ss.ActiveUsersForIP,
 			QuotaByModel:            ss.QuotaByModel,
 			PremiumQuota:            premium,

--- a/backend/internal/server/engine.go
+++ b/backend/internal/server/engine.go
@@ -319,6 +319,12 @@ func (s *Server) chatCore(w http.ResponseWriter, r *http.Request, model string, 
 	if fallbackReason != "" {
 		w.Header().Set("X-FreeBuff-Fallback", fallbackReason)
 		routingAttrs = append(routingAttrs, "served_model", servedModel)
+	} else if servedModel != model {
+		// Issue #230: upstream coercion transparency. When upstream binds the
+		// session to a different model (e.g. limited-tier token coerced to mimo),
+		// surface served_model in the INFO routing log so operators immediately
+		// see the requested->served redirection.
+		routingAttrs = append(routingAttrs, "served_model", servedModel)
 	}
 	s.logger.Info(kind+" routing", routingAttrs...)
 

--- a/backend/internal/server/models.go
+++ b/backend/internal/server/models.go
@@ -136,6 +136,7 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 	}
 	codexReq := codexClientVersion(r)
 	hideUnavailable := s.cfg.Load().ModelsHideUnavailable
+	tier := currentAccessTier(snaps)
 	data := make([]map[string]any, 0, len(models))
 	listed := make([]string, 0, len(models))
 	for _, id := range models {
@@ -153,14 +154,18 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 			// variants stay invisible on the catalog surface.
 			continue
 		}
-		data = append(data, map[string]any{
+		row := map[string]any{
 			"id":        id,
 			"object":    "model",
 			"created":   created,
 			"owned_by":  "freebuff",
 			"available": available,
 			"status":    status,
-		})
+		}
+		if tier != "" {
+			row["current_access_tier"] = tier
+		}
+		data = append(data, row)
 		listed = append(listed, id)
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -285,9 +290,50 @@ func codexModelRow(id string) codexModelInfo {
 	}
 }
 
+// currentAccessTier resolves the effective access tier across the pool snapshots.
+// Returns "full", "limited", "free", or "" if no token has reported an access tier yet.
+func currentAccessTier(snaps []pool.TokenSnapshot) string {
+	hasLimited := false
+	for _, snap := range snaps {
+		switch snap.AccessTier {
+		case "full":
+			return "full"
+		case "free":
+			return "free"
+		case "limited":
+			hasLimited = true
+		}
+	}
+	if hasLimited {
+		return "limited"
+	}
+	return ""
+}
+
+// isModelAllowedForTier reports whether id can be served under tier.
+// On limited tier, only limited-tier models (mimo-v2.5) or GLM 5.2 with active referral quota
+// can be admitted.
+func isModelAllowedForTier(id, tier string, snaps []pool.TokenSnapshot) bool {
+	if tier != "limited" {
+		return true
+	}
+	if modelcat.IsLimitedTierAllowed(id) {
+		return true
+	}
+	if id == modelcat.Glm52ModelID {
+		for _, snap := range snaps {
+			if q, ok := snap.QuotaByModel[id]; ok && q.Limit > 0 && q.RecentCount < q.Limit {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // modelAvailability derives the advisory per-model annotation from the pool
 // token snapshots. The snapshot does not carry the model of a live session,
-// so the signal set is: quotaByModel presence (the session admitted this
+// so the signal set is: accessTier (limited tier marks non-mimo models as
+// region_limited), quotaByModel presence (the session admitted this
 // model), quota exhaustion (recent >= limit), and session-level locks.
 // available defaults to true when no signal exists, so a working model is
 // never hidden.
@@ -297,6 +343,7 @@ func modelAvailability(id string, snaps []pool.TokenSnapshot) (available bool, s
 	quotaHit := false
 	quotaExhausted := false
 	locked := false
+	tier := currentAccessTier(snaps)
 	for _, snap := range snaps {
 		switch snap.SessionStatus {
 		case "model_locked", "disabled":
@@ -310,6 +357,9 @@ func modelAvailability(id string, snaps []pool.TokenSnapshot) (available bool, s
 		}
 	}
 	switch {
+	case tier == "limited" && !isModelAllowedForTier(id, tier, snaps):
+		available = false
+		status = "region_limited"
 	case quotaExhausted:
 		status = "quota_exhausted"
 	case locked:

--- a/backend/internal/server/openai.go
+++ b/backend/internal/server/openai.go
@@ -145,12 +145,16 @@ func (s *Server) handleModelRetrieve(w http.ResponseWriter, r *http.Request) {
 	snaps := s.pool.Snapshot()
 	available, status := modelAvailability(model, snaps)
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]any{
+	row := map[string]any{
 		"id":        modelName,
 		"object":    "model",
 		"created":   created,
 		"owned_by":  "freebuff",
 		"available": available,
 		"status":    status,
-	})
+	}
+	if tier := currentAccessTier(snaps); tier != "" {
+		row["current_access_tier"] = tier
+	}
+	_ = json.NewEncoder(w).Encode(row)
 }

--- a/backend/internal/server/server_models_test.go
+++ b/backend/internal/server/server_models_test.go
@@ -1314,3 +1314,180 @@ func TestMetricsFamiliesContract(t *testing.T) {
 		}
 	})
 }
+
+// TestModelsEndpointLimitedTier verifies that when upstream reports accessTier: "limited",
+// /v1/models annotates each row with current_access_tier: "limited", marks mimo/mimo-v2.5
+// available: true, and marks models outside the limited-tier allowlist available: false,
+// status: "region_limited".
+func TestModelsEndpointLimitedTier(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.AccessTier = "limited"
+	ts, _ := newTestServer(t, nil, mock)
+
+	// Execute a chat to admit a session and populate the pool snapshot with AccessTier: "limited".
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody("mimo/mimo-v2.5"), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("chat status = %d, want 200: %s", resp.StatusCode, data)
+	}
+
+	resp, data = doJSON(t, http.MethodGet, ts.URL+"/v1/models", nil, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("models status = %d, want 200: %s", resp.StatusCode, data)
+	}
+	var out struct {
+		Data []struct {
+			ID                string `json:"id"`
+			Available         bool   `json:"available"`
+			Status            string `json:"status"`
+			CurrentAccessTier string `json:"current_access_tier"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal /v1/models: %v", err)
+	}
+	if len(out.Data) == 0 {
+		t.Fatal("empty models data")
+	}
+	for _, m := range out.Data {
+		if m.CurrentAccessTier != "limited" {
+			t.Errorf("model %s current_access_tier = %q, want limited", m.ID, m.CurrentAccessTier)
+		}
+		if m.ID == "mimo/mimo-v2.5" {
+			if !m.Available {
+				t.Errorf("mimo available = false, want true on limited tier")
+			}
+		} else {
+			if m.Available {
+				t.Errorf("model %s available = true, want false on limited tier", m.ID)
+			}
+			if m.Status != "region_limited" {
+				t.Errorf("model %s status = %q, want region_limited", m.ID, m.Status)
+			}
+		}
+	}
+}
+
+// TestModelsEndpointLimitedTierHideUnavailable verifies that MODELS_HIDE_UNAVAILABLE=true
+// prunes region_limited models on the limited tier, returning only the limited-allowed models.
+func TestModelsEndpointLimitedTierHideUnavailable(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.AccessTier = "limited"
+	ts, _ := newTestServerCfg(t, nil, func(cfg *config.Config) {
+		cfg.ModelsHideUnavailable = true
+	}, mock)
+
+	// Admit session so AccessTier is known.
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody("mimo/mimo-v2.5"), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("chat status = %d, want 200: %s", resp.StatusCode, data)
+	}
+
+	resp, data = doJSON(t, http.MethodGet, ts.URL+"/v1/models", nil, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("models status = %d, want 200: %s", resp.StatusCode, data)
+	}
+	var out struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal /v1/models: %v", err)
+	}
+	if len(out.Data) != 1 || out.Data[0].ID != "mimo/mimo-v2.5" {
+		t.Errorf("got models %+v, want only [mimo/mimo-v2.5]", out.Data)
+	}
+}
+
+// TestModelRetrieveLimitedTier verifies that single model retrieval /v1/models/{model...}
+// returns the current_access_tier and region_limited annotations.
+func TestModelRetrieveLimitedTier(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.AccessTier = "limited"
+	ts, _ := newTestServer(t, nil, mock)
+
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody("mimo/mimo-v2.5"), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("chat status = %d, want 200: %s", resp.StatusCode, data)
+	}
+
+	// Non-limited model
+	resp, data = doJSON(t, http.MethodGet, ts.URL+"/v1/models/z-ai/glm-5.3-flash", nil, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get glm-5.3-flash status = %d, want 200: %s", resp.StatusCode, data)
+	}
+	var glm struct {
+		ID                string `json:"id"`
+		Available         bool   `json:"available"`
+		Status            string `json:"status"`
+		CurrentAccessTier string `json:"current_access_tier"`
+	}
+	if err := json.Unmarshal(data, &glm); err != nil {
+		t.Fatalf("unmarshal glm: %v", err)
+	}
+	if glm.Available || glm.Status != "region_limited" || glm.CurrentAccessTier != "limited" {
+		t.Errorf("glm row = %+v, want available=false, status=region_limited, current_access_tier=limited", glm)
+	}
+
+	// Limited model
+	resp, data = doJSON(t, http.MethodGet, ts.URL+"/v1/models/mimo/mimo-v2.5", nil, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get mimo status = %d, want 200: %s", resp.StatusCode, data)
+	}
+	var mimo struct {
+		ID                string `json:"id"`
+		Available         bool   `json:"available"`
+		Status            string `json:"status"`
+		CurrentAccessTier string `json:"current_access_tier"`
+	}
+	if err := json.Unmarshal(data, &mimo); err != nil {
+		t.Fatalf("unmarshal mimo: %v", err)
+	}
+	if !mimo.Available || mimo.CurrentAccessTier != "limited" {
+		t.Errorf("mimo row = %+v, want available=true, current_access_tier=limited", mimo)
+	}
+}
+
+// TestChatRoutingLogsServedModelOnCoercion verifies issue #230: when upstream coerces
+// the session to a different model (e.g. mimo), the INFO routing log line explicitly
+// includes served_model and the response carries X-FreeBuff-Served-Model.
+func TestChatRoutingLogsServedModelOnCoercion(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-coerced","accessTier":"limited","model":"mimo/mimo-v2.5","expiresAt":"2030-01-01T00:00:00Z"}`)
+	}
+
+	ring := logring.NewHandler(slog.NewTextHandler(io.Discard, nil), 500)
+	ts, _ := newTestServerWithLogger(t, nil, slog.New(ring), ring, mock)
+
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody("z-ai/glm-5.3-flash"), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("chat status = %d, want 200: %s", resp.StatusCode, data)
+	}
+
+	if servedHeader := resp.Header.Get("X-FreeBuff-Served-Model"); servedHeader != "mimo/mimo-v2.5" {
+		t.Errorf("X-FreeBuff-Served-Model header = %q, want mimo/mimo-v2.5", servedHeader)
+	}
+
+	var routingEntry *logring.Entry
+	for _, e := range ring.Recent(500) {
+		if e.Message == "chat routing" {
+			routingEntry = &e
+			break
+		}
+	}
+	if routingEntry == nil {
+		t.Fatal("missing 'chat routing' entry in log ring")
+	}
+	if gotModel := entryField(*routingEntry, "model"); gotModel != "z-ai/glm-5.3-flash" {
+		t.Errorf("routing model = %q, want z-ai/glm-5.3-flash", gotModel)
+	}
+	if gotServed := entryField(*routingEntry, "served_model"); gotServed != "mimo/mimo-v2.5" {
+		t.Errorf("routing served_model = %q, want mimo/mimo-v2.5 (upstream coercion logged)", gotServed)
+	}
+}

--- a/backend/internal/session/session.go
+++ b/backend/internal/session/session.go
@@ -153,7 +153,8 @@ type Manager struct {
 	// invalidation/re-admission cycles, mirroring savedQuota (issue #178):
 	// the GLM promo quota row must stay visible while the session is
 	// between quota-carrying responses.
-	savedGlmPromo string
+	savedGlmPromo   string
+	savedAccessTier string
 
 	// adopt is the issue #97 CLI-session adoption mode (ADOPT_CLI_SESSION):
 	// nil (default) = create sessions normally. When set, the manager adopts
@@ -199,6 +200,7 @@ type cachedState struct {
 	status             string
 	instanceID         string
 	model              string
+	accessTier         string
 	expiresAt          time.Time
 	gracePeriodEndsAt  time.Time
 	position           int
@@ -300,6 +302,9 @@ func (m *Manager) commit(cs *cachedState) {
 		if m.state.referral != nil {
 			m.savedReferral = m.state.referral
 		}
+		if m.state.accessTier != "" {
+			m.savedAccessTier = m.state.accessTier
+		}
 	}
 	// Restore the previously-seen quota map when the new state omits
 	// rateLimitsByModel (the upstream intermittently drops the field on
@@ -315,6 +320,9 @@ func (m *Manager) commit(cs *cachedState) {
 	}
 	// Restore the countdown and referral the same way when the new state
 	// omits them.
+	if cs != nil && cs.accessTier == "" && m.savedAccessTier != "" {
+		cs.accessTier = m.savedAccessTier
+	}
 	if cs != nil && cs.remainingMs == 0 && m.savedRemainingMs > 0 {
 		cs.remainingMs = m.savedRemainingMs
 	}
@@ -566,6 +574,7 @@ func (m *Manager) Snapshot() SessionSnapshot {
 			GlmPromo:     m.savedGlmPromo,
 			RemainingMs:  m.savedRemainingMs,
 			Referral:     m.savedReferral,
+			AccessTier:   m.savedAccessTier,
 		}
 	}
 	quota := make(map[string]QuotaSnapshot, len(m.state.quotaByModel))
@@ -590,6 +599,7 @@ func (m *Manager) Snapshot() SessionSnapshot {
 		Status:             m.state.status,
 		InstanceID:         m.state.instanceID,
 		Model:              m.state.model,
+		AccessTier:         m.state.accessTier,
 		QueuePosition:      m.state.position,
 		QueueDepth:         m.state.queueDepth,
 		Refreshing:         m.refreshing,
@@ -688,6 +698,12 @@ func (m *Manager) UpdateQuotaFromProbe(st *upstream.SessionState) {
 			m.state.referral = st.Referral
 		}
 	}
+	if st.AccessTier != "" {
+		m.savedAccessTier = st.AccessTier
+		if m.state != nil {
+			m.state.accessTier = st.AccessTier
+		}
+	}
 }
 
 // Invalidate drops the cached session so the next EnsureSession re-creates
@@ -774,6 +790,20 @@ func (m *Manager) SetSessionStateForTest(status, instanceID, model string, expir
 		status:            status,
 		instanceID:        instanceID,
 		model:             model,
+		expiresAt:         expiresAt,
+		gracePeriodEndsAt: graceEndsAt,
+	})
+}
+
+// SetSessionStateWithTierForTest sets cached session state with an access tier for tests.
+func (m *Manager) SetSessionStateWithTierForTest(status, instanceID, model, accessTier string, expiresAt, graceEndsAt time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.commit(&cachedState{
+		status:            status,
+		instanceID:        instanceID,
+		model:             model,
+		accessTier:        accessTier,
 		expiresAt:         expiresAt,
 		gracePeriodEndsAt: graceEndsAt,
 	})

--- a/backend/internal/session/session_admission.go
+++ b/backend/internal/session/session_admission.go
@@ -432,6 +432,7 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string, preemptive
 				quotaByModel:       st.RateLimitsByModel,
 				glmPromo:           st.GlmPromo,
 				standing:           st.Standing,
+				accessTier:         st.AccessTier,
 			})
 			// Issue #60: the successful admission refreshes the probe cache
 			// window — subsequent session poll GETs within the TTL are
@@ -483,6 +484,7 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string, preemptive
 				queueDepth: st.QueueDepth,
 				pollAt:     pollAt,
 				glmPromo:   st.GlmPromo,
+				accessTier: st.AccessTier,
 			})
 			m.mu.Unlock()
 			slog.Debug("session queued", "instance_id", st.InstanceID, "model", model,

--- a/backend/internal/session/session_admission_test.go
+++ b/backend/internal/session/session_admission_test.go
@@ -713,6 +713,20 @@ func TestCacheRecordsUpstreamServedModel(t *testing.T) {
 	}
 }
 
+func TestSessionSnapshotAccessTier(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.AccessTier = "limited"
+	mgr := newTestManager(t, mock)
+
+	if _, err := mgr.EnsureSessionForModel(context.Background(), "mimo/mimo-v2.5"); err != nil {
+		t.Fatal(err)
+	}
+	if snap := mgr.Snapshot(); snap.AccessTier != "limited" {
+		t.Fatalf("snapshot AccessTier = %q, want limited", snap.AccessTier)
+	}
+}
+
 // TestActiveSessionWithoutModelServesAnyModel pins the leniency: a
 // session created via the default-model path (cached model "") is reused for
 // ANY requested model — the cache-hit check treats "" as a wildcard. The

--- a/backend/internal/session/session_types.go
+++ b/backend/internal/session/session_types.go
@@ -20,7 +20,10 @@ type SessionSnapshot struct {
 	RemainingMs int64
 	// Refreshing reports whether a session admission or pre-emptive re-admit
 	// is currently in flight for this manager.
-	Refreshing         bool
+	Refreshing bool
+	// AccessTier is the upstream access tier ("full", "limited", "free") from
+	// the last session admission; "" until reported.
+	AccessTier         string
 	CountryCode        string
 	CountryBlockReason string
 	// ActiveUsersForIP is the last known distinct-user count on the token's

--- a/backend/internal/session/store.go
+++ b/backend/internal/session/store.go
@@ -34,6 +34,7 @@ type persistedState struct {
 	PollAt             time.Time                 `json:"poll_at"`
 	CountryCode        string                    `json:"country_code"`
 	CountryBlockReason string                    `json:"country_block_reason"`
+	AccessTier         string                    `json:"access_tier,omitempty"`
 	QuotaByModel       map[string]persistedQuota `json:"quota_by_model,omitempty"`
 	// GlmPromo is the raw upstream glmPromo block ({dailySessions,
 	// endsAt}); "" when absent (issue #178).
@@ -225,6 +226,7 @@ func (s *Store) Load(key string) *cachedState {
 		pollAt:             ps.PollAt,
 		countryCode:        ps.CountryCode,
 		countryBlockReason: ps.CountryBlockReason,
+		accessTier:         ps.AccessTier,
 		glmPromo:           ps.GlmPromo,
 	}
 	if len(ps.QuotaByModel) > 0 {
@@ -277,6 +279,7 @@ func (s *Store) Save(key string, cs *cachedState) {
 		PollAt:             cs.pollAt,
 		CountryCode:        cs.countryCode,
 		CountryBlockReason: cs.countryBlockReason,
+		AccessTier:         cs.accessTier,
 		GlmPromo:           cs.glmPromo,
 	}
 	if len(cs.quotaByModel) > 0 {

--- a/backend/internal/testutil/mockupstream.go
+++ b/backend/internal/testutil/mockupstream.go
@@ -81,6 +81,9 @@ type MockUpstream struct {
 	// tests can exercise region reporting end-to-end.
 	CountryCode        string
 	CountryBlockReason string
+	// AccessTier, when non-empty, is embedded in the active/probe session body
+	// ("full", "limited", "free") so tests can exercise access tier annotations.
+	AccessTier string
 
 	// Standing, when non-empty, is embedded in the session create/poll
 	// response body's "standing" key (issue #96) so dashboard e2e tests can
@@ -361,6 +364,7 @@ func (m *MockUpstream) handleSession(w http.ResponseWriter, r *http.Request) {
 	limits := m.RateLimitsByModel
 	glmPromo := m.GlmPromo
 	countryCode, countryBlockReason := m.CountryCode, m.CountryBlockReason
+	accessTier := m.AccessTier
 	standing := m.Standing
 	m.mu.Unlock()
 
@@ -385,6 +389,9 @@ func (m *MockUpstream) handleSession(w http.ResponseWriter, r *http.Request) {
 		}
 		if countryBlockReason != "" {
 			body["countryBlockReason"] = countryBlockReason
+		}
+		if accessTier != "" {
+			body["accessTier"] = accessTier
 		}
 		if len(standing) > 0 {
 			body["standing"] = standing
@@ -453,6 +460,7 @@ func (m *MockUpstream) handleProbe(w http.ResponseWriter) {
 	limits := m.RateLimitsByModel
 	glmPromo := m.GlmPromo
 	countryCode, countryBlockReason := m.CountryCode, m.CountryBlockReason
+	accessTier := m.AccessTier
 	m.mu.Unlock()
 	if len(limits) == 0 {
 		limits = defaultProbeQuota
@@ -473,6 +481,9 @@ func (m *MockUpstream) handleProbe(w http.ResponseWriter) {
 	}
 	if countryBlockReason != "" {
 		body["countryBlockReason"] = countryBlockReason
+	}
+	if accessTier != "" {
+		body["accessTier"] = accessTier
 	}
 	writeJSON(w, 200, body)
 }

--- a/backend/internal/upstream/client_session_test.go
+++ b/backend/internal/upstream/client_session_test.go
@@ -45,6 +45,24 @@ func TestSessionControlCalls(t *testing.T) {
 	}
 }
 
+func TestSessionParseAccessTier(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.AccessTier = "limited"
+
+	client, err := New("tok", testConfig(mock.URL(), nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := client.CreateSession(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.AccessTier != "limited" {
+		t.Fatalf("AccessTier = %q, want limited", st.AccessTier)
+	}
+}
+
 // TestProbeAccount verifies the zero-cost token probe: a GET
 // /api/v1/freebuff/session with NO instance header that claims no session
 // slot, returns the live per-model quota, and classifies

--- a/backend/internal/upstream/session_parse.go
+++ b/backend/internal/upstream/session_parse.go
@@ -23,6 +23,7 @@ type SessionState struct {
 	Model              string
 	CurrentModel       string
 	RequestedModel     string
+	AccessTier         string
 	ExpiresAt          time.Time
 	AdmittedAt         time.Time
 	RemainingMs        int64
@@ -343,6 +344,7 @@ func (c *Client) parseSessionResponse(req *http.Request, resp *http.Response, bo
 		PollAt                 any                      `json:"pollAt"`
 		CountryCode            string                   `json:"countryCode"`
 		CountryBlockReason     string                   `json:"countryBlockReason"`
+		AccessTier             string                   `json:"accessTier"`
 		IpPrivacySignals       []string                 `json:"ipPrivacySignals"`
 		ActiveUsersForIP       int                      `json:"activeUsersForIp"`
 		Limit                  float64                  `json:"limit"`
@@ -372,6 +374,7 @@ func (c *Client) parseSessionResponse(req *http.Request, resp *http.Response, bo
 			CountryCode:        raw.CountryCode,
 			CountryBlockReason: raw.CountryBlockReason,
 			IpPrivacySignals:   raw.IpPrivacySignals,
+			AccessTier:         raw.AccessTier,
 			ActiveUsersForIP:   raw.ActiveUsersForIP,
 			Limit:              raw.Limit,
 			RecentCount:        raw.RecentCount,


### PR DESCRIPTION
## Summary

Fixes #230 by adding transparency when operating under an upstream limited-tier token or egress IP:
1. **Routing Log Coercion Visibility**: When upstream coerces a session to a different model (e.g. `mimo/mimo-v2.5`), `served_model` is now explicitly logged in the `INFO` level `chat routing` entry (`requested != served`).
2. **Access Tier Propagation**: `accessTier` from upstream session responses is now parsed, stored in cached session state, and exposed through `session.SessionSnapshot`, `pool.TokenSnapshot`, and `pool.BridgeTokenSnapshot`.
3. **`/v1/models` Annotations**:
   - Each model row now includes `current_access_tier` when the active token/IP reports its tier.
   - When on the limited tier, models outside the limited-tier allowlist (`mimo/mimo-v2.5`) are marked with `available: false, status: "region_limited"`.
   - `MODELS_HIDE_UNAVAILABLE=true` correctly prunes unavailable models on the limited tier.
   - Single-model retrieval (`GET /v1/models/{model...}`) returns matching availability and access tier annotations.

## Verification
- Hermetic test suite passed across all 21 packages (`env -u AUTH_TOKENS -u ADMIN_TOKEN go test ./backend/...`).
- Added end-to-end tests covering:
  - `TestSessionParseAccessTier` (upstream package)
  - `TestSessionSnapshotAccessTier` (session package)
  - `TestModelsEndpointLimitedTier` (server package)
  - `TestModelsEndpointLimitedTierHideUnavailable` (server package)
  - `TestModelRetrieveLimitedTier` (server package)
  - `TestChatRoutingLogsServedModelOnCoercion` (server package)
- `gofmt` and `go vet` passed cleanly with 0 diagnostics.