### PR TITLE
test: restore quota-absent assert + pin unmetered wiring on quota-less pool

### DIFF
--- a/backend/internal/dashboard/dashboard_internal_test.go
+++ b/backend/internal/dashboard/dashboard_internal_test.go
@@ -438,3 +438,22 @@ func TestUnmeteredModelsDerivation(t *testing.T) {
 		}
 	}
 }
+
+// TestTokensDataUnmeteredWithoutQuota pins #342's third box at the payload
+// level: a pool with zero quota rows (compact-poll shape) still carries the
+// modelcat-derived list, proving the section ignores quota presence.
+func TestTokensDataUnmeteredWithoutQuota(t *testing.T) {
+	d := testDashboard(t)
+	td := d.tokensData()
+	if len(td.Tokens) != 0 {
+		t.Fatalf("empty-pool tokens = %d, want 0", len(td.Tokens))
+	}
+	if len(td.UnmeteredModels) == 0 {
+		t.Fatal("UnmeteredModels empty on quota-less pool, want modelcat derivation")
+	}
+	for _, r := range td.UnmeteredModels {
+		if modelcat.IsPremium(r.ID) {
+			t.Errorf("premium model %q in payload unmetered list", r.ID)
+		}
+	}
+}

--- a/frontend/e2e/ux.spec.ts
+++ b/frontend/e2e/ux.spec.ts
@@ -737,6 +737,9 @@ test.describe("operator UX journey (hermetic mocks)", () => {
         "No premium quota data — run a request or -test-token to populate.",
       ),
     ).toHaveCount(2);
+    await expect(
+      page.getByText("No quota data available for this session."),
+    ).toHaveCount(2);
     // Unmetered models section and accounting revamp notice render per account card.
     // No unmetered_models in payload here, so the static fallback renders.
     await expect(page.getByText("Unmetered Models")).toHaveCount(2);


### PR DESCRIPTION
Two coverage gaps from the #342 arc:

- The fallback-assert edit silently dropped the `No quota data available for this session` x2 assert (range overlapped it after prettier shifted lines). Restored.
- `TestUnmeteredModelsDerivation` pins the helper but not the payload wiring. New `TestTokensDataUnmeteredWithoutQuota`: empty pool (compact-poll shape, zero quota rows) still carries a premium-free `UnmeteredModels` list.
