### PR TITLE
fix(pool,convert): atomic RPM admission, <tool_calls> plural dialect, failover knob doc

### DIFF
--- a/backend/internal/config/keycatalog.go
+++ b/backend/internal/config/keycatalog.go
@@ -160,7 +160,7 @@ var keyCatalog = []KeyDef{
 		Description: `Burst request capacity per client IP (0 = defaults to 2 × RATE_LIMIT_PER_IP).`},
 	{Key: "RATE_LIMIT_FAILOVER", Group: GroupPool, Kind: "bool", Hidden: true,
 		Default:     "true",
-		Description: `Automatically rotate and lease another available token when an in-flight request encounters a 429 rate limit (default true).`},
+		Description: `Rotate to another available token when an in-flight request hits a token-level 429 (rate limit / throttle). turn_spend_limited is TERMINAL (upstream per-turn spend breaker — a retry re-trips instantly) and is excluded from failover (default true).`},
 	{Key: "RATE_LIMIT_PER_IP", Group: GroupPool, Kind: "text", Essential: true,
 		Default:     "0",
 		Description: `Requests/second allowed per client IP (0 = disabled; e.g. 20).`},

--- a/backend/internal/convert/accumulator_xml.go
+++ b/backend/internal/convert/accumulator_xml.go
@@ -22,11 +22,11 @@ import (
 // reference common/src/tools/constants.ts — the CLI's stream parser
 // util/stream-xml-parser.ts extracts exactly this tag from model output).
 var (
-	xmlToolCallBlockRe = regexp.MustCompile(`(?s)<tool_call>(.*?)</tool_call>|<codebuff_tool_call>(.*?)</codebuff_tool_call>|<function_call>(.*?)</function_call>|<\|?tool[_\-]?call[_\-]?start\|?>(.*?)<\|?tool[_\-]?call[_\-]?end\|?>`)
+	xmlToolCallBlockRe = regexp.MustCompile(`(?s)<tool_call>(.*?)</tool_call>|<codebuff_tool_call>(.*?)</codebuff_tool_call>|<function_call>(.*?)</function_call>|<\|?tool[_\-]?call[_\-]?start\|?>(.*?)<\|?tool[_\-]?call[_\-]?end\|?>|<tool_calls>(.*?)</tool_calls>`)
 	fencedToolCallRe   = regexp.MustCompile("(?s)```(?:json|tool_?call)?\\s*\\n?(\\{\\s*\"(?:name|function|cb_tool_name)\"\\s*:\\s*.*?\\})\\s*\\n?```")
 	xmlFunctionHeadRe  = regexp.MustCompile(`(?i)<function[=\s]+["']?([^>"\s]+)["']?>`)
 	xmlParamRe         = regexp.MustCompile(`(?s)<parameter[=\s]+["']?([^>"\s]+)["']?>(.*?)</parameter>|<param[=\s]+["']?([^>"\s]+)["']?>(.*?)</param>`)
-	danglingToolTagsRe = regexp.MustCompile(`(?i)</?(?:tool_call|codebuff_tool_call|function_call|function|parameter|param|\|?tool[_\-]?call[_\-]?(?:start|end)\|?)(?:[=\s][^>]*)?>`)
+	danglingToolTagsRe = regexp.MustCompile(`(?i)</?(?:tool_call|tool_calls|codebuff_tool_call|function_call|function|parameter|param|\|?tool[_\-]?call[_\-]?(?:start|end)\|?)(?:[=\s][^>]*)?>`)
 )
 
 // extractXMLToolCalls parses text-based tool calls (Hermes/Qwen/MiMo XML format)
@@ -52,10 +52,10 @@ func extractXMLToolCallsBytes(content []byte) (string, []*toolCall) {
 
 	// 1. Check XML block matches (<tool_call>...</tool_call>).
 	// FindAllSubmatchIndex reports each alternation group's span; the
-	// matching branch's group (1..4) carries the raw payload.
+	// matching branch's group (1..5) carries the raw payload.
 	for _, loc := range matches {
 		raw := ""
-		for g := 1; g <= 4 && 2*g+1 < len(loc); g++ {
+		for g := 1; g <= 5 && 2*g+1 < len(loc); g++ {
 			if loc[2*g] >= 0 && loc[2*g+1] > loc[2*g] {
 				raw = string(content[loc[2*g]:loc[2*g+1]])
 				break
@@ -211,6 +211,7 @@ type xmlStreamShape int
 const (
 	xmlShapeNone xmlStreamShape = iota
 	xmlShapeToolCall
+	xmlShapeToolCalls
 	xmlShapeCodebuff
 	xmlShapeFunctionCall
 	xmlShapePipe
@@ -223,6 +224,7 @@ const (
 // xmlStreamClosers maps literal block shapes to their closing tag.
 var xmlStreamClosers = map[xmlStreamShape]string{
 	xmlShapeToolCall:     "</tool_call>",
+	xmlShapeToolCalls:    "</tool_calls>",
 	xmlShapeCodebuff:     "</codebuff_tool_call>",
 	xmlShapeFunctionCall: "</function_call>",
 }
@@ -232,6 +234,7 @@ var xmlStreamClosers = map[xmlStreamShape]string{
 // conversion).
 var xmlStreamCloserBytes = map[xmlStreamShape][]byte{
 	xmlShapeToolCall:     []byte("</tool_call>"),
+	xmlShapeToolCalls:    []byte("</tool_calls>"),
 	xmlShapeCodebuff:     []byte("</codebuff_tool_call>"),
 	xmlShapeFunctionCall: []byte("</function_call>"),
 }
@@ -408,6 +411,7 @@ func (x *XMLToolCallExtractor) findOpener(s string) int {
 	// Literal openers.
 	for shape, open := range map[xmlStreamShape]string{
 		xmlShapeToolCall:     "<tool_call>",
+		xmlShapeToolCalls:    "<tool_calls>",
 		xmlShapeCodebuff:     "<codebuff_tool_call>",
 		xmlShapeFunctionCall: "<function_call>",
 	} {
@@ -506,6 +510,7 @@ func xmlStreamFencePending(s string, from int) bool {
 // handled separately (xmlStreamFencePending / xmlStreamFenceBrace).
 var xmlStreamLiteralOpeners = []string{
 	"<tool_call>",
+	"<tool_calls>",
 	"<codebuff_tool_call>",
 	"<function_call>",
 	"<|tool_call_start|>",
@@ -578,7 +583,7 @@ func xmlFenceCloseEnd(s []byte, from int) int {
 // buf, or -1 while the block is still open.
 func (x *XMLToolCallExtractor) closerEnd() int {
 	switch x.shape {
-	case xmlShapeToolCall, xmlShapeCodebuff, xmlShapeFunctionCall:
+	case xmlShapeToolCall, xmlShapeToolCalls, xmlShapeCodebuff, xmlShapeFunctionCall:
 		if i := bytes.Index(x.buf, xmlStreamCloserBytes[x.shape]); i >= 0 {
 			return i + len(xmlStreamClosers[x.shape])
 		}

--- a/backend/internal/convert/convert_xml_test.go
+++ b/backend/internal/convert/convert_xml_test.go
@@ -483,3 +483,75 @@ func TestAccumulator_AssistantToolCallContentNull(t *testing.T) {
 		t.Fatalf("len(tool_calls) = %d, want 1", len(calls))
 	}
 }
+
+// TestExtractXMLToolCallsPluralDialect pins the <tool_calls> (plural) XML
+// dialect: some models emit the plural wrapper around the same
+// <function=...>/<parameter=...> payload, and it must extract like the
+// singular form instead of leaking literal "<tool_calls>" into content.
+func TestExtractXMLToolCallsPluralDialect(t *testing.T) {
+	raw := "Reading VansRouter executor first half\n<tool_calls>\n<function=read_file>\n<parameter=path>VansRouter executor first half</parameter>\n</function>\n</tool_calls>"
+	cleaned, calls := extractXMLToolCalls(raw)
+	if len(calls) != 1 {
+		t.Fatalf("want 1 tool call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "read_file" {
+		t.Errorf("name = %q, want read_file", calls[0].Function.Name)
+	}
+	if strings.Contains(cleaned, "<tool_calls>") || strings.Contains(cleaned, "</tool_calls>") {
+		t.Errorf("cleaned content still carries the plural tags: %q", cleaned)
+	}
+	if !strings.Contains(cleaned, "Reading VansRouter executor first half") {
+		t.Errorf("cleaned content lost the prose: %q", cleaned)
+	}
+
+	// JSON payload inside the plural wrapper.
+	rawJSON := "x <tool_calls>{\"name\":\"read_file\",\"arguments\":{\"path\":\"a.go\"}}</tool_calls> y"
+	cleanedJSON, callsJSON := extractXMLToolCalls(rawJSON)
+	if len(callsJSON) != 1 || callsJSON[0].Function.Name != "read_file" {
+		t.Fatalf("plural JSON payload not extracted: %d calls, first %+v", len(callsJSON), callsJSON)
+	}
+	if strings.Contains(cleanedJSON, "<tool_calls>") {
+		t.Errorf("cleaned JSON content still carries plural tags: %q", cleanedJSON)
+	}
+}
+
+// TestXMLStreamExtractorPluralDialect streams a <tool_calls> block split
+// across fragments: the opener lands mid-tag, the payload and closer in a
+// later fragment. Regression: the plural opener was not a stream shape, so
+// the block leaked as literal "<tool_calls>" text to the harness.
+func TestXMLStreamExtractorPluralDialect(t *testing.T) {
+	var x XMLToolCallExtractor
+	text, calls := x.Feed("Let me check:\n<tool_cal")
+	if text != "Let me check:\n" {
+		t.Errorf("pre-opener text = %q, want %q", text, "Let me check:\n")
+	}
+	text, calls = x.Feed("ls>\n<function=read_file>\n<parameter=path>a.go</parameter>\n</function>\n</tool_calls>")
+	if len(calls) != 1 || calls[0].Function.Name != "read_file" {
+		t.Fatalf("want read_file call, got %d calls: %+v", len(calls), calls)
+	}
+	if text != "" {
+		t.Errorf("block fragment leaked as text: %q", text)
+	}
+	text, calls = x.Feed("done")
+	if text != "done" || len(calls) != 0 {
+		t.Errorf("post-block text = %q calls = %d", text, len(calls))
+	}
+}
+
+// TestXMLStreamExtractorPluralDanglingFlush pins Flush scrubbing of an
+// unclosed <tool_calls> block: no call parses, and the dangling tags are
+// removed instead of reaching the client as literal text.
+func TestXMLStreamExtractorPluralDanglingFlush(t *testing.T) {
+	var x XMLToolCallExtractor
+	text, calls := x.Feed("intro <tool_calls>\n<function=read_file>")
+	if text != "intro " {
+		t.Errorf("pre-opener text = %q, want %q", text, "intro ")
+	}
+	text, calls = x.Flush()
+	if len(calls) != 0 {
+		t.Fatalf("unclosed block parsed %d calls, want 0", len(calls))
+	}
+	if strings.Contains(text, "<tool_calls>") || strings.Contains(text, "<function") {
+		t.Errorf("dangling tags survived Flush: %q", text)
+	}
+}

--- a/backend/internal/convert/convert_xml_test.go
+++ b/backend/internal/convert/convert_xml_test.go
@@ -521,7 +521,7 @@ func TestExtractXMLToolCallsPluralDialect(t *testing.T) {
 // the block leaked as literal "<tool_calls>" text to the harness.
 func TestXMLStreamExtractorPluralDialect(t *testing.T) {
 	var x XMLToolCallExtractor
-	text, calls := x.Feed("Let me check:\n<tool_cal")
+	text, _ := x.Feed("Let me check:\n<tool_cal")
 	if text != "Let me check:\n" {
 		t.Errorf("pre-opener text = %q, want %q", text, "Let me check:\n")
 	}
@@ -543,7 +543,7 @@ func TestXMLStreamExtractorPluralDialect(t *testing.T) {
 // removed instead of reaching the client as literal text.
 func TestXMLStreamExtractorPluralDanglingFlush(t *testing.T) {
 	var x XMLToolCallExtractor
-	text, calls := x.Feed("intro <tool_calls>\n<function=read_file>")
+	text, _ := x.Feed("intro <tool_calls>\n<function=read_file>")
 	if text != "intro " {
 		t.Errorf("pre-opener text = %q, want %q", text, "intro ")
 	}

--- a/backend/internal/convert/convert_xml_test.go
+++ b/backend/internal/convert/convert_xml_test.go
@@ -525,7 +525,7 @@ func TestXMLStreamExtractorPluralDialect(t *testing.T) {
 	if text != "Let me check:\n" {
 		t.Errorf("pre-opener text = %q, want %q", text, "Let me check:\n")
 	}
-	text, calls = x.Feed("ls>\n<function=read_file>\n<parameter=path>a.go</parameter>\n</function>\n</tool_calls>")
+	text, calls := x.Feed("ls>\n<function=read_file>\n<parameter=path>a.go</parameter>\n</function>\n</tool_calls>")
 	if len(calls) != 1 || calls[0].Function.Name != "read_file" {
 		t.Fatalf("want read_file call, got %d calls: %+v", len(calls), calls)
 	}
@@ -547,7 +547,7 @@ func TestXMLStreamExtractorPluralDanglingFlush(t *testing.T) {
 	if text != "intro " {
 		t.Errorf("pre-opener text = %q, want %q", text, "intro ")
 	}
-	text, calls = x.Flush()
+	text, calls := x.Flush()
 	if len(calls) != 0 {
 		t.Fatalf("unclosed block parsed %d calls, want 0", len(calls))
 	}

--- a/backend/internal/pool/acquire.go
+++ b/backend/internal/pool/acquire.go
@@ -577,6 +577,23 @@ func (p *Pool) leaseFromOrder(ctx context.Context, model string, agentID string,
 			"country", ss.CountryCode)
 		p.logger.Debug("pool: lease acquired", "token", idx+1, "model", effectiveModel, "agent", effectiveAgentID, "instance_id", instanceID,
 			"country", ss.CountryCode)
+		lease := &Lease{Token: idx, Model: effectiveModel, AgentID: effectiveAgentID, Run: run, SessionInstanceID: instanceID,
+			entry: tok, AcquiredAt: time.Now()}
+		// MAX_REQUESTS_PER_MINUTE admission is enforced atomically HERE at
+		// lease grant. The pre-filter above only reads the rolling window;
+		// recording later (in Chat) raced it — a concurrent burst (agent
+		// spawn batches) all passed the cap before any record landed. On a
+		// full window the run is released and the token counted as
+		// rate-limited so the loop tries the next one. Admission is always
+		// recorded (even with cap 0 = unlimited) so the token snapshot
+		// counters stay meaningful.
+		if !p.tryAdmitRequest(tok) {
+			p.LeaseRelease(lease)
+			rateLimited = appendRateLimit(rateLimited, p.rpmLimitError(idx))
+			errs = append(errs, fmt.Sprintf("%s: per-minute request limit (%d) reached", name, cfg.MaxRequestsPerMinute))
+			p.logger.Debug("pool: token skipped (per-minute request limit)", "token", idx+1, "limit", cfg.MaxRequestsPerMinute)
+			continue
+		}
 		// Track the activity and end any idle-maintenance pause: the next
 		// maintain tick resumes rotation/refresh work.
 		p.lastActiveMu.Lock()
@@ -590,8 +607,7 @@ func (p *Pool) leaseFromOrder(ctx context.Context, model string, agentID string,
 		}
 		p.lastTokenByModel[effectiveModel] = idx
 		p.lastTokenMu.Unlock()
-		return &Lease{Token: idx, Model: effectiveModel, AgentID: effectiveAgentID, Run: run, SessionInstanceID: instanceID,
-			entry: tok, AcquiredAt: time.Now()}, nil
+		return lease, nil
 	}
 
 	// Failover precedence (PRD §6 error matrix): when buckets are mixed the

--- a/backend/internal/pool/bridge.go
+++ b/backend/internal/pool/bridge.go
@@ -422,6 +422,16 @@ sessionReady:
 
 	p.logger.Debug("pool: bridge lease acquired", "model", effectiveModel, "agent", effectiveAgentID, "instance_id", ss.InstanceID,
 		"country", ss.CountryCode)
+	// MAX_REQUESTS_PER_MINUTE admission enforced atomically at grant time,
+	// mirroring Acquire: the pre-filter above only reads the window, and a
+	// concurrent burst must not pass the cap before any record lands.
+	// Admission is always recorded (even with cap 0 = unlimited) so the
+	// bridge snapshot counters stay meaningful.
+	if !p.bridgeTryAdmitRequest(entry) {
+		p.LeaseRelease(&Lease{Token: -1, Model: effectiveModel, AgentID: effectiveAgentID, Run: run, SessionInstanceID: ss.InstanceID,
+			Bridge: entry, AcquiredAt: time.Now()})
+		return nil, p.bridgeRpmLimitError(entry)
+	}
 	// Track the activity and end any idle-maintenance pause, mirroring
 	// Acquire: without this, IDLE_ROTATION_TIMEOUT was dead config in
 	// bridge mode — lastActive stayed zero forever, so the pool never

--- a/backend/internal/pool/pool.go
+++ b/backend/internal/pool/pool.go
@@ -903,14 +903,10 @@ func (p *Pool) Chat(ctx context.Context, lease *Lease, opts upstream.ChatOptions
 		return nil, errors.New("pool: chat: invalid lease")
 	}
 	rc, err := t.client.ChatCompletions(ctx, opts, body)
-	// Per-minute request accounting (MAX_REQUESTS_PER_MINUTE): every request
-	// that went upstream counts, success or failure — the exact rate
-	// upstream observes (retries that later fail are throttled too).
-	if t.bridge != nil {
-		p.bridgeRecordRequest(t.bridge)
-	} else if t.entry != nil {
-		p.recordRequestEntry(t.entry)
-	}
+	// Per-minute request accounting (MAX_REQUESTS_PER_MINUTE) happens at
+	// lease-grant time in Acquire/AcquireBridge — atomically, so a burst
+	// cannot pass the cap before any record lands. Only the success-side
+	// records (daily message cap, Pacific-day request cap) live here.
 	if err == nil {
 		if t.bridge != nil {
 			// Only chats that actually went upstream count against the

--- a/backend/internal/pool/pool_request_test.go
+++ b/backend/internal/pool/pool_request_test.go
@@ -25,9 +25,8 @@ func TestAcquirePerMinuteRequestCap(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	chatOnce(t, p, lease) // records the admitted request + successful chat
+	chatOnce(t, p, lease) // admission counted at Acquire; chat records the successful chat
 	p.LeaseRelease(lease)
-
 	if got := p.Snapshot()[0].RequestsPerMinute; got != 1 {
 		t.Errorf("RequestsPerMinute = %d, want 1", got)
 	}
@@ -280,5 +279,95 @@ func TestRequestLedgerDayBucketRollsAtPacificMidnight(t *testing.T) {
 	l3 := newAccountLedger()
 	if d := l3.dayRequestResetIn(time.Now()); d <= 0 || d > 26*time.Hour {
 		t.Errorf("dayRequestResetIn = %s, want (0, 26h]", d)
+	}
+}
+
+// TestAcquireRPMAdmitBurstIsAtomic pins that RPM admission counting is
+// atomic with the lease grant: two concurrent acquires against cap=1 must
+// admit exactly one (the other 429s) — never both. Regression: the old
+// check-in-Acquire / record-in-Chat split let a concurrent burst (agent
+// spawn batches) pass the cap before any record landed, since Chat records
+// after an upstream call the test path never makes.
+func TestAcquireRPMAdmitBurstIsAtomic(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	p := newTestPoolCfg(t, func(c *config.Config) { c.MaxRequestsPerMinute = 1 }, mock)
+
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			<-start
+			_, err := p.Acquire(context.Background(), modelA)
+			results <- err
+		}()
+	}
+	close(start)
+	var okCount, cappedCount int
+	for range 2 {
+		if err := <-results; err == nil {
+			okCount++
+		} else if errors.Is(err, upstream.ErrRateLimited) {
+			cappedCount++
+		} else {
+			t.Fatalf("unexpected acquire error: %v", err)
+		}
+	}
+	if okCount != 1 || cappedCount != 1 {
+		t.Errorf("burst admit = %d ok / %d capped, want 1/1 (admission counting must be atomic with the grant)", okCount, cappedCount)
+	}
+}
+
+// TestAcquireCountsAdmissionAtGrant pins that an admitted request is
+// counted the moment the lease is granted — before any chat. A lease with
+// no follow-up chat still consumed its admission slot.
+func TestAcquireCountsAdmissionAtGrant(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	p := newTestPool(t, mock) // RPM cap 0 (unlimited) — counting still happens
+
+	lease, err := p.Acquire(context.Background(), modelA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.LeaseRelease(lease)
+	if got := p.Snapshot()[0].RequestsPerMinute; got != 1 {
+		t.Errorf("RequestsPerMinute right after Acquire = %d, want 1 (admission counted at lease grant)", got)
+	}
+}
+
+// TestBridgeRPMAdmitBurstIsAtomic is the bridge-mode mirror: two
+// concurrent AcquireBridge calls for one client token against cap=1 must
+// admit exactly one.
+func TestBridgeRPMAdmitBurstIsAtomic(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	p := newBridgePool(t, mock)
+	cfg := p.cfg.Load()
+	cfg.MaxRequestsPerMinute = 1
+	p.cfg.Store(cfg)
+
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			<-start
+			_, err := p.AcquireBridge(context.Background(), "client-a", modelA)
+			results <- err
+		}()
+	}
+	close(start)
+	var okCount, cappedCount int
+	for range 2 {
+		if err := <-results; err == nil {
+			okCount++
+		} else if errors.Is(err, upstream.ErrRateLimited) {
+			cappedCount++
+		} else {
+			t.Fatalf("unexpected bridge acquire error: %v", err)
+		}
+	}
+	if okCount != 1 || cappedCount != 1 {
+		t.Errorf("bridge burst admit = %d ok / %d capped, want 1/1", okCount, cappedCount)
 	}
 }

--- a/backend/internal/pool/quota.go
+++ b/backend/internal/pool/quota.go
@@ -269,9 +269,13 @@ func (p *Pool) usageResetIn(token int) time.Duration { return p.roster.usageRese
 
 // --- per-token request limits (MAX_REQUESTS_PER_DAY / _PER_MINUTE) ---
 
-// recordRequestEntry appends one ADMITTED chat request for the lease's
-// backing entry by pointer (see roster.recordRequestEntry).
-func (p *Pool) recordRequestEntry(entry *tokenEntry) { p.roster.recordRequestEntry(entry) }
+// tryAdmitRequest atomically records one ADMITTED chat request for the
+// lease's backing entry at lease-grant time (MAX_REQUESTS_PER_MINUTE):
+// returns false when the rolling 60s window is already at the cap, so the
+// acquire loop counts the token as rate-limited and tries the next one.
+func (p *Pool) tryAdmitRequest(entry *tokenEntry) bool {
+	return p.roster.tryAdmitRequest(entry, p.cfg.Load().MaxRequestsPerMinute)
+}
 
 // rpmCount returns how many admitted requests token sent within the last
 // 60s window, pruning expired timestamps.
@@ -337,16 +341,21 @@ func (p *Pool) bridgeRecordChat(entry *bridgeEntry) {
 	p.bridgeDailyUsage++
 }
 
-// bridgeRecordRequest appends one ADMITTED chat request for the bridge
-// entry (MAX_REQUESTS_PER_MINUTE): success or failure upstream, the request
-// was sent.
-func (p *Pool) bridgeRecordRequest(entry *bridgeEntry) {
+// bridgeTryAdmitRequest atomically checks and records one ADMITTED chat
+// request for the bridge entry (MAX_REQUESTS_PER_MINUTE) under bridgeMu, at
+// AcquireBridge grant time — burst-safe like the pooled path. Returns false
+// when the 60s window is at the cap.
+func (p *Pool) bridgeTryAdmitRequest(entry *bridgeEntry) bool {
 	if entry == nil {
-		return
+		return false
 	}
 	p.bridgeMu.Lock()
 	defer p.bridgeMu.Unlock()
+	if cap := p.cfg.Load().MaxRequestsPerMinute; cap > 0 && entry.ledger.rpmCount(time.Now()) >= cap {
+		return false
+	}
 	entry.ledger.recordRequest(time.Now())
+	return true
 }
 
 // bridgeRpmCount returns how many admitted requests the bridge entry sent

--- a/backend/internal/pool/roster.go
+++ b/backend/internal/pool/roster.go
@@ -224,16 +224,24 @@ func (r *tokenRoster) recordChatEntry(entry *tokenEntry) {
 	entry.ledger.recordDayRequest(now)
 }
 
-// recordRequestEntry appends one ADMITTED chat request for a lease's backing
-// entry by pointer (MAX_REQUESTS_PER_MINUTE): success or failure upstream,
-// the request was sent — counted at the exact rate upstream observes.
-func (r *tokenRoster) recordRequestEntry(entry *tokenEntry) {
+// tryAdmitRequest atomically checks and records one ADMITTED chat request
+// for the entry (MAX_REQUESTS_PER_MINUTE) under the roster lock: the 60s
+// window is pruned and the request appended only while the count is below
+// the cap. Returns false when the window is full — the caller treats the
+// token as rate-limited and moves on. Atomicity is the point: the old
+// check-in-Acquire / record-in-Chat split let a concurrent burst (agent
+// spawn batches) pass the cap before any record landed.
+func (r *tokenRoster) tryAdmitRequest(entry *tokenEntry, cap int) bool {
 	if entry == nil {
-		return
+		return false
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if cap > 0 && entry.ledger.rpmCount(time.Now()) >= cap {
+		return false
+	}
 	entry.ledger.recordRequest(time.Now())
+	return true
 }
 
 // rpmCount returns the entry at token's admitted-request count in the

--- a/frontend/e2e/fixtures/config-meta.json
+++ b/frontend/e2e/fixtures/config-meta.json
@@ -330,7 +330,7 @@
     "secret": false,
     "essential": false,
     "hidden": true,
-    "description": "Automatically rotate and lease another available token when an in-flight request encounters a 429 rate limit (default true)."
+    "description": "Rotate to another available token when an in-flight request hits a token-level 429 (rate limit / throttle). turn_spend_limited is TERMINAL (upstream per-turn spend breaker — a retry re-trips instantly) and is excluded from failover (default true)."
   },
   {
     "key": "RATE_LIMIT_PER_IP",


### PR DESCRIPTION
## Problems

1. **MAX_REQUESTS_PER_MINUTE race**: admission was checked in `Acquire` but recorded later in `Chat`. A concurrent burst (agent spawn batches of 6-8) all passed the cap before any record landed — e.g. a 5/min cap admitted 8. Observed: user set 5/min and bursts went through.
2. **`<tool_calls>` plural dialect**: some models emit the plural wrapper around the same `<function=...>` payload. The extractor only knew singular/pipe/fence forms, so plural blocks leaked as literal `<tool_calls>` text to the harness and never became tool calls.
3. **Misleading knob text**: `RATE_LIMIT_FAILOVER` description did not say `turn_spend_limited` is TERMINAL and excluded from failover.

## Changes

- `pool`: `tryAdmitRequest` (roster lock) + `bridgeTryAdmitRequest` (bridgeMu) record the admission atomically at lease-grant time; grant fails over to the next token when the window filled concurrently. `Pool.Chat` no longer records admissions (success-side RPD/usage records stay). Dead `recordRequestEntry` paths removed.
- `convert`: new `xmlShapeToolCalls` stream shape (opener/closer/split-opener/dangling scrub) + 5th block-regex group for the non-stream path; payload parsing (function heads/params/JSON) is shape-agnostic.
- `keycatalog`: `RATE_LIMIT_FAILOVER` description states the terminal exclusion.
- Fixture regenerated (`FP_REGEN_FIXTURE=1`).

## Verification

- `TestAcquireRPMAdmitBurstIsAtomic` / `TestBridgeRPMAdmitBurstIsAtomic`: 2 concurrent acquires, cap=1 -> exactly 1 admits (deterministic; pre-fix both admitted).
- `TestAcquireCountsAdmissionAtGrant`: count is 1 right after Acquire with no chat.
- `TestExtractXMLToolCallsPluralDialect` / `TestXMLStreamExtractorPluralDialect` / `TestXMLStreamExtractorPluralDanglingFlush`.
- Full hermetic backend suite green; `go vet` clean.