### PR TITLE
fix(upstream): REQUEST_TIMEOUT guards TTFB only, never the streamed body

### DIFF
--- a/backend/internal/config/keycatalog.go
+++ b/backend/internal/config/keycatalog.go
@@ -265,7 +265,7 @@ var keyCatalog = []KeyDef{
 		Description: `Random delay range [0, REQUEST_JITTER) before upstream chat calls; SAFE_MODE sets 200ms when unset; 0 disables.`},
 	{Key: "REQUEST_TIMEOUT", Group: GroupUpstream, Kind: "text", RestartOnly: true, Hidden: true,
 		Default:     "15m",
-		Description: `Upstream request timeout.`},
+		Description: `Upstream response-header (TTFB) timeout; the streamed chat body runs until upstream finishes or the client disconnects (never cut by this knob).`},
 	{Key: "SESSION_CALL_TIMEOUT", Group: GroupUpstream, Kind: "text", RestartOnly: true, Hidden: true,
 		Default:     "30s",
 		Description: `Session call timeout.`},

--- a/backend/internal/upstream/chat.go
+++ b/backend/internal/upstream/chat.go
@@ -104,15 +104,14 @@ func (c *Client) ChatCompletions(ctx context.Context, opts ChatOptions, body []b
 		if err != nil {
 			return nil, err
 		}
-		// The streamed response body must stay readable after this call returns,
-		// so the request timeout is applied here (not inside do) and released
-		// only when the body is closed.
+		// The streamed response body must stay readable after this call
+		// returns, so no deadline is attached to the request context: the
+		// transport's ResponseHeaderTimeout (REQUEST_TIMEOUT) bounds only
+		// the wait for response headers, and the body streams until
+		// upstream EOF or the caller cancels (client disconnect). cancel
+		// stays nil here; cancelBody exists so a future deadline-based
+		// caller still gets correct release-on-close semantics.
 		var cancel context.CancelFunc
-		if _, hasDeadline := req.Context().Deadline(); !hasDeadline && c.requestTimeout > 0 {
-			reqCtx, cancelFn := context.WithTimeout(req.Context(), c.requestTimeout)
-			cancel = cancelFn
-			req = req.WithContext(reqCtx)
-		}
 		req.Header.Set("Accept", "application/json, text/event-stream")
 		// Chat is the ONLY path carrying the ai-sdk UA: the real
 		// CLI pins it on model calls alone; newRequest defaulted this

--- a/backend/internal/upstream/client.go
+++ b/backend/internal/upstream/client.go
@@ -180,6 +180,14 @@ func NewWithIndex(token string, tokenIndex int, cfg *config.Config) (*Client, er
 	transport.MaxConnsPerHost = 64 // cap bursts; 0=unlimited would spike 64 TLS handshakes on cold start (h1 path). h2 multiplexes within this cap.
 	transport.WriteBufferSize = 32 * 1024
 	transport.ReadBufferSize = 32 * 1024
+	// REQUEST_TIMEOUT guards only the wait for response HEADERS (TTFB) —
+	// never the streamed body. The old request-context deadline cut healthy
+	// long streams at the default 15m: a turn-heavy agent session died
+	// mid-stream with the connection still feeding data. The body now runs
+	// until upstream EOF or the caller's context cancels (client
+	// disconnect). Control calls are unaffected: they keep their own ctx
+	// deadlines (SessionCallTimeout), which stay tighter than this bound.
+	transport.ResponseHeaderTimeout = c.requestTimeout
 	var baseDial func(ctx context.Context, network, addr string) (net.Conn, error)
 
 	var stealthProf *stealth.Profile

--- a/backend/internal/upstream/client_chat_test.go
+++ b/backend/internal/upstream/client_chat_test.go
@@ -1062,3 +1062,79 @@ func TestDeviceOSWireContract(t *testing.T) {
 		}
 	}
 }
