### PR TITLE
test: fix mock Requests data race under -race detector

### DIFF
--- a/backend/internal/pool/pool_cooldown_test.go
+++ b/backend/internal/pool/pool_cooldown_test.go
@@ -236,10 +236,10 @@ func TestMaintainTickSkipsCooldownToken(t *testing.T) {
 
 	p.CooldownToken(0, time.Hour)
 
-	before := mock.Requests
+	before := mock.RequestsSnapshot()
 	p.maintainTick(context.Background())
 	p.sessionPollTick(context.Background())
-	if got := mock.Requests; got != before {
+	if got := mock.RequestsSnapshot(); got != before {
 		t.Errorf("upstream requests during cooldown maintain = %d, want %d (no poll/rotate)", got, before)
 	}
 }

--- a/backend/internal/pool/pool_edge_test.go
+++ b/backend/internal/pool/pool_edge_test.go
@@ -69,7 +69,7 @@ func TestLiveFailoverMatrix(t *testing.T) {
 			if snap := p.Snapshot()[0]; snap.CooldownUntil.Before(time.Now()) {
 				t.Errorf("failing token not cooled down: %v", snap.CooldownUntil)
 			}
-			reqs := failing.Requests
+			reqs := failing.RequestsSnapshot()
 			if reqs == 0 {
 				t.Errorf("failing token never hit (live admission expected)")
 			}
@@ -84,7 +84,7 @@ func TestLiveFailoverMatrix(t *testing.T) {
 				t.Errorf("second lease token = %d, want 1 (cooled token skipped)", lease.Token)
 			}
 			p.LeaseRelease(lease)
-			if got := failing.Requests; got != reqs {
+			if got := failing.RequestsSnapshot(); got != reqs {
 				t.Errorf("failing token re-hit: requests = %d, want %d", got, reqs)
 			}
 			if got := healthy.SessionCreatesSnapshot(); got != 1 {
@@ -119,7 +119,7 @@ func TestLiveFailoverAllBanned(t *testing.T) {
 	// before the session counter, so observe via total requests) and cooled
 	// for the ban window; the remembered error keeps surfacing without
 	// re-hitting.
-	reqs := mock0.Requests + mock1.Requests
+	reqs := mock0.RequestsSnapshot() + mock1.RequestsSnapshot()
 	if reqs == 0 {
 		t.Error("banned tokens never hit (live admission expected)")
 	}
@@ -132,7 +132,7 @@ func TestLiveFailoverAllBanned(t *testing.T) {
 	if !errors.Is(err, upstream.ErrBanned) {
 		t.Errorf("second acquire = %v, want remembered ErrBanned", err)
 	}
-	if got := mock0.Requests + mock1.Requests; got != reqs {
+	if got := mock0.RequestsSnapshot() + mock1.RequestsSnapshot(); got != reqs {
 		t.Errorf("requests after cooldown = %d, want %d (no re-hit)", got, reqs)
 	}
 }
@@ -328,10 +328,10 @@ func TestBridgeIdlePause(t *testing.T) {
 
 	// Idle passes must not touch the upstream (no session poll / queued
 	// advance / rotation) and must not evict the recently-used entry.
-	reqs := mock.Requests
+	reqs := mock.RequestsSnapshot()
 	p.maintainTick(context.Background())
 	p.maintainTick(context.Background())
-	if got := mock.Requests; got != reqs {
+	if got := mock.RequestsSnapshot(); got != reqs {
 		t.Errorf("upstream requests during idle passes = %d, want %d (no maintain activity)", got, reqs)
 	}
 	if got := p.bridgeLen(); got != 1 {

--- a/backend/internal/server/request_params_test.go
+++ b/backend/internal/server/request_params_test.go
@@ -70,8 +70,8 @@ func TestChatUnsupportedParamsRejected(t *testing.T) {
 			if !strings.Contains(string(data), tc.wantErr) {
 				t.Errorf("error body missing %q: %s", tc.wantErr, truncate(string(data), 200))
 			}
-			if mock.Requests != 0 {
-				t.Errorf("upstream requests = %d, want 0 (rejected before pool)", mock.Requests)
+			if mock.RequestsSnapshot() != 0 {
+				t.Errorf("upstream requests = %d, want 0 (rejected before pool)", mock.RequestsSnapshot())
 			}
 		})
 	}
@@ -179,8 +179,8 @@ func TestResponsesUnsupportedParamsRejected(t *testing.T) {
 			if !strings.Contains(string(data), tc.wantErr) {
 				t.Errorf("error body missing %q: %s", tc.wantErr, truncate(string(data), 200))
 			}
-			if mock.Requests != 0 {
-				t.Errorf("upstream requests = %d, want 0 (rejected before pool)", mock.Requests)
+			if mock.RequestsSnapshot() != 0 {
+				t.Errorf("upstream requests = %d, want 0 (rejected before pool)", mock.RequestsSnapshot())
 			}
 		})
 	}
@@ -307,8 +307,8 @@ func TestAnthropicServerToolsRejected(t *testing.T) {
 			if !strings.Contains(string(data), tc.wantErr) {
 				t.Errorf("error body missing %q: %s", tc.wantErr, truncate(string(data), 200))
 			}
-			if mock.Requests != 0 {
-				t.Errorf("upstream requests = %d, want 0 (rejected before pool)", mock.Requests)
+			if mock.RequestsSnapshot() != 0 {
+				t.Errorf("upstream requests = %d, want 0 (rejected before pool)", mock.RequestsSnapshot())
 			}
 		})
 	}

--- a/backend/internal/server/server_api_test.go
+++ b/backend/internal/server/server_api_test.go
@@ -62,8 +62,8 @@ func TestCORSPreflight204(t *testing.T) {
 			t.Errorf("Access-Control-Allow-Methods missing %q", want)
 		}
 	}
-	if mock.Requests != 0 {
-		t.Errorf("upstream requests = %d, want 0 (preflight answered before routing)", mock.Requests)
+	if mock.RequestsSnapshot() != 0 {
+		t.Errorf("upstream requests = %d, want 0 (preflight answered before routing)", mock.RequestsSnapshot())
 	}
 }
 
@@ -142,8 +142,8 @@ func TestEmbeddingsUnsupported(t *testing.T) {
 	if !strings.Contains(body.Error.Message, modelA) {
 		t.Errorf("message missing model list (want %q): %q", modelA, body.Error.Message)
 	}
-	if mock.Requests != 0 {
-		t.Errorf("upstream requests = %d, want 0 (rejected before pool)", mock.Requests)
+	if mock.RequestsSnapshot() != 0 {
+		t.Errorf("upstream requests = %d, want 0 (rejected before pool)", mock.RequestsSnapshot())
 	}
 }
 
@@ -698,8 +698,8 @@ func TestMessagesCountTokens(t *testing.T) {
 	if out.InputTokens != 9 {
 		t.Errorf("input_tokens = %d, want 9", out.InputTokens)
 	}
-	if mock.Requests != 0 {
-		t.Errorf("upstream requests = %d, want 0 (local estimate only)", mock.Requests)
+	if mock.RequestsSnapshot() != 0 {
+		t.Errorf("upstream requests = %d, want 0 (local estimate only)", mock.RequestsSnapshot())
 	}
 }
 
@@ -734,8 +734,8 @@ func TestMessagesCountTokensComplexRequest(t *testing.T) {
 	if out.InputTokens != 93 {
 		t.Errorf("input_tokens = %d, want 93 (golden reference)", out.InputTokens)
 	}
-	if mock.Requests != 0 {
-		t.Errorf("upstream requests = %d, want 0", mock.Requests)
+	if mock.RequestsSnapshot() != 0 {
+		t.Errorf("upstream requests = %d, want 0", mock.RequestsSnapshot())
 	}
 }
 
@@ -766,8 +766,8 @@ func TestMessagesCountTokensDeterministic(t *testing.T) {
 			t.Fatalf("iteration %d input_tokens = %d, want %d (deterministic)", i, out.InputTokens, first)
 		}
 	}
-	if mock.Requests != 0 {
-		t.Errorf("upstream requests = %d, want 0", mock.Requests)
+	if mock.RequestsSnapshot() != 0 {
+		t.Errorf("upstream requests = %d, want 0", mock.RequestsSnapshot())
 	}
 }
 
@@ -793,8 +793,8 @@ func TestMessagesCountTokensMissingModel(t *testing.T) {
 	if out.Error.Type != "invalid_request_error" || out.Error.Code != "model_not_found" {
 		t.Errorf("type/code = %q/%q, want invalid_request_error/model_not_found", out.Error.Type, out.Error.Code)
 	}
-	if mock.Requests != 0 {
-		t.Errorf("upstream requests = %d, want 0", mock.Requests)
+	if mock.RequestsSnapshot() != 0 {
+		t.Errorf("upstream requests = %d, want 0", mock.RequestsSnapshot())
 	}
 }
 
@@ -820,8 +820,8 @@ func TestMessagesCountTokensUnknownModel(t *testing.T) {
 	if out.Error.Type != "invalid_request_error" {
 		t.Errorf("type = %q, want invalid_request_error", out.Error.Type)
 	}
-	if mock.Requests != 0 {
-		t.Errorf("upstream requests = %d, want 0", mock.Requests)
+	if mock.RequestsSnapshot() != 0 {
+		t.Errorf("upstream requests = %d, want 0", mock.RequestsSnapshot())
 	}
 }
 
@@ -847,8 +847,8 @@ func TestMessagesCountTokensInvalidJSON(t *testing.T) {
 			t.Errorf("body %q code = %q, want invalid_json", body, out.Error.Code)
 		}
 	}
-	if mock.Requests != 0 {
-		t.Errorf("upstream requests = %d, want 0", mock.Requests)
+	if mock.RequestsSnapshot() != 0 {
+		t.Errorf("upstream requests = %d, want 0", mock.RequestsSnapshot())
 	}
 }
 
@@ -868,8 +868,8 @@ func TestMessagesCountTokensOversizedBody(t *testing.T) {
 	if !strings.Contains(string(data), "content_too_large") {
 		t.Errorf("body missing content_too_large: %s", truncate(string(data), 200))
 	}
-	if mock.Requests != 0 {
-		t.Errorf("upstream requests = %d, want 0 (oversized body rejected before counting)", mock.Requests)
+	if mock.RequestsSnapshot() != 0 {
+		t.Errorf("upstream requests = %d, want 0 (oversized body rejected before counting)", mock.RequestsSnapshot())
 	}
 }
 
@@ -898,8 +898,8 @@ func TestMessagesCountTokensDocumentRejected(t *testing.T) {
 	if out.Error.Code != "unsupported_content" {
 		t.Errorf("code = %q, want unsupported_content (valid JSON, so invalid_json would mislead)", out.Error.Code)
 	}
-	if mock.Requests != 0 {
-		t.Errorf("upstream requests = %d, want 0", mock.Requests)
+	if mock.RequestsSnapshot() != 0 {
+		t.Errorf("upstream requests = %d, want 0", mock.RequestsSnapshot())
 	}
 }
 
@@ -925,8 +925,8 @@ func TestMessagesCountTokensSystemImageFlat(t *testing.T) {
 	if out.InputTokens != 1600+8+1 { // system image + message overhead + "hi"
 		t.Errorf("input_tokens = %d, want %d (flat 1600, base64 never tokenized)", out.InputTokens, 1600+8+1)
 	}
-	if mock.Requests != 0 {
-		t.Errorf("upstream requests = %d, want 0", mock.Requests)
+	if mock.RequestsSnapshot() != 0 {
+		t.Errorf("upstream requests = %d, want 0", mock.RequestsSnapshot())
 	}
 }
 
@@ -957,8 +957,8 @@ func TestMessagesCountTokensAuth(t *testing.T) {
 		t.Fatalf("Bearer status = %d, want 200: %s", resp.StatusCode, truncate(string(data), 200))
 	}
 
-	if mock.Requests != 0 {
-		t.Errorf("upstream requests = %d, want 0", mock.Requests)
+	if mock.RequestsSnapshot() != 0 {
+		t.Errorf("upstream requests = %d, want 0", mock.RequestsSnapshot())
 	}
 }
 

--- a/backend/internal/server/server_edge_test.go
+++ b/backend/internal/server/server_edge_test.go
@@ -37,8 +37,8 @@ func TestChatOversizedBody413(t *testing.T) {
 	if !strings.Contains(string(data), "content_too_large") {
 		t.Errorf("body missing content_too_large: %s", truncate(string(data), 200))
 	}
-	if mock.Requests != 0 {
-		t.Errorf("upstream requests = %d, want 0 (oversized body rejected before pool)", mock.Requests)
+	if mock.RequestsSnapshot() != 0 {
+		t.Errorf("upstream requests = %d, want 0 (oversized body rejected before pool)", mock.RequestsSnapshot())
 	}
 }
 
@@ -73,8 +73,8 @@ func TestChatInvalidJSONTable(t *testing.T) {
 			}
 		})
 	}
-	if mock.Requests != 0 {
-		t.Errorf("upstream requests = %d, want 0 (malformed bodies rejected before pool)", mock.Requests)
+	if mock.RequestsSnapshot() != 0 {
+		t.Errorf("upstream requests = %d, want 0 (malformed bodies rejected before pool)", mock.RequestsSnapshot())
 	}
 }
 

--- a/backend/internal/upstream/client_chat_test.go
+++ b/backend/internal/upstream/client_chat_test.go
@@ -671,7 +671,7 @@ func TestRequestJitter(t *testing.T) {
 
 	// The jitter gate must hold the request before any upstream contact.
 	time.Sleep(50 * time.Millisecond)
-	if n := mock.Requests; n != 0 {
+	if n := mock.RequestsSnapshot(); n != 0 {
 		t.Fatalf("upstream hit %d times during the jitter window, want 0", n)
 	}
 	cancel()
@@ -683,7 +683,7 @@ func TestRequestJitter(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("ChatCompletions did not abort on cancel during jitter")
 	}
-	if n := mock.Requests; n != 0 {
+	if n := mock.RequestsSnapshot(); n != 0 {
 		t.Fatalf("upstream hit %d times after cancel, want 0", n)
 	}
 
@@ -702,8 +702,8 @@ func TestRequestJitter(t *testing.T) {
 			t.Fatalf("chat with jitter failed: %v", err)
 		}
 		_ = rc.Close()
-		if mock2.Requests != 1 {
-			t.Errorf("Requests = %d, want 1", mock2.Requests)
+		if mock2.RequestsSnapshot() != 1 {
+			t.Errorf("Requests = %d, want 1", mock2.RequestsSnapshot())
 		}
 	})
 }
@@ -767,8 +767,8 @@ func TestChatNonObjectBodyAndGzipError(t *testing.T) {
 		if !strings.Contains(err.Error(), "envelope") {
 			t.Errorf("err = %v, want an envelope error", err)
 		}
-		if mock.Requests != 0 {
-			t.Errorf("upstream hit %d times for a rejected body, want 0", mock.Requests)
+		if mock.RequestsSnapshot() != 0 {
+			t.Errorf("upstream hit %d times for a rejected body, want 0", mock.RequestsSnapshot())
 		}
 	})
 

--- a/backend/internal/upstream/client_retry_test.go
+++ b/backend/internal/upstream/client_retry_test.go
@@ -597,8 +597,8 @@ func TestRateLimitNeverRetried(t *testing.T) {
 	if !errors.Is(err, ErrRateLimited) {
 		t.Fatalf("err = %v, want ErrRateLimited", err)
 	}
-	if mock.Requests != 1 {
-		t.Errorf("upstream requests = %d, want exactly 1 (429 must never be retried)", mock.Requests)
+	if mock.RequestsSnapshot() != 1 {
+		t.Errorf("upstream requests = %d, want exactly 1 (429 must never be retried)", mock.RequestsSnapshot())
 	}
 	if got := client.TransientRetries(); got != 0 {
 		t.Errorf("TransientRetries = %d, want 0", got)
@@ -621,8 +621,8 @@ func TestBanNeverRetried(t *testing.T) {
 	if !errors.Is(err, ErrBanned) {
 		t.Fatalf("err = %v, want ErrBanned", err)
 	}
-	if mock.Requests != 1 {
-		t.Errorf("upstream requests = %d, want exactly 1 (403 banned must never be retried)", mock.Requests)
+	if mock.RequestsSnapshot() != 1 {
+		t.Errorf("upstream requests = %d, want exactly 1 (403 banned must never be retried)", mock.RequestsSnapshot())
 	}
 	if got := client.TransientRetries(); got != 0 {
 		t.Errorf("TransientRetries = %d, want 0", got)


### PR DESCRIPTION
CI `Test (race detector)` on main (`5a8ca75`) flagged a DATA RACE: `MockUpstream.handle` writes `Requests` under `m.mu` on the httptest goroutine while pool tests read `mock.Requests` raw. The read side became racy once `Snapshot()` started firing background backfill fetches (streak/account-info) that overlap test assertions.

Converts all 54 raw mock `.Requests` reads (pool/server/upstream tests) to the existing locked `RequestsSnapshot()` accessor. Zero production change; `Run`-struct `got.Requests` and `TokenSnapshot.snap.Requests` field reads untouched.
