### PR TITLE
refactor(deps): drop brotli/zstd response decoders, bump transitive deps

### DIFF
--- a/backend/internal/stealth/profiles.go
+++ b/backend/internal/stealth/profiles.go
@@ -51,7 +51,7 @@ var (
 		SecChUA:         `"Not_A Brand";v="8", "Chromium";v="120", "Google Chrome";v="120"`,
 		SecChUAPlatform: `"Windows"`,
 		AcceptLanguage:  "en-US,en;q=0.9",
-		AcceptEncoding:  "gzip, deflate, br",
+		AcceptEncoding:  "gzip, deflate",
 	}
 
 	// ProfileChrome126 mimics Chrome 126 on Windows (2024+).
@@ -62,7 +62,7 @@ var (
 		SecChUA:         `"Not/A)Brand";v="8", "Chromium";v="126", "Google Chrome";v="126"`,
 		SecChUAPlatform: `"Windows"`,
 		AcceptLanguage:  "en-US,en;q=0.9",
-		AcceptEncoding:  "gzip, deflate, br, zstd",
+		AcceptEncoding:  "gzip, deflate",
 	}
 
 	// ProfileSafari17 mimics Safari 17 on macOS.
@@ -72,7 +72,7 @@ var (
 		CustomSpec:     safari17Spec(),
 		UserAgent:      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
 		AcceptLanguage: "en-US,en;q=0.9",
-		AcceptEncoding: "gzip, deflate, br",
+		AcceptEncoding: "gzip, deflate",
 	}
 
 	// ProfileSafari18 mimics Safari 18 on macOS (2024+).
@@ -82,7 +82,7 @@ var (
 		CustomSpec:     safari17Spec(),
 		UserAgent:      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
 		AcceptLanguage: "en-US,en;q=0.9",
-		AcceptEncoding: "gzip, deflate, br",
+		AcceptEncoding: "gzip, deflate",
 	}
 
 	// ProfileFirefox120 mimics Firefox 120 on Linux.
@@ -91,7 +91,7 @@ var (
 		ClientHelloID:  utls.HelloFirefox_120,
 		UserAgent:      "Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0",
 		AcceptLanguage: "en-US,en;q=0.5",
-		AcceptEncoding: "gzip, deflate, br",
+		AcceptEncoding: "gzip, deflate",
 	}
 
 	// ProfileFirefox128 mimics Firefox 128 ESR on Linux (2024+).
@@ -100,7 +100,7 @@ var (
 		ClientHelloID:  utls.HelloFirefox_120,
 		UserAgent:      "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0",
 		AcceptLanguage: "en-US,en;q=0.5",
-		AcceptEncoding: "gzip, deflate, br, zstd",
+		AcceptEncoding: "gzip, deflate",
 	}
 
 	// ProfileEdge126 mimics Microsoft Edge 126 on Windows (2024+).
@@ -111,7 +111,7 @@ var (
 		SecChUA:         `"Not/A)Brand";v="8", "Chromium";v="126", "Microsoft Edge";v="126"`,
 		SecChUAPlatform: `"Windows"`,
 		AcceptLanguage:  "en-US,en;q=0.9",
-		AcceptEncoding:  "gzip, deflate, br, zstd",
+		AcceptEncoding:  "gzip, deflate",
 	}
 
 	// ProfileRandom picks a random fingerprint per connection.
@@ -119,7 +119,7 @@ var (
 		ID:             ProfileIDRandom,
 		ClientHelloID:  utls.HelloRandomized,
 		AcceptLanguage: "en-US,en;q=0.9",
-		AcceptEncoding: "gzip, deflate, br",
+		AcceptEncoding: "gzip, deflate",
 	}
 
 	// ProfileAuto rotates across modern profiles per connection.

--- a/backend/internal/upstream/client_chat.go
+++ b/backend/internal/upstream/client_chat.go
@@ -24,9 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/andybalholm/brotli"
-	"github.com/klauspost/compress/zstd"
-
 	"freebuff-proxy/backend/internal/stealth"
 	"freebuff-proxy/backend/internal/telemetry"
 )
@@ -345,12 +342,10 @@ func (c *Client) retryDelay() time.Duration {
 }
 
 // wrapDecompress replaces resp.Body with a transparent decompressing reader
-// when the upstream compresses the response. This is REQUIRED with the
-// stealth profile: the browser Accept-Encoding ("gzip, deflate, br") makes
-// Go's transport skip its automatic gzip handling (that only kicks in when
-// Go itself set the header), so compressed bodies would arrive as garbage.
-// The plain transport sends no Accept-Encoding and is unaffected (Go
-// decompresses its own gzip transparently and strips the header).
+// when the upstream compresses the response (gzip/deflate only — stdlib).
+// newRequest intentionally sends no browser Accept-Encoding (CLI fidelity),
+// so live upstream wire is Go-default gzip handled here; an uninvited
+// br/zstd/lz4 errors as unsupported Content-Encoding, same as before.
 func wrapDecompress(resp *http.Response) error {
 	enc := strings.ToLower(strings.TrimSpace(resp.Header.Get("Content-Encoding")))
 	if enc == "" || enc == "identity" {
@@ -384,19 +379,6 @@ func wrapDecompress(resp *http.Response) error {
 		} else {
 			resp.Body = &decompressCloser{Reader: flate.NewReader(br), underlying: underlying}
 		}
-	case "br":
-		resp.Body = &decompressCloser{Reader: brotli.NewReader(underlying), underlying: underlying}
-	case "zstd":
-		// The stealth profiles advertise zstd in Accept-Encoding, so the
-		// upstream may legitimately respond with it.
-		zr, err := zstd.NewReader(underlying, zstd.WithDecoderConcurrency(1))
-		if err != nil {
-			return fmt.Errorf("zstd: %w", err)
-		}
-		// zstd decoders are stateful (per-response buffers), unlike
-		// gzip/brotli: Close must release the decoder's resources, not just
-		// the underlying socket.
-		resp.Body = &decompressCloser{Reader: zr, underlying: underlying, closeFn: func() error { zr.Close(); return nil }}
 	default:
 		return fmt.Errorf("unsupported Content-Encoding %q", enc)
 	}
@@ -406,19 +388,14 @@ func wrapDecompress(resp *http.Response) error {
 }
 
 // decompressCloser bridges a decompressing reader back to the underlying
-// response body so Close always reaches the socket. closeFn optionally
-// releases decoder-local resources (e.g. a zstd decoder's buffers) that are
-// distinct from the underlying stream.
+// response body so Close always reaches the socket. The stdlib decoders
+// (gzip/zlib/flate) need no per-response cleanup beyond that.
 type decompressCloser struct {
 	io.Reader
 	underlying io.ReadCloser
-	closeFn    func() error
 }
 
 func (d *decompressCloser) Close() error {
-	if d.closeFn != nil {
-		_ = d.closeFn()
-	}
 	return d.underlying.Close()
 }
 

--- a/backend/internal/upstream/client_test.go
+++ b/backend/internal/upstream/client_test.go
@@ -17,9 +17,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/andybalholm/brotli"
-	"github.com/klauspost/compress/zstd"
-
 	"freebuff-proxy/backend/internal/config"
 	"freebuff-proxy/backend/internal/testutil"
 )
@@ -201,20 +198,8 @@ func TestWrapDecompress(t *testing.T) {
 		// Multi-value Content-Encoding is rejected with a clear error, not
 		// silently mis-decoded.
 		{"multi-value encoding rejected", "gzip, br", nil, "unsupported Content-Encoding"},
-		{"brotli", "br", func(b []byte) []byte {
-			var buf bytes.Buffer
-			zw := brotli.NewWriter(&buf)
-			_, _ = zw.Write(b)
-			_ = zw.Close()
-			return buf.Bytes()
-		}, ""},
-		{"zstd", "zstd", func(b []byte) []byte {
-			var buf bytes.Buffer
-			zw, _ := zstd.NewWriter(&buf)
-			_, _ = zw.Write(b)
-			_ = zw.Close()
-			return buf.Bytes()
-		}, ""},
+		{"brotli rejected", "br", nil, "unsupported Content-Encoding"},
+		{"zstd rejected", "zstd", nil, "unsupported Content-Encoding"},
 		{"unsupported encoding", "lz4", nil, "unsupported Content-Encoding"},
 	}
 	for _, tc := range cases {
@@ -306,37 +291,6 @@ func TestDumpRedactsTokenHeaders(t *testing.T) {
 	// stays for any future setter).
 	if strings.Contains(strings.ToLower(dump), "x-codebuff-api-key") {
 		t.Errorf("dump file contains an x-codebuff-api-key header line (absent on the chat path):\n%s", dump)
-	}
-}
-
-// TestWrapDecompressZstdDecoderClosed guards the zstd decoder lifecycle: closing a
-// zstd-wrapped response body must release the per-response decoder, not just
-// the underlying socket (decoder buffers would otherwise linger until GC).
-func TestWrapDecompressZstdDecoderClosed(t *testing.T) {
-	var buf bytes.Buffer
-	zw, _ := zstd.NewWriter(&buf)
-	_, _ = zw.Write([]byte(`{"status":"active"}`))
-	_ = zw.Close()
-
-	resp := &http.Response{
-		Header: http.Header{"Content-Encoding": []string{"zstd"}},
-		Body:   io.NopCloser(bytes.NewReader(buf.Bytes())),
-	}
-	if err := wrapDecompress(resp); err != nil {
-		t.Fatal(err)
-	}
-	dc, ok := resp.Body.(*decompressCloser)
-	if !ok {
-		t.Fatalf("body = %T, want *decompressCloser", resp.Body)
-	}
-	if dc.closeFn == nil {
-		t.Error("zstd decompressCloser has no closeFn: decoder resources leak until GC")
-	}
-	if _, err := io.ReadAll(dc); err != nil {
-		t.Fatalf("read: %v", err)
-	}
-	if err := dc.Close(); err != nil {
-		t.Fatalf("close: %v", err)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,6 @@ module freebuff-proxy
 go 1.26.6
 
 require (
-	github.com/andybalholm/brotli v1.2.3
-	github.com/klauspost/compress v1.19.2
 	github.com/refraction-networking/utls v1.8.2
 	github.com/tiktoken-go/tokenizer v0.8.1
 	golang.org/x/net v0.58.0
@@ -12,8 +10,10 @@ require (
 )
 
 require (
-	github.com/dlclark/regexp2/v2 v2.5.1 // indirect
+	github.com/andybalholm/brotli v1.2.3 // indirect
+	github.com/dlclark/regexp2/v2 v2.7.1 // indirect
+	github.com/klauspost/compress v1.19.2 // indirect
 	github.com/xyproto/randomstring v1.2.0 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/andybalholm/brotli v1.2.3 h1:8H1qwOkl2LPfjf3YezB90JnCliZb6SInJ/OJkEbA5NQ=
 github.com/andybalholm/brotli v1.2.3/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
-github.com/dlclark/regexp2/v2 v2.5.1 h1:E5Ug7Dh264W1ymdySmiHNcDG7fmsR307APCE5R07a20=
-github.com/dlclark/regexp2/v2 v2.5.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
+github.com/dlclark/regexp2/v2 v2.7.1 h1:yqDtwI1ptXXvEUNpYTk2lad4jLtAcKqkzepn4savSk4=
+github.com/dlclark/regexp2/v2 v2.7.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/klauspost/compress v1.19.2 h1:hMRETovs/pu/dVWN7zIT1PGG8t509MwT6bO7XSi26R8=
 github.com/klauspost/compress v1.19.2/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/refraction-networking/utls v1.8.2 h1:j4Q1gJj0xngdeH+Ox/qND11aEfhpgoEvV+S9iJ2IdQo=
@@ -10,8 +10,8 @@ github.com/tiktoken-go/tokenizer v0.8.1 h1:4obDoB6/dhdBt9xMweX4nww5cjdOq/nYF4ecw
 github.com/tiktoken-go/tokenizer v0.8.1/go.mod h1:eLA0t6nGvn9mDc7gt90qt7pMat+gE9ViqwQ6l9B+tA4=
 github.com/xyproto/randomstring v1.2.0 h1:y7PXAEBM3XlwJjPG2JQg4voxBYZ4+hPgRdGKCfU8wik=
 github.com/xyproto/randomstring v1.2.0/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=
 golang.org/x/net v0.58.0/go.mod h1:YwCddHnFlT7eLQqVprV19OnhLGtc5xOKgE0RyqgfWAU=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=


### PR DESCRIPTION
## Scope
#324 steps 1–3. `utls` stays (out of scope, tracked separately).

## Change
- `refactor(upstream)`: drop `br`/`zstd` decode branches + imports + zstd-only `closeFn`; uninvited encodings error as unsupported (as `lz4` did). `br`/`zstd` test cases become rejection pins; zstd lifecycle test removed.
- `refactor(stealth)`: all 8 `AcceptEncoding` literals narrowed to `gzip, deflate`.
- `chore(deps)`: `go mod tidy` + regexp2 v2.7.1 / x/crypto v0.56.0.

## Honest correction to the issue premise
Both codecs **stay linked in the binary via `utls`** (`go mod why` + `go list -deps` confirm non-test imports through `refraction-networking/utls`). What this PR removes is *our* direct imports and the dead branches — not the transitive link or its AV-heuristic weight. Fully shedding them requires the out-of-scope `utls` decision.

## Verify
- `grep brotli|klauspost backend/ --include=*.go`: only a comment + rejection-pin test names.
- Scoped hermetic suite green: `upstream`, `stealth`, `tokenestimate` (goldens untouched).
- `gofmt` clean, `go vet` clean on touched packages.

No merge — review first.
