### PR TITLE
feat(log): dev-default debug and req_id on stream-death and cancel drops

### DIFF
--- a/backend/internal/cli/cli.go
+++ b/backend/internal/cli/cli.go
@@ -58,8 +58,9 @@ func Serve(configPath string, verbose bool, version string) int {
 		return 1
 	}
 
-	// Effective log level: LOG_LEVEL config wins, else -v → debug, else info.
-	level := resolveLogLevel(cfg.LogLevel, verbose)
+	// Effective log level: LOG_LEVEL config wins, else -v → debug, else a
+	// dev build (no ldflags version stamp) defaults to debug, else info.
+	level := resolveLogLevel(cfg.LogLevel, verbose, version)
 	logger := telemetry.New(level, cfg.LogFile, cfg.LogFormat)
 	// The dashboard log viewer reads from an in-memory ring that mirrors
 	// every record the process logger emits (no log file or docker needed).
@@ -414,9 +415,11 @@ func ModeFlagsExclusiveWarning(flags ...bool) string {
 }
 
 // resolveLogLevel applies the effective log-level precedence: a set
-// LOG_LEVEL config wins, -v → debug, else info. An unparseable LOG_LEVEL
-// silently falls back to info (ParseLevel returns level 0, which is Info).
-func resolveLogLevel(cfgLogLevel string, verbose bool) slog.Level {
+// LOG_LEVEL config wins, -v → debug, a dev build (version "dev", i.e. no
+// ldflags version stamp) defaults to debug so anomalies are analyzable
+// without flags, else info. An unparseable LOG_LEVEL silently falls back
+// to info (ParseLevel returns level 0, which is Info).
+func resolveLogLevel(cfgLogLevel string, verbose bool, version string) slog.Level {
 	if cfgLogLevel != "" {
 		if lv, ok := telemetry.ParseLevel(cfgLogLevel); ok {
 			return lv
@@ -424,6 +427,9 @@ func resolveLogLevel(cfgLogLevel string, verbose bool) slog.Level {
 		return slog.LevelInfo
 	}
 	if verbose {
+		return slog.LevelDebug
+	}
+	if version == "dev" {
 		return slog.LevelDebug
 	}
 	return slog.LevelInfo

--- a/backend/internal/cli/cli_test.go
+++ b/backend/internal/cli/cli_test.go
@@ -105,28 +105,33 @@ func TestModeFlagsExclusiveWarning(t *testing.T) {
 }
 
 // TestResolveLogLevel pins the effective log-level precedence: LOG_LEVEL
-// config wins when set and parseable (even over -v), -v → debug, else
-// info, and an unparseable LOG_LEVEL silently falls back to info.
+// config wins when set and parseable (even over -v), -v → debug, a dev
+// build (version "dev") defaults to debug when unset, else info, and an
+// unparseable LOG_LEVEL silently falls back to info.
 func TestResolveLogLevel(t *testing.T) {
 	cases := []struct {
 		name     string
 		logLevel string
 		verbose  bool
+		version  string
 		want     slog.Level
 	}{
-		{"empty not verbose", "", false, slog.LevelInfo},
-		{"empty verbose", "", true, slog.LevelDebug},
-		{"config wins", "warn", false, slog.LevelWarn},
-		{"config beats verbose", "error", true, slog.LevelError},
-		{"config case-insensitive", "DEBUG", false, slog.LevelDebug},
-		{"trace level", "trace", false, telemetry.LevelTrace},
-		{"trace case-insensitive", "TRACE", true, telemetry.LevelTrace},
-		{"unparseable falls back to info", "bogus", true, slog.LevelInfo},
+		{"empty not verbose release", "", false, "1.2.3", slog.LevelInfo},
+		{"empty verbose release", "", true, "1.2.3", slog.LevelDebug},
+		{"empty not verbose dev", "", false, "dev", slog.LevelDebug},
+		{"verbose dev", "", true, "dev", slog.LevelDebug},
+		{"config wins", "warn", false, "1.2.3", slog.LevelWarn},
+		{"config beats verbose", "error", true, "dev", slog.LevelError},
+		{"config beats dev default", "info", false, "dev", slog.LevelInfo},
+		{"config case-insensitive", "DEBUG", false, "1.2.3", slog.LevelDebug},
+		{"trace level", "trace", false, "1.2.3", telemetry.LevelTrace},
+		{"trace case-insensitive", "TRACE", true, "dev", telemetry.LevelTrace},
+		{"unparseable falls back to info", "bogus", true, "dev", slog.LevelInfo},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := resolveLogLevel(tc.logLevel, tc.verbose); got != tc.want {
-				t.Errorf("resolveLogLevel(%q, %v) = %v, want %v", tc.logLevel, tc.verbose, got, tc.want)
+			if got := resolveLogLevel(tc.logLevel, tc.verbose, tc.version); got != tc.want {
+				t.Errorf("resolveLogLevel(%q, %v, %q) = %v, want %v", tc.logLevel, tc.verbose, tc.version, got, tc.want)
 			}
 		})
 	}

--- a/backend/internal/server/anthropic_stream.go
+++ b/backend/internal/server/anthropic_stream.go
@@ -120,7 +120,7 @@ func (s *Server) relayAnthropicStream(ctx context.Context, w http.ResponseWriter
 		case lc := <-lines:
 			if lc.err != nil {
 				if ctx.Err() == nil {
-					s.logger.Warn("anthropic upstream stream error", "err", lc.err)
+					s.logger.Warn("anthropic upstream stream error", streamErrorAttrs(ctx, chatStart, stats, lc.err)...)
 					s.flushAnthropicXMLToolCalls(send, st, xmlExtractor, &xmlCallIndex)
 					send(map[string]any{
 						"type": "error",

--- a/backend/internal/server/engine_helpers.go
+++ b/backend/internal/server/engine_helpers.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -61,8 +63,14 @@ func (s *Server) traceChat(lease *pool.Lease, model string, ms int64, status, er
 	s.logger.Info("chat trace", attrs...)
 }
 
-// chatErrClass buckets an upstream error into the trace error column.
+// chatErrClass buckets an upstream error into the trace error column. A
+// canceled downstream client gets its own bucket: the access line keeps a
+// 200 default when nothing was (or could be) written, so a generic "error"
+// would render a context-free "ERROR 200" on the dashboard.
 func chatErrClass(err error) string {
+	if errors.Is(err, context.Canceled) {
+		return "client_canceled"
+	}
 	switch err.(type) {
 	case *upstream.RateLimitError:
 		return "rate_limited"

--- a/backend/internal/server/engine_helpers_test.go
+++ b/backend/internal/server/engine_helpers_test.go
@@ -1,0 +1,37 @@
+package server
+
+// chatErrClass bucket pins: the trace error column is the dashboard's only
+// signal when the downstream access line keeps its 200 default (client gone
+// before anything was written), so a canceled client must not collapse into
+// the generic "error" bucket.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"freebuff-proxy/backend/internal/upstream"
+)
+
+func TestChatErrClass(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"canceled", context.Canceled, "client_canceled"},
+		{"wrapped canceled", fmt.Errorf("chat attempt: %w", context.Canceled), "client_canceled"},
+		{"turn spend limited", &upstream.TurnSpendLimitError{Status: http.StatusTooManyRequests, Body: "x"}, "turn_spend_limited"},
+		{"superseded", &upstream.SessionSupersededError{Status: http.StatusConflict}, "session_superseded"},
+		{"generic", errors.New("boom"), "error"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := chatErrClass(tc.err); got != tc.want {
+				t.Errorf("chatErrClass(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/server/errors.go
+++ b/backend/internal/server/errors.go
@@ -186,12 +186,19 @@ func (s *Server) rateLimitWarnShouldLog(key string) bool {
 // request's effective model, lease the acquired token lease (nil when the
 // error fired before acquisition — e.g. an unfit-egress refusal).
 func (s *Server) writeError(w http.ResponseWriter, r *http.Request, err error, model string, lease *pool.Lease) {
+	// A dropped client leaves no downstream status (the access wrapper keeps
+	// its 200 default), so req_id is the only correlation key — always log
+	// it here, or the dashboard renders a context-free "ERROR 200".
+	reqID := ""
+	if r != nil {
+		reqID = reqIDFrom(r.Context())
+	}
 	if errors.Is(err, context.Canceled) {
-		s.logger.Debug("request canceled by client", "err", err)
+		s.logger.Debug("request canceled by client", "req_id", reqID, "err", err)
 		return
 	}
 	if r != nil && r.Context().Err() != nil {
-		s.logger.Debug("client context canceled; not writing error", "err", err)
+		s.logger.Debug("client context canceled; not writing error", "req_id", reqID, "err", err)
 		return
 	}
 

--- a/backend/internal/server/openai_stream.go
+++ b/backend/internal/server/openai_stream.go
@@ -136,7 +136,7 @@ func (s *Server) relayStream(ctx context.Context, w http.ResponseWriter, r io.Re
 			if lc.err != nil {
 				if ctx.Err() == nil {
 					emitXMLFlush()
-					s.logger.Warn("upstream stream error", "err", lc.err)
+					s.logger.Warn("upstream stream error", streamErrorAttrs(ctx, chatStart, stats, lc.err)...)
 					_, _ = w.Write(convert.ErrorChunk("upstream stream interrupted: "+lc.err.Error(), "upstream_stream_error"))
 					_, _ = w.Write(convert.DONE)
 					flusher.Flush()

--- a/backend/internal/server/relay_internal_test.go
+++ b/backend/internal/server/relay_internal_test.go
@@ -6,8 +6,10 @@ package server
 // so no network/timing flakiness is involved.
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http/httptest"
@@ -171,6 +173,53 @@ func TestRelayStreamMidStreamError(t *testing.T) {
 	}
 	if !strings.Contains(body, "data: [DONE]") {
 		t.Error("body missing [DONE] after the error frame")
+	}
+}
+
+// TestStreamErrorAttrs pins the mid-stream death correlation fields: req_id
+// rides along when the relay context carries one (chatCore stamps it) and is
+// omitted for lease-less direct relay calls, so the WARN is never noise.
+func TestStreamErrorAttrs(t *testing.T) {
+	stats := &relayStats{chunks: 3, bytes: 128}
+	toMap := func(attrs []any) map[string]any {
+		m := make(map[string]any, len(attrs)/2)
+		for i := 0; i+1 < len(attrs); i += 2 {
+			m[fmt.Sprint(attrs[i])] = attrs[i+1]
+		}
+		return m
+	}
+	withID := toMap(streamErrorAttrs(
+		context.WithValue(context.Background(), reqIDKey{}, "req-test-1"),
+		time.Now(), stats, errors.New("boom")))
+	if withID["req_id"] != "req-test-1" {
+		t.Errorf("req_id = %v, want req-test-1", withID["req_id"])
+	}
+	if withID["chunks"] != 3 || withID["bytes"] != 128 {
+		t.Errorf("progress = (%v, %v), want (3, 128)", withID["chunks"], withID["bytes"])
+	}
+	if _, ok := withID["elapsed_ms"]; !ok {
+		t.Error("missing elapsed_ms")
+	}
+	withoutID := toMap(streamErrorAttrs(context.Background(), time.Now(), stats, errors.New("boom")))
+	if v, ok := withoutID["req_id"]; ok {
+		t.Errorf("req_id = %v, want absent without a request context", v)
+	}
+}
+
+// TestRelayStreamErrorLogsReqID pins the anomaly-analysis contract: a
+// mid-stream death after WriteHeader(200) logs req_id + relay progress, so a
+// dashboard "ERROR 200" group resolves back to its request.
+func TestRelayStreamErrorLogsReqID(t *testing.T) {
+	var buf bytes.Buffer
+	s := &Server{logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))}
+	rec := httptest.NewRecorder()
+	ctx := context.WithValue(context.Background(), reqIDKey{}, "req-test-2")
+	s.relayStream(ctx, rec, &errAfterLineReader{}, &relayStats{}, time.Now())
+	out := buf.String()
+	for _, want := range []string{"upstream stream error", "req_id=req-test-2", "chunks=", "bytes=", "elapsed_ms="} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stream error log missing %q: %q", want, out)
+		}
 	}
 }
 

--- a/backend/internal/server/responses_stream.go
+++ b/backend/internal/server/responses_stream.go
@@ -141,7 +141,7 @@ func (s *Server) relayResponsesStream(ctx context.Context, w http.ResponseWriter
 		case lc := <-lines:
 			if lc.err != nil {
 				if ctx.Err() == nil {
-					s.logger.Warn("responses upstream stream error", "err", lc.err)
+					s.logger.Warn("responses upstream stream error", streamErrorAttrs(ctx, chatStart, stats, lc.err)...)
 					flushXMLCalls()
 					s.endResponsesStream(w, send, st, model, respID, createdAt, true, map[string]any{
 						"type":    "upstream_stream_error",

--- a/backend/internal/server/server_api_test.go
+++ b/backend/internal/server/server_api_test.go
@@ -1205,6 +1205,13 @@ func TestTransientRetrySkippedOnCanceledContext(t *testing.T) {
 		}
 		return false
 	})
+	// The cancel drop carries req_id: without it a client-abandoned request
+	// is uncorrelated (the access line keeps its 200 default).
+	for _, e := range ring.Recent(400) {
+		if e.Message == "request canceled by client" && entryField(e, "req_id") == "" {
+			t.Error(`"request canceled by client" missing req_id`)
+		}
+	}
 	for _, e := range ring.Recent(400) {
 		if strings.Contains(e.Message, "transient chat error") {
 			t.Errorf("canceled request logged a retry announcement: %s", e.Message)

--- a/backend/internal/server/stream_shared.go
+++ b/backend/internal/server/stream_shared.go
@@ -219,6 +219,25 @@ func newStreamRelay(ctx context.Context, w http.ResponseWriter, r io.Reader) (fl
 	return flusher, keepalive, ch, &now, true
 }
 
+// streamErrorAttrs builds the structured attributes for a mid-stream death
+// (upstream read failure after WriteHeader(200)): the downstream access
+// line keeps status 200, so without req_id + relay progress (chunks/bytes/
+// elapsed) the failure is uncorrelated noise. req_id rides the request
+// context (chatCore stamps it); relays driven directly in tests carry none
+// and omit the key.
+func streamErrorAttrs(ctx context.Context, chatStart time.Time, stats *relayStats, err error) []any {
+	attrs := []any{
+		"err", err,
+		"elapsed_ms", time.Since(chatStart).Milliseconds(),
+		"chunks", stats.chunks,
+		"bytes", stats.bytes,
+	}
+	if reqID := reqIDFrom(ctx); reqID != "" {
+		attrs = append(attrs, "req_id", reqID)
+	}
+	return attrs
+}
+
 // maybeKeepalive writes the protocol's keepalive frame when the relay has
 // been silent past keepaliveInterval, advancing the client-write clock. The
 // three relays select on the same ticker; the frame text is the only

--- a/backend/internal/upstream/client_chat.go
+++ b/backend/internal/upstream/client_chat.go
@@ -135,6 +135,18 @@ func (c *Client) do(req *http.Request, timeout time.Duration) (*http.Response, c
 	if req.GetBody != nil {
 		replayBody = req.GetBody
 	}
+	// Wire correlation at debug: every upstream attempt below logs its
+	// response ("upstream response"/"upstream ok"/"upstream error"), but
+	// without a start line a death that never answers (hang until the
+	// caller gives up) leaves no trace of which call was in flight.
+	// Headers stay out — the token must never reach the logs.
+	if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
+		attrs := []any{"method", req.Method, "path", req.URL.Path}
+		if reqID := ReqID(ctx); reqID != "" {
+			attrs = append(attrs, "req_id", reqID)
+		}
+		slog.Debug("upstream request", attrs...)
+	}
 
 	for attempt := 1; ; attempt++ {
 		resp, err := c.http.Do(req)

--- a/backend/internal/upstream/wire_metrics_test.go
+++ b/backend/internal/upstream/wire_metrics_test.go
@@ -163,6 +163,12 @@ func TestDoKeepsUpstreamOkForSuccess(t *testing.T) {
 	if entryFields(entries, "upstream response") != nil {
 		t.Errorf("`upstream response` must not fire for 200 responses")
 	}
+	startFields := entryFields(entries, "upstream request")
+	if startFields == nil {
+		t.Errorf("missing `upstream request` start line for 200 response")
+	} else if joined := strings.Join(startFields, " "); !strings.Contains(joined, "path=/api/v1/chat/completions") {
+		t.Errorf("`upstream request` missing method path: %s", joined)
+	}
 }
 
 // TestRateLimitClassificationLedger pins the ledger counters: distinct upstream


### PR DESCRIPTION
## Why

Two dashboard groups rendered as `ERROR 200 · error`: a streaming request whose headers flushed 200, then the downstream client went away (~60s harness timeout) before the upstream attempt resolved. The trace bucket collapsed to `error`, the access line kept its 200 default, and the decisive lines (client-cancel drops, mid-stream deaths) carried no `req_id` — undebuggable at info level.

## What

- Dev builds (no release version stamp) default to `debug` when `LOG_LEVEL` is unset; explicit `LOG_LEVEL` and `-v` keep existing precedence.
- All three relay mid-stream-death WARNs log `req_id` + `chunks`/`bytes`/`elapsed_ms` via a shared `streamErrorAttrs` helper.
- `writeError` client-cancel paths log `req_id`.
- Trace buckets `context.Canceled` as `client_canceled` instead of `error`.
- Upstream client logs a redacted request-start line at debug (method/path/`req_id`, never headers).

## Verification

- `gofmt` clean, `go vet` clean.
- Hermetic `go test ./backend/...` green.
- New pins: dev log-level precedence, `client_canceled` bucket, stream-death attrs + `req_id` log, cancel-drop `req_id`, upstream request-start line.
- Live-log cross-check: the two `ERROR 200` groups both show ~60s lifetimes with `attempts=1`, no `statuses_seen`, stream mode — consistent with client abandonment, which this PR makes explicit next time.