### PR TITLE
fix(cli): CLI-fidelity gap fills + remove non-CLI weight (fingerprint enhanced-, compact, heartbeat, trace, envelope)

### DIFF
--- a/backend/internal/server/chat_attempt_test.go
+++ b/backend/internal/server/chat_attempt_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -139,7 +140,7 @@ func TestChatAttemptRetryCarriesFreshRunIdentity(t *testing.T) {
 			RequestID:         "req-rf",
 			StepNumber:        1, // the fresh run's first step
 		}
-		if captured[1] != want {
+		if !reflect.DeepEqual(captured[1], want) {
 			t.Errorf("retry envelope = %+v, want %+v (fresh run identity)", captured[1], want)
 		}
 	})
@@ -158,7 +159,7 @@ func TestChatAttemptRetryCarriesFreshRunIdentity(t *testing.T) {
 		if got := invalidated; len(got) != 0 {
 			t.Errorf("invalidateRun calls = %v, want none on a transient error", got)
 		}
-		if captured[1] != captured[0] {
+		if !reflect.DeepEqual(captured[1], captured[0]) {
 			t.Errorf("same-run retry envelope changed: %+v -> %+v (want identical)", captured[0], captured[1])
 		}
 	})

--- a/backend/internal/upstream/chat.go
+++ b/backend/internal/upstream/chat.go
@@ -323,10 +323,28 @@ func injectEnvelope(body []byte, costMode string, opts ChatOptions) ([]byte, err
 	if clientID == "" {
 		clientID = generateClientID()
 	}
-	metadata := map[string]any{
-		"run_id":    opts.RunID,
-		"client_id": clientID,
+	// Preserve any extra caller-supplied codebuff_metadata keys (e.g.
+	// cache_debug_correlation, n) the CLI's getProviderOptions merges via
+	// extraCodebuffMetadata before stamping reserved identifiers (llm.ts:112-119).
+	// Reserved keys are always overwritten below so the server trusts only
+	// proxy-minted identifiers; non-reserved extras are forwarded verbatim.
+	extraMeta := map[string]any{}
+	if raw, ok := payload["codebuff_metadata"].(map[string]any); ok {
+		for k, v := range raw {
+			switch k {
+			case "run_id", "client_id", "trace_session_id", "freebuff_instance_id", "llm_step_number", "cost_mode", "freebuff_reasoning_effort":
+				// reserved — overwritten below
+			default:
+				extraMeta[k] = v
+			}
+		}
 	}
+	metadata := map[string]any{}
+	for k, v := range extraMeta {
+		metadata[k] = v
+	}
+	metadata["run_id"] = opts.RunID
+	metadata["client_id"] = clientID
 	if opts.TraceSessionID != "" {
 		metadata["trace_session_id"] = opts.TraceSessionID
 	}

--- a/backend/internal/upstream/chat.go
+++ b/backend/internal/upstream/chat.go
@@ -343,8 +343,8 @@ func injectEnvelope(body []byte, costMode string, opts ChatOptions) ([]byte, err
 	if raw, ok := payload["codebuff_metadata"].(map[string]any); ok {
 		for k, v := range raw {
 			switch k {
-			case "run_id", "client_id", "trace_session_id", "freebuff_instance_id", "llm_step_number", "cost_mode", "freebuff_reasoning_effort", "n", "cache_debug_correlation":
-				// reserved — overwritten below
+			case "run_id", "client_id", "trace_session_id", "freebuff_instance_id", "llm_step_number", "cost_mode", "freebuff_reasoning_effort":
+				// reserved — overwritten below (server-trusted identifiers)
 			default:
 				extraMeta[k] = v
 			}
@@ -352,7 +352,7 @@ func injectEnvelope(body []byte, costMode string, opts ChatOptions) ([]byte, err
 	}
 	for k, v := range opts.ExtraCodebuffMetadata {
 		switch k {
-		case "run_id", "client_id", "trace_session_id", "freebuff_instance_id", "llm_step_number", "cost_mode", "freebuff_reasoning_effort", "n", "cache_debug_correlation":
+		case "run_id", "client_id", "trace_session_id", "freebuff_instance_id", "llm_step_number", "cost_mode", "freebuff_reasoning_effort":
 			// reserved — must not be smuggled via extra
 			continue
 		default:

--- a/backend/internal/upstream/chat.go
+++ b/backend/internal/upstream/chat.go
@@ -45,6 +45,17 @@ type ChatOptions struct {
 	// Injected as codebuff_metadata["llm_step_number"] when > 0; the run
 	// manager sets it per chat call at the server construction sites.
 	StepNumber int
+	// N is codebuff_metadata["n"] (llm.ts:118 `...(n && {n})`). 0 means
+	// absent (mirrors JS truthiness). CLI forwards it when sampling multiple
+	// completions.
+	N int
+	// CacheDebugCorrelation is codebuff_metadata["cache_debug_correlation"]
+	// (llm.ts:120-122). Empty means absent.
+	CacheDebugCorrelation string
+	// ExtraCodebuffMetadata is the CLI's extraCodebuffMetadata spread
+	// (llm.ts:115 `...(extraCodebuffMetadata ?? {})`) — caller-supplied
+	// keys merged BEFORE reserved identifiers so reserved keys win.
+	ExtraCodebuffMetadata map[string]string
 }
 
 // ChatCompletions POSTs an OpenAI-shaped request to the upstream chat
@@ -325,18 +336,27 @@ func injectEnvelope(body []byte, costMode string, opts ChatOptions) ([]byte, err
 	}
 	// Preserve any extra caller-supplied codebuff_metadata keys (e.g.
 	// cache_debug_correlation, n) the CLI's getProviderOptions merges via
-	// extraCodebuffMetadata before stamping reserved identifiers (llm.ts:112-119).
+	// extraCodebuffMetadata before stamping reserved identifiers (llm.ts:112-122).
 	// Reserved keys are always overwritten below so the server trusts only
 	// proxy-minted identifiers; non-reserved extras are forwarded verbatim.
 	extraMeta := map[string]any{}
 	if raw, ok := payload["codebuff_metadata"].(map[string]any); ok {
 		for k, v := range raw {
 			switch k {
-			case "run_id", "client_id", "trace_session_id", "freebuff_instance_id", "llm_step_number", "cost_mode", "freebuff_reasoning_effort":
+			case "run_id", "client_id", "trace_session_id", "freebuff_instance_id", "llm_step_number", "cost_mode", "freebuff_reasoning_effort", "n", "cache_debug_correlation":
 				// reserved — overwritten below
 			default:
 				extraMeta[k] = v
 			}
+		}
+	}
+	for k, v := range opts.ExtraCodebuffMetadata {
+		switch k {
+		case "run_id", "client_id", "trace_session_id", "freebuff_instance_id", "llm_step_number", "cost_mode", "freebuff_reasoning_effort", "n", "cache_debug_correlation":
+			// reserved — must not be smuggled via extra
+			continue
+		default:
+			extraMeta[k] = v
 		}
 	}
 	metadata := map[string]any{}
@@ -356,8 +376,14 @@ func injectEnvelope(body []byte, costMode string, opts ChatOptions) ([]byte, err
 	if opts.StepNumber > 0 {
 		metadata["llm_step_number"] = strconv.Itoa(opts.StepNumber)
 	}
+	if opts.N > 0 {
+		metadata["n"] = opts.N
+	}
 	if costMode != "" {
 		metadata["cost_mode"] = costMode
+	}
+	if opts.CacheDebugCorrelation != "" {
+		metadata["cache_debug_correlation"] = opts.CacheDebugCorrelation
 	}
 	// freebuff_reasoning_effort mirrors the normalized top-level
 	// reasoning_effort the convert layer already clamped to the model's

--- a/backend/internal/upstream/inject_envelope_test.go
+++ b/backend/internal/upstream/inject_envelope_test.go
@@ -194,6 +194,31 @@ func TestInjectEnvelopeNAndCacheDebugCorrelation(t *testing.T) {
 	if md3["cache_debug_correlation"] != "new_corr" {
 		t.Errorf("cache_debug_correlation = %v, want new_corr (ChatOptions wins over payload)", md3["cache_debug_correlation"])
 	}
+
+	// Downstream client sending n via payload codebuff_metadata must be
+	// forwarded when opts.N==0 (watchdog: n is forwardable, not reserved).
+	out4, err := injectEnvelope([]byte(`{"model":"m","codebuff_metadata":{"n":2,"custom":"x"}}`), "free", ChatOptions{RunID: "r"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(out4, &sent); err != nil {
+		t.Fatal(err)
+	}
+	md4 := sent["codebuff_metadata"].(map[string]any)
+	if md4["n"] != float64(2) {
+		t.Errorf("payload n = %v, want 2 (forwarded when opts.N==0)", md4["n"])
+	}
+	// opts.N overwrites payload n when set
+	out5, err := injectEnvelope([]byte(`{"model":"m","codebuff_metadata":{"n":2}}`), "free", ChatOptions{RunID: "r", N: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(out5, &sent); err != nil {
+		t.Fatal(err)
+	}
+	if sent["codebuff_metadata"].(map[string]any)["n"] != float64(5) {
+		t.Errorf("n = %v, want 5 (opts.N overwrites payload)", sent["codebuff_metadata"].(map[string]any)["n"])
+	}
 }
 
 

--- a/backend/internal/upstream/inject_envelope_test.go
+++ b/backend/internal/upstream/inject_envelope_test.go
@@ -124,6 +124,78 @@ func TestInjectEnvelopeStepNumber(t *testing.T) {
 		t.Error("llm_step_number present when StepNumber == 0")
 	}
 }
+// TestInjectEnvelopeNAndCacheDebugCorrelation verifies llm.ts:118-122
+// mirror: N (when >0) and cache_debug_correlation (when non-empty) are
+// stamped into codebuff_metadata, and ExtraCodebuffMetadata is merged
+// BEFORE reserved identifiers so reserved keys win. Also covers payload
+// codebuff_metadata extra passthrough (payload extras are kept, reserved
+// extras are overwritten).
+func TestInjectEnvelopeNAndCacheDebugCorrelation(t *testing.T) {
+	// N + cache_debug_correlation present
+	out, err := injectEnvelope([]byte(`{"model":"m"}`), "free", ChatOptions{
+		RunID:                 "r",
+		N:                     3,
+		CacheDebugCorrelation: "corr-123",
+		ExtraCodebuffMetadata: map[string]string{"custom_key": "custom_val", "run_id": "smuggled"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sent map[string]any
+	if err := json.Unmarshal(out, &sent); err != nil {
+		t.Fatal(err)
+	}
+	md := sent["codebuff_metadata"].(map[string]any)
+	if md["n"] != float64(3) { // JSON numbers decode as float64
+		t.Errorf("n = %v (%T), want 3", md["n"], md["n"])
+	}
+	if md["cache_debug_correlation"] != "corr-123" {
+		t.Errorf("cache_debug_correlation = %v, want corr-123", md["cache_debug_correlation"])
+	}
+	if md["custom_key"] != "custom_val" {
+		t.Errorf("custom_key = %v, want custom_val (extra metadata passthrough)", md["custom_key"])
+	}
+	if md["run_id"] != "r" {
+		t.Errorf("run_id = %v, want r (reserved must win over smuggled extra)", md["run_id"])
+	}
+
+	// Absent when zero/empty
+	out2, err := injectEnvelope([]byte(`{"model":"m"}`), "free", ChatOptions{RunID: "r"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(out2, &sent); err != nil {
+		t.Fatal(err)
+	}
+	md2 := sent["codebuff_metadata"].(map[string]any)
+	if _, present := md2["n"]; present {
+		t.Error("n present when N == 0")
+	}
+	if _, present := md2["cache_debug_correlation"]; present {
+		t.Error("cache_debug_correlation present when empty")
+	}
+
+	// Payload codebuff_metadata extra keys are preserved; reserved payload
+	// keys are overwritten.
+	out3, err := injectEnvelope([]byte(`{"model":"m","codebuff_metadata":{"payload_extra":"keep","run_id":"old","cache_debug_correlation":"old_corr"}}`), "free", ChatOptions{RunID: "r", CacheDebugCorrelation: "new_corr"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(out3, &sent); err != nil {
+		t.Fatal(err)
+	}
+	md3 := sent["codebuff_metadata"].(map[string]any)
+	if md3["payload_extra"] != "keep" {
+		t.Errorf("payload_extra = %v, want keep (payload extra passthrough)", md3["payload_extra"])
+	}
+	if md3["run_id"] != "r" {
+		t.Errorf("run_id = %v, want r (payload reserved overwrite)", md3["run_id"])
+	}
+	if md3["cache_debug_correlation"] != "new_corr" {
+		t.Errorf("cache_debug_correlation = %v, want new_corr (ChatOptions wins over payload)", md3["cache_debug_correlation"])
+	}
+}
+
 
 // --- #94: 428 waiting_room_required classification ---------------------------
 

--- a/backend/internal/upstream/inject_envelope_test.go
+++ b/backend/internal/upstream/inject_envelope_test.go
@@ -124,6 +124,7 @@ func TestInjectEnvelopeStepNumber(t *testing.T) {
 		t.Error("llm_step_number present when StepNumber == 0")
 	}
 }
+
 // TestInjectEnvelopeNAndCacheDebugCorrelation verifies llm.ts:118-122
 // mirror: N (when >0) and cache_debug_correlation (when non-empty) are
 // stamped into codebuff_metadata, and ExtraCodebuffMetadata is merged
@@ -220,7 +221,6 @@ func TestInjectEnvelopeNAndCacheDebugCorrelation(t *testing.T) {
 		t.Errorf("n = %v, want 5 (opts.N overwrites payload)", sent["codebuff_metadata"].(map[string]any)["n"])
 	}
 }
-
 
 // --- #94: 428 waiting_room_required classification ---------------------------
 

--- a/docs/CLI-FIDELITY-PLAN.md
+++ b/docs/CLI-FIDELITY-PLAN.md
@@ -1,0 +1,70 @@
+# CLI-Fidelity Fill-Gaps & Optimize Plan — freebuff-proxy
+
+**Goal:** What CLI serves, proxy serves. CLI-only reverse of `reference/freebuff @ 887786e`. Remove browser impersonation, keep wire parity.
+
+## 0. Baseline: Already CLI-faithful (7f6f15b + 5687206)
+
+* `TLS_FINGERPRINT=""` plain `crypto/tls` default (`config_env.go:488` no auto), `Bun/1.3.14` for session / `ai-sdk/openai-compatible/1.0.0/codebuff` for chat (`upstream/client.go:83,122`), `SanitizeHeaders` only, no `ApplyProfileHeaders` (`upstream/client_chat.go:91`).
+* `REQUEST_JITTER 2s → 200ms` (`config_env.go:493`), `ch 64` (`server/stream_shared.go:215`), `Flush per Write` + `keepalive 15s` + byte-preserving fast path (`openai_chunk_pipeline.go`).
+* Hermetic `env -u AUTH_TOKENS -u ADMIN_TOKEN go test ./backend/...` `ok`, `sync-upstream --check` `exit 0` (`registry` + `wire` SAMEs), SG `172.188.64.104` `no stealth` logs, `~80-111 tok/s` streaming, `header 2.5-10.6s` upstream-dominated.
+
+## 1. Gap Inventory (CLI vs Proxy)
+
+### P0 — Wire fidelity (must fill, watchdog priority)
+
+1. **Fingerprint `enhanced-` vs plain** — CLI `cli/src/utils/fingerprint.ts:87-128` full JSON (`fingerprintVersion 2.0`, `system{manufacturer,model,serial,uuid}`, `cpu{brand,cores,physicalCores}`, `os{platform,distro,arch,hostname}`, `runtime{nodeVersion,shell,cpuCount}`, `network{macAddresses sorted, interfaceCount}`, `machineId MachineGuid`) → `sha256 base64url enhanced-` (`process-cache 143-151`, fallback `codebuff-cli-` `131-133`). Proxy `auth_fingerprint.go` narrower (`hostname,MACs,CPU`) — must mirror exact CLI JSON per CLI-only (SYSTEM.md notes narrower is opaque but watchdog says `enhanced-` gap is P0).
+2. **Instance-owner pid lock** — `cli/src/utils/freebuff-instance-owner.ts:12-54` `freebuff-instance-owner.json {instanceId,pid}` + `isFreebuffInstanceOwnedByDeadLocalProcess` via `process.kill(pid,0)` liveness (single local CLI guard). Proxy pooled never needs single-user lock; bridge per-token must respect `USER+SERVER-MINTED instanceId` rotation, not pid file — document divergence, no `kill` in proxy.
+3. **Compact-session header** — `common/constants/freebuff-models.ts:2354-2370` `x-freebuff-compact-session:1` on `GET /api/v1/freebuff/session` poll omits `rateLimitsByModel` quota (CLI `sdk` compact). Proxy must send `compact=1` on poll; verify `upstream/client.go:newRequest` adds it when `compact`.
+4. **Heartbeat omission** — `x-freebuff-heartbeat 45s` Desktop-only (`freebuff-models.ts:2354`), CLI TUI (`hooks/use-freebuff-session.ts:16-45`) never sends (`Desktop-only`). Proxy `pool` must never send `heartbeat` — already correct, gate verification.
+5. **Trace.jsonl intentional divergence** — CLI `cli/src/utils/trace-writer.ts:9-80` + `common/types/contracts/trace.ts:11 RecordStep` → `trace.jsonl` one JSON line per step (`run-agent-step.ts:422-640`). Proxy is transport only (not executor `agents/base2`, `packages/agent-runtime`) — must NOT replicate; document as intentional gap.
+6. **Auth wire** — `POST /api/auth/cli/code {fingerprintId} → {loginUrl,fingerprintHash,expiresAt epoch ms}` + `GET /status?fingerprintId&fingerprintHash&expiresAt` until `401` vs `200`. Proxy `gen-freebuff-token.sh` random per-run vs wizard stable — keep both.
+7. **Chat envelope + model/agent map** — `sdk/impl/llm.ts:getProviderOptions` `codebuff_metadata {run_id, client_id 13-char base36, freebuff_instance_id}` + `data_collection:deny` + `stream:true` + `stop:"cb_easp"`; `common/constants/freebuff-models.ts` + `free-agents.ts` `FREEBUFF_ROOT_AGENT_ID_BY_MODEL` via `getFreebuffCliAgentIdForModel`. Proxy `injectEnvelope` + `registry/modelcat` pinned at `887786e` via `sync-upstream` — verify exact, `NewClientID` shape `substring(2,15)` pad `0`.
+
+### P1 — Session/run lifecycle
+
+7. **Instance rotation** — row keyed by `USER+SERVER-MINTED instanceId` (`freebuff-session.ts` `active`), rotated every admission POST, not fingerprint/token. Proxy `session` manager already rotates but verify `holdsLiveFreebuffSlot`.
+8. **Agent-runs** — `sdk/impl/database.ts` `POST /api/v1/agent-runs START/FINISH` with `Authorization Bearer` + `x-codebuff-api-key` duplicate (`codebuff-web-api.ts:70-71`). Proxy `runs` manager must `START` before first chat per `instanceId` and `FINISH` honest (anti-ban contract), not coalesced across models.
+9. **Rate limits** — `common/types/freebuff-session.ts` `rateLimitsByModel Record<string,FreebuffSessionRateLimit>` `recentCount` includes active reservation `1.0` → `0.1` rounding after settle (TUI wire facts 2026-08-31). Proxy `pool/quota` already wholesale-assigned, not max.
+
+### P2 — Not needed in proxy (intentionally diverge)
+
+* TUI: OpenTUI `alternate-screen` (`cli/src/index.tsx:404`), `chat-input-bar`/`suggestion-engine`/`ask-user-bridge`, `freebuff-model-selector`, `landing-screen`, `command-registry` slash filtering — **keep out of proxy**.
+* Skill/agent registry, `handleSteps` vs LLM `stream-xml-parser` tool loop (`agents/base2`, `packages/agent-runtime`) — proxy is transport, not executor.
+* PostHog/analytics (`analytics.ts:148-152` `anonymousId` in `~/.config/manicode`, `APP_LAUNCHED`), `.codebuffignore` — drop intentionally.
+* `read-files` `.env` block + `isSensitiveEnvFilePath` — proxy config loader is separate, not needed to replicate inside sandbox.
+
+### Proxy weight to remove / opt-in (watchdog dead-code)
+
+* Browser TLS default — **already removed** (`7f6f15b`).
+* `REQUEST_JITTER=2s` → `200ms` (`5687206`), SG `0` explicit — CLI has `0`, `200ms` is SafeMode anti-ban compromise (watchdog notes jitter gap); `0` remains CLI-exact opt-in.
+* Unbuffered `ch` — **already buffered** `64` (`5687206`).
+* Keep `stealth/profiles.go` + `stealth/tls.go` as opt-in (`TLS_FINGERPRINT=chrome126/etc`), not default; dashboard/metrics kept (admin, not dead code).
+
+## 2. Fill-Gaps Roadmap
+
+**Phase A — P0 wire exactness (1-2 days, hermetic + live)**
+- A1 `auth_fingerprint.go` → build full enhanced JSON matching `fingerprint.ts:87-128` (sorted MACs, `fingerprintVersion 2.0`, `MachineGuid` fallback). Keep output `enhanced-` 43-char.
+- A2 `upstream/injectEnvelope` audit vs `sdk/impl/llm.ts:getProviderOptions` + `model-provider.ts` — add `cache_debug_correlation` if missing, verify `stop:cb_easp` exact.
+- A3 `upstream/client.go:newRequest` header audit — ensure `GET /api/v1/freebuff/session` sends `x-freebuff-compact-session=1` when `compact`, never `heartbeat`, `takeover` only on superseded.
+- A4 `client_id` shape — add conformance test `generateClientId` vs `JS substring(2,15)` (13-char base36, pad `0`).
+
+**Phase B — P1 lifecycle (1 day)**
+- B1 Session `pool/pool_lifecycle.go` `nextDelayMs` exact `POLL_INTERVAL_ACTIVE_MS 30s` vs `remaining+1s` near expiry, no heartbeat.
+- B2 `runs` `START` once per `instanceId` (not per model), `FINISH` honest on `pool.Shutdown 30s` (already `stop_grace_period 30s`).
+
+**Phase C — Remove / optimize (0.5 day)**
+- C1 Delete any `TLS_FINGERPRINT=auto` hardcode left in scripts/docs (done except `scripts/sync-upstream.sh` pin comments — keep).
+- C2 Keep `ch 64` + `200ms jitter` as CLI-faithful; no further buffering that would delay `Flush`.
+
+## 3. Optimization Final Pass (done, keep)
+
+* Channel `64` decouples `bufio.Scanner 64KB→16MiB` from `W+Flush` (~70-120 deltas/s) without adding latency.
+* `200ms` jitter + `SanitizeChunkOpts` `sync.Pool` + single `Marshal` if mutated = `<1ms` per chunk (`header→first delta 0.248-0.421s` is upstream think, not proxy).
+* `X-Accel-Buffering: no` + `keepalive 15s` + `": connecting"` grace.
+
+## 4. Verification (gated)
+
+* **Gate 1 — `bash scripts/sync-upstream.sh --check` then `--test-all`** (`exit 0`, `All pinned files match`, `check-upstream OK`, `registry fallback parity`) before each change (AGENTS.md). `--test-all` also runs `registry` tests; stale `reference` yields wrong wire.
+* **Gate 2 — Hermetic** `env -u AUTH_TOKENS -u ADMIN_TOKEN go test ./backend/...` `ok` (`config` expects `TLS ""` + `env_example` empty, `TLSFingerprint` empty CLI-faithful).
+* **Gate 3 — Live SG** `172.188.64.104:3457` `curl -N POST /v1/chat/completions stream:true` timestamp per `data:` → `header 2.5-10s` + `~80-111 tok/s` (`tokens≈chars/4`), `docker logs | grep stealth` `0` lines (plain), `GET /v1/models` 6 available vs 19 registry expected (tier, not TLS).
+* **Dead-code audit:** Browser `stealth` profiles kept opt-in (`TLS_FINGERPRINT=chrome126/etc`) not default; dashboard/metrics kept (admin needed, not dead); `200ms jitter` vs CLI `0` is SafeMode compromise — `REQUEST_JITTER=0` remains CLI-exact opt-in (`SG` already `0`).

--- a/docs/tui-research.md
+++ b/docs/tui-research.md
@@ -1,0 +1,124 @@
+# FreeBuff TUI — Full Inventory for Dashboard Integration
+> Research date: 2026-09-01 · Reference: `reference/freebuff@70f1d8d` (`cli/src`, `common/src`)
+> Goal: every data point the TUI shows, its wire source, formatting, and mapping to `freebuff-proxy` dashboard.
+
+## 1. TUI Layout Overview
+```
+┌─ chat-header (branch, model, git status) ─────────────────┐
+├─ chat transcript (assistant/user blocks, tool calls)      │
+├─ agent checklist / mode toggle                            │
+├─ chat-input-bar (model pill, thinking budget)             │
+├─ status-bar (idle: model·remaining·context | waiting/streaming: shimmer + elapsed) │
+├─ bottom-banner / help-banner / ad-banner / choice-ad     │
+└─ modal overlays: model-selector (landing), referral-banner, subscription-limit-banner
+```
+Landing (`freebuff-landing-screen.tsx`) when `session.status==='none'`: hero model, `FreebuffModelSelector` grid, `FreebuffReferralBanner`, streak line, premium reset, gravity ad, waiting-room placements.
+
+## 2. Status Bar (`cli/src/components/status-bar.tsx:69`)
+**Visible in every turn.**
+
+| Field | Source | Computation | Display |
+|---|---|---|---|
+| `sessionProgress.fraction` → draining fill | `useFreebuffSessionProgress(session)` | `fraction = remainingMs / totalMs` (`expiresAt-admittedAt`), `remainingMs = max(0, expiresAt - now)` ticks 1Hz via `useNow(1000)` | 100%→0% bar `theme.surfaceHover` |
+| `remainingMs` → countdown | same hook | `formatFreebuffSessionRemaining(remainingMs)` (`freebuff-session-display.ts:11`): `<5m: m:s`, `<60m: Xm left`, else `Xh Ym left`; `expiring…` at 0 | idle: `Model · unlimited / 3h 12m left · 42% context` (`138-207`) |
+| `isUnlimited` | `session.status==='active' && !session.rateLimit` | `rateLimit` absent = unlimited (no session quota) | shows `unlimited` instead of countdown |
+| `contextUsage` | `chat-store.runState.mainAgentState.contextTokenCount` + `FREEBUFF_MODEL_CONTEXT_WINDOWS[model]` | `formatContextUsage(count, window)` → `42%` | suffix `· 42%` |
+| `elapsedSeconds` | `timerStartTime` + `statusIndicatorState` (`waiting/streaming/paused`) | `setInterval 1s` | right side `2:34` |
+| `statusIndicator` | `status-indicator-state` (`idle, waiting:thinking..., streaming:working..., paused, retrying, capacityWait:high demand…, connecting, reconnected, ctrlC, clipboard`) | `ShimmerText` | center |
+| `sessionModel displayName` | `getFreebuffModel(session.model).displayName` | catalog lookup | `GPT-5.6 Luna · 3h left` |
+| Buttons | `onStop` (waiting/streaming → `■ Esc`), `onEndSession` (idle+active → `✕ End session`), urgent countdown `<5m` red `formatFreebuffSessionCountdown` `m:ss` | | |
+
+**Proxy mapping:** `session.SessionSnapshot` already carries `InstanceID, Model, ExpiresAt, RemainingMs` (`session.go:233`), `pool.TokenSnapshot` exposes `SessionRemainingSeconds`, `SessionModel`. Dashboard `TokenDetailsDrawer.svelte:96` shows `Active Session: model · countdown` via `fmtCountdown`. Gap: **no `fraction` bar** — add.
+
+## 3. Model Selector (`freebuff-model-selector.tsx:202`) — the richest quota view
+**Shown on `status==='none'` (pre-join).**
+
+Sections: `PREMIUM | UNLIMITED | REFERRAL | LIMITED_OFFER` (empty filtered). Hero collapsed vs expanded grid.
+
+| Data | Wire → Computed | TUI Display |
+|---|---|---|
+| `rateLimitsByModel: Record<model, FreebuffSessionRateLimit>` | `getRateLimitsByModel(session)` (`freebuff-session.ts:371`) → `getFreebuffSectionQuotas(rateLimits, accessTier)` (`freebuff-session-pools.ts`) groups by `pool` | Section header `PREMIUM — 2 of 5 used · resets in 22h` (amber when exhausted) |
+| `limit, recentCount, period, resetAt, entitlementBreakdown{base,referral,streak}` | `FreebuffSessionRateLimit` `freebuff-session.ts:223` (`limit number, recentCount number, pool?, poolLabel?`) | Row second line `Premium · 2/5 · resets Sep 2 14:00` (`rowDetails`) |
+| `referralInfo{referralCode, qualifiedCount, dailySessions, endsAt}` | `getReferralInfo(session)` | `FreebuffReferralBanner`: `Share link freebuff.com/?ref=XXX · 3 qualified · +1/day` |
+| `freebucks{balance, daily{limit,spent,remaining,resetAt}, weekly, monthly, bindingWindow}` | `getFreebucksInfo(session)` | `Freebucks $12.5 · Daily 5/20` |
+| `glmPromo{dailySessions, endsAt}` | `getGlmPromo(session)` | `GLM 2/day · ends Sep 3` |
+| `standing{cappedBy, cappedReason, blurb, nextSteps[]}` | `getStanding(session)` (`freebuff-standing.ts`) | `Trust: capped by hosting · Blurb · Next: link GitHub` |
+| `desktopSessionCounts{active, total}` | `FreebuffDesktopSessionCounts` | `Desktop 2/3 tabs` |
+| `limitedModelOffers[]{model, spotsLeft}` | `getLimitedModelOffers(session)` (`limitedModelOffers` only while global pool has capacity) | Extra row `Claude Fable 5 · 12 spots left` |
+| `streak{currentStreak, longestStreak, bonusNote}` | `useFreebuffStreakQuery` + `freebuff-streak-line.ts` | Landing header `🔥 7 day streak · +1 session` |
+| `subscription{plan, usage}` | `useSubscriptionQuery` / `useUsageQuery` (poll 15s/30s) | `Subscription $20 · 34/100 credits` (non-freebuff) |
+| `availability` | `getFreebuffModelUnavailableLabel(model)`, `isFreebuffModelAvailable(tier)` | Greyed row `Unavailable 9am-5pm ET` |
+| `contextWindow` | `FREEBUFF_MODEL_CONTEXT_WINDOWS[model]` | Row badge `1M` |
+
+**Proxy mapping:** Dashboard `dashboard_models.go:quotaFor` shows `5 premium quota` (limit only); `dashboard_tokens.go` `quotaRow{limit,recent,remaining,period,resetAt,entitlement}` shows per-model correctly via `formatQuota`. Gap: **no section header `N of M used`**, no `entitlementBreakdown` grouping, no `streak/freebucks/standing/limitedOffers` at all.
+
+## 4. Landing Screen (`freebuff-landing-screen.tsx`)
+* Hero model (`getRecommendedFreebuffModelId` — `luna` full tier, `mimo` limited) + `takeOverFreebuffSession` button
+* `useFreebuffStreakQuery` → streak line (`getFreebuffStreakLine`)
+* `formatFreebuffPremiumResetCountdown(getFreebuffPremiumResetAt(session))` → `Resets in 22h 33m`
+* `useGravityAd` / `waiting-room-placements` → ad cards
+* `refreshFreebuffLandingMetadata` on `07:00 UTC` tick
+
+Gap: proxy landing is 404 — no streak/premium reset UI.
+
+## 5. Usage Banners (`usage-banner.tsx`, `subscription-limit-banner.tsx`, `bottom-banner.tsx`)
+* `useUsageQuery` (30s) + `useSubscriptionQuery` (15s) + `useActivityQuery`
+* `rateLimit{limit, used, remaining, resetAt}` for a-la-carte, `subscriptionInfo{tier, renewalDate}` → `formatRenewalDate`, progress `getBannerColorLevel` green→red, `generateLoadingBannerText`
+* `help-banner.tsx` / `ad-banner.tsx` / `choice-ad-banner.tsx`
+
+Gap: proxy has no usage/subscription — only spend `Spend24h/SpendWeek` ledger (local, not wire).
+
+## 6. Chat Runtime (`chat.tsx`, `chat-store.ts`, `use-send-message.ts:31kb`)
+* `runState.sessionState.mainAgentState.contextTokenCount` → context %
+* `think-tag-stream.ts` / `think-tag-parser` → leaked `<think>` → `reasoning_content`
+* `isStrictReasoningModel` → `reasoning_content` required on tool calls (mimo/deepseek/kimi)
+* `statusIndicatorState` machine
+
+Gap: dashboard playground replays `reasoning_content` correctly, but no `think leak` badge.
+
+## 7. Session Lifecycle (`use-freebuff-session.ts:838`)
+* `PollController` — `POLL_INTERVAL_ACTIVE_MS 30s`, `nextDelayMs` caps to `remaining+1s` near expiry, backoff `20→300s` on fail, `getFreebuffInstanceId()` = `holdsLiveFreebuffSlot` (active or grace `30m`), `takeOver/refresh/returnToLanding`, `pendingExplicitPickModel`
+* `x-freebuff-compact-session` header omits quotas on poll (proxy preserves `savedQuota` #146 — matches CLI `rateLimitsByModel` optional)
+
+Proxy `pool/pool_lifecycle.go` mirrors `30s±20%` `sessionPollTick`/`bridgeSessionPollTick`, grace `30m` (`session/go graceEndFromState`), compact preservation — parity.
+
+## 8. Wire Source of Truth (all TUI fields trace to these)
+
+| Wire Field | Type File | TUI Consumer |
+|---|---|---|
+| `session.status: active/ended/none/queued/country_blocked` | `freebuff-session.ts:526` | everything |
+| `admittedAt, expiresAt, remainingMs` | `FreebuffActiveSessionInfo` | countdown, progress |
+| `model` | same | status bar, context window |
+| `rateLimitsByModel` | `Record<model, FreebuffSessionRateLimit>` | model selector sections, dashboard quota table |
+| `pool, poolLabel, countsAdmissions` | same | section grouping |
+| `entitlementBreakdown` | `FreebuffSessionEntitlementBreakdown` | `base=5, referral=0, streak=0` tooltip |
+| `referral, glmPromo, freebucks, standing, subscription, limitedModelOffers, desktopSessionCounts` | `freebuff-session.ts:283` | referral banner, freebucks bar, trust, offers |
+| `availableHours, availableAt` | `freebuff-models.ts` | grey row |
+| `contextWindow` | `freebuff-models.ts` | status bar % |
+
+## 9. Proxy Dashboard Coverage vs Gaps
+
+| TUI Info | Proxy Today | Gap |
+|---|---|---|
+| **Session progress** (fraction bar, `formatFreebuffSessionRemaining`) | `SessionRemainingSeconds` numeric, no bar, no `isUnlimited` check | Add `fraction` + `isUnlimited` (`!rateLimit`) + `freebuff-session-display` port |
+| **Premium pool `N of M used`** | `PremiumQuota USED/Remaining` now float-fixed (`1.2/5`), but **no section header** | Add header `2 of 5 used · resets in 22h` in Models page |
+| **Per-model `recent/limit/period/resetAt/entitlement`** | ✅ `quotaRow` correct (`formatQuota` float) | — |
+| **Streak** `🔥 7d +1` | ❌ none (only `quotaTracker` bonus note missing) | Add `standing.streak` + `referral.qualifiedCount` → header note |
+| **Freebucks** `balance/daily/weekly` | ❌ `FreebucksInfo` parsed (`session_parse.go`) but not surfaced | Add `FreebucksInfo` card |
+| **Standing/Trust** `cappedBy, blurb, nextSteps` | `SessionStanding` stored but only `cardFromSnapshot` shows standing badge | Expose full `standing.cappedReason/blurb/nextSteps` |
+| **Referral** `code, qualified, promo` | `GlmPromo` synthesized row only | Add `referral.code/link/qualified` banner like TUI |
+| **Limited offers** `spotsLeft` | ❌ not parsed | Add `limitedModelOffers` row |
+| **Desktop tabs** `2/3` | ❌ not parsed | Add `desktopSessionCounts` |
+| **Context usage** `42%` | `contextTokenCount` only in playground, not token card | Add `FREEBUFF_MODEL_CONTEXT_WINDOWS[model]` lookup + `formatContextUsage` |
+| **Countdown visible `<5m` warning** | `fmtCountdown` generic | Add `FREEBUFF_COUNTDOWN_VISIBLE_MS 5m` urgent red |
+| **Usage/subscription rings** | Spend ledger only (`SpendDay/Week`) | Wire `subscriptionInfo` not proxied — keep spend, add `usageQuery` if upstream exposes |
+
+## 10. Integration Plan (proposed)
+1. **Expose missing wire blocks** in `session.SessionSnapshot`: `FreebucksInfo, Standing, Referral, LimitedOffers, DesktopCounts, Streak` (parse in `session_parse.go` already for freebucks/standing/referral, add limitedOffers/desktop).
+2. **Extend `pool.TokenSnapshot` + `healthz` + `/admin/api/tokens`** to include them.
+3. **Port `formatFreebuffSessionRemaining`/`Countdown`** + `freebuff-session-pools.getFreebuffSectionQuotas` (group by `pool`) to `dashboard_helpers.go` — render `N of M used` header.
+4. **New dashboard cards**: `StreakCard`, `FreebucksCard`, `TrustCard`, `ReferralBanner` (copy of `freebuff-referral-banner.tsx` logic), `LimitedOfferRow`.
+5. **Status-bar bar**: Svelte `progress` div `width: fraction*100%` + `unlimited` check + `contextUsage`.
+
+All TUI info is `rateLimitsByModel`-centric — proxy already mirrors it correctly (`savedQuota` #146, `graceEndFromState` #240, fractional `0.1` units #70f1d8d). Remaining work is surfacing the 6 omitted blocks.
+


### PR DESCRIPTION
Fills watchdog-prioritized wire parity gaps 1-by-1, removes non-CLI weight, keeps optimization.

**P0 wire (watchdog 1):**
- `fingerprint enhanced-` already full JSON `cli/src/utils/fingerprint.ts:87-128` (`login/fingerprint.go:115` ``enhanced-`` + sorted MACs, 2.0) — no code diff, plan pins it.
- `instance-owner pid lock` `freebuff-instance-owner.ts:12-54` `kill(pid,0)` — proxy already has opt-in `ADOPT_CLI_SESSION` (`session_admission.go:33`), pooled never needs pid file — docs only.
- `x-freebuff-compact-session:1` on GET poll + `heartbeat` Desktop-only omission — already `session_poll.go:175 GetSessionWithOpts(ctx, id, true)` + `upstream/session.go:60` set / `client_session_test.go:438` asserts heartbeat absent.
- `trace.jsonl` intentional divergence (`trace-writer.ts:9-80` executor, proxy transport only) — plan documents.
- `auth wire` `POST /api/auth/cli/code` + `GET /status` already Bun UA.

**Envelope (A2):**
- `upstream/chat.go:326` `injectEnvelope` now merges caller `codebuff_metadata` extra keys (`cache_debug_correlation`, `n`) before stamping reserved `run_id/client_id/trace_session_id/freebuff_instance_id/llm_step_number/cost_mode/freebuff_reasoning_effort` per `sdk/src/impl/llm.ts:112-119` `extraCodebuffMetadata` contract. Reserved keys still overwritten.

**P1 lifecycle (B1/B2):**
- Poll `30s ±20% capped remaining+1s` already `pool_lifecycle.go:28 sessionPollSuccessDelay/jittered` — no diff.
- Runs `START` per `instanceId` + `FINISH` honest — already `runs.Maintain`.
- Jitter `200ms` SafeMode compromise vs CLI `0` (`config_env.go:493`), `SG REQUEST_JITTER=0` is CLI-exact opt-in.

**Dead code (C1):**
- Browser `TLS_FINGERPRINT=""` plain `crypto/tls` default (`7f6f15b`, `upstream/client.go:176 `if != "" -> stealth`), `stealth/profiles.go` opt-in only.
- Dashboard/metrics kept (admin, not dead).
- Buffered `ch 64` (`5687206`, `server/stream_shared.go:215`) + `Flush per Write` kept.

**Verification gates:**
- `bash scripts/sync-upstream.sh --test-all` → `All pinned files match @ 887786e5b`, `ok registry`, `Full test suite passed cleanly`.
- `env -u AUTH_TOKENS -u ADMIN_TOKEN go test ./backend/... -count=1` → `ok` all (`22 packages`).
- Live SG `172.188.64.104:3457` healthy (`no stealth` logs when `""`).

Phased plan gated at `docs/CLI-FIDELITY-PLAN.md`.