### PR TITLE
fix(pool): backfill streak on maintain loop, never on Snapshot path

### DIFF
--- a/backend/internal/pool/pool_lifecycle.go
+++ b/backend/internal/pool/pool_lifecycle.go
@@ -126,18 +126,19 @@ func (p *Pool) Start(ctx context.Context) {
 		p.wg.Add(1)
 		go p.maintainLoop(runCtx)
 		p.wg.Add(1)
-		go p.accountBackfillLoop(runCtx)
+		go p.backfillLoop(runCtx)
 	})
 }
 
-// accountBackfillLoop periodically fetches account info (email/id) for
-// pooled tokens that still have an empty email (issue #269). It runs as a
-// plain background job so neither pool.New nor the Snapshot read path ever
-// issues upstream traffic; the first pass fires shortly after Start, later
-// passes are throttled to one try per entry per tick via
-// asyncAccountInfoFetch's in-flight guard. The dashboard token cards get
-// their email shortly after the first poll.
-func (p *Pool) accountBackfillLoop(ctx context.Context) {
+// backfillLoop periodically fetches account info (email/id, issue #269) for
+// pooled tokens that still have an empty email, and streak position (issue
+// #336) for tokens whose streak is missing or older than an hour. It runs
+// as a plain background job so neither pool.New nor the Snapshot read path
+// ever issues upstream traffic; the first pass fires shortly after Start,
+// later passes are throttled to one try per entry per tick via the
+// in-flight guards. The dashboard token cards fill in shortly after the
+// first poll.
+func (p *Pool) backfillLoop(ctx context.Context) {
 	defer p.wg.Done()
 	first := time.NewTimer(2 * time.Second)
 	ticker := time.NewTicker(30 * time.Second)
@@ -161,6 +162,7 @@ func (p *Pool) accountBackfillLoop(ctx context.Context) {
 			if tok.email.Load() == nil {
 				p.asyncAccountInfoFetch(tok)
 			}
+			p.asyncStreakFetch(tok)
 		}
 	}
 }

--- a/backend/internal/pool/snapshot.go
+++ b/backend/internal/pool/snapshot.go
@@ -180,6 +180,9 @@ func (p *Pool) Snapshot() []TokenSnapshot {
 				quarantineReason = q.reason
 			}
 		}
+		// Streak is a pure cache read here: backfills run on the maintain
+		// loop, never on the Snapshot path (which must not issue upstream
+		// traffic). Nil streak simply renders no streak card.
 		var streak int
 		var todayUsed bool
 		var lastUsage string
@@ -189,8 +192,6 @@ func (p *Pool) Snapshot() []TokenSnapshot {
 			todayUsed = st.TodayUsed
 			lastUsage = st.LastUsageDate
 			streakUpdated = st.UpdatedAt
-		} else {
-			p.asyncStreakFetch(tok)
 		}
 
 		out = append(out, TokenSnapshot{


### PR DESCRIPTION
PR #336 put `asyncStreakFetch` on the `Snapshot()` read path, violating the pool's own invariant (neither New nor Snapshot ever issues upstream traffic). Test clients point at the mock over real HTTP, so every Snapshot with nil streak fired `GET /api/v1/freebuff/streak` — this broke `TestReplayModelsSurface` (asserts zero upstream requests on the catalog surface) and would storm upstream once per dashboard poll in production (error path never caches, so it refires every time).

- `snapshot.go`: streak is a pure cache read again (nil = no card).
- `pool_lifecycle.go`: `accountBackfillLoop` generalized to `backfillLoop`, fetching email (when unknown) + streak (freshness-guarded inside `asyncStreakFetch`) on first pass + 30s ticks.
- Carries the test-only `RequestsSnapshot()` conversion from #343 (suppressed the -race DATA RACE it was masking behind).
