### PR TITLE
test(e2e): fix unmetered absence assertion colliding with announcements banner

### DIFF
--- a/frontend/e2e/ux.spec.ts
+++ b/frontend/e2e/ux.spec.ts
@@ -779,7 +779,9 @@ test.describe("operator UX journey (hermetic mocks)", () => {
     );
     await expect(page.getByText("deepseek/deepseek-v4-flash")).toHaveCount(2);
     // Fallback-only rows must not render when the payload carries the list.
-    await expect(page.getByText(/Solar Pro 4/)).toHaveCount(0);
+    // Assert on the model id (the banner's tier-change copy also names
+    // "Solar Pro 4", so the display name is not a stable absence signal).
+    await expect(page.getByText("upstage/solar-pro4")).toHaveCount(0);
   });
 
   test("quota: streak indicator renders progress dots and perk countdown", async ({


### PR DESCRIPTION
CI frontend failed on the #342 merge: `getByText(/Solar Pro 4/)` expected 0 but found 1 — the AnnouncementsBanner tier-change copy ("Solar Pro 4 is now unmetered...") also renders on the Quota page, and `toHaveCount(0)` resolves before/after the banner fetch depending on timing (passed locally, failed on slower CI).

Scope the absence assertion to the model id `upstage/solar-pro4`, which only ever renders in the section cards. No production change.