+
+// TestChatStreamSurvivesPastRequestTimeout pins that REQUEST_TIMEOUT guards
+// only the wait for response headers (TTFB), never the streamed body.
+// Regression: the request-context deadline cut healthy long streams at
+// REQUEST_TIMEOUT (default 15m) — a turn-heavy session died mid-stream with
+// the connection still feeding data (observed live 2026-09-06).
+func TestChatStreamSurvivesPastRequestTimeout(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	const chunkCount = 10
+	mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		for range chunkCount {
+			_, _ = io.WriteString(w, testutil.SSEEvent(`{"id":"c","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"x"},"finish_reason":null}]}`))
+			flusher.Flush()
+			time.Sleep(150 * time.Millisecond)
+		}
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}
+
+	client, err := New("tok-a", testConfig(mock.URL(), func(c *config.Config) {
+		c.RequestTimeout = 400 * time.Millisecond // far shorter than the 1.5s stream
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rc, err := client.ChatCompletions(context.Background(), ChatOptions{Model: "m", RunID: "r"}, []byte(`{"model":"m","messages":[{"role":"user","content":"hi"}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("stream cut at REQUEST_TIMEOUT while upstream was still feeding (want TTFB-only timeout): %v", err)
+	}
+	if got := strings.Count(string(data), `"content":"x"`); got != chunkCount {
+		t.Errorf("stream delivered %d chunks, want %d (truncated mid-stream?)", got, chunkCount)
+	}
+	if !strings.Contains(string(data), "[DONE]") {
+		t.Error("stream missing [DONE] terminal frame")
+	}
+}
+
+// TestChatTTFBTimeoutStillAborts pins that the TTFB guard is not lost: an
+// upstream that never sends response headers still aborts the attempt at
+// REQUEST_TIMEOUT instead of hanging forever.
+func TestChatTTFBTimeoutStillAborts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second) // stall before headers
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client, err := New("tok-a", testConfig(srv.URL, func(c *config.Config) {
+		c.RequestTimeout = 300 * time.Millisecond
+		c.TransientRetries = 0
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	rc, err := client.ChatCompletions(context.Background(), ChatOptions{Model: "m", RunID: "r"}, []byte(`{"model":"m","messages":[{"role":"user","content":"hi"}]}`))
+	if err == nil {
+		_ = rc.Close()
+		t.Fatal("want error for stalled response headers")
+	}
+	if elapsed := time.Since(start); elapsed > 1500*time.Millisecond {
+		t.Errorf("header timeout took %v, want abort near REQUEST_TIMEOUT (300ms)", elapsed)
+	}
+}

--- a/frontend/e2e/fixtures/config-meta.json
+++ b/frontend/e2e/fixtures/config-meta.json
@@ -707,7 +707,7 @@
     "secret": false,
     "essential": false,
     "hidden": true,
-    "description": "Upstream request timeout."
+    "description": "Upstream response-header (TTFB) timeout; the streamed chat body runs until upstream finishes or the client disconnects (never cut by this knob)."
   },
   {
     "key": "SESSION_CALL_TIMEOUT",


### PR DESCRIPTION
## Problem

Healthy long streams were cut at `REQUEST_TIMEOUT` (default 15m): the request-context deadline killed the body read mid-stream even while upstream kept feeding data. Observed live: turn-heavy agent sessions die at exactly the bound with no upstream error.

## Change

- `client.go`: `transport.ResponseHeaderTimeout = c.requestTimeout` — the knob now bounds only the wait for response headers (TTFB).
- `chat.go`: removed the `context.WithTimeout` wrap around the chat request; the streamed body runs until upstream EOF or the caller's context cancels (client disconnect).
- Control calls unaffected: `SessionCallTimeout` ctx deadlines are tighter and untouched.
- `keycatalog.go`: `REQUEST_TIMEOUT` description now states TTFB-only semantics; fixture regenerated.

## Verification

- `TestChatStreamSurvivesPastRequestTimeout`: 1.5s stream with 400ms knob — passes post-fix, failed pre-fix (context deadline exceeded at 400ms).
- `TestChatTTFBTimeoutStillAborts`: stalled headers still abort near the bound.
- Hermetic backend suite: all packages green.