### PR TITLE
docs(pool,convert,upstream,server): task-local CONTRACT.md + burst-test lease hygiene

### DIFF
--- a/backend/internal/convert/CONTRACT.md
+++ b/backend/internal/convert/CONTRACT.md
@@ -1,0 +1,44 @@
+# Package Contract: `backend/internal/convert`
+
+Task-local contract for agents modifying this package. Load before editing any file here.
+
+## Purpose
+
+Pure OpenAI request/response normalization for the bridge. Performs NO I/O: every function is a pure transformation over JSON decoded from a request body or SSE frame. Covers request sanitization (parameter whitelist, developer→system role rewrite, tool-schema normalization, `end_turn` injection), SSE frame encoding + per-chunk stream sanitization, the non-streaming response accumulator with XML tool-call extraction, reasoning-effort extraction, and tool-name mapping.
+
+## Public API (stable surface)
+
+- Request normalization: `NormalizeRequest(body, modelOverride)`, `NormalizeRequestOpts`, `NormalizeRequestMapped(Opts)` → `([]byte, ToolMapper, error)`.
+- Tools: `NewToolMapper(body) ToolMapper` (+ `MsgCount`/`ToolCount`, request rename / response restore); `ToolCallDeltaFragment(index, tc)`.
+- SSE: `EncodeSSE(data)`, `DONE`, `ErrorChunk(msg, code)`, `SanitizeChunk(line) ([]byte, bool)` + `SanitizeChunkOpts`, `StripEndTurnToolCalls(chunk) (remaining bool, finishReason string)`.
+- Accumulator: `NewAccumulator()`, `NewAccumulatorOpts(Options)`, `Accumulator.Add/…/Finish()`; `XMLToolCallExtractor` (Feed/Flush).
+- Effort: `ExtractReasoningEffort(payload)`; `InjectCacheControl(messages)`.
+- Options: `Options`, `DefaultOptions()`.
+
+## Allowed dependencies
+
+`modelcat`, `reasoningcache` (via `Options.ReasoningLookup`), `tokenestimate` — exactly the set pinned by `layer_reviewfix_test.go` (`TestConvertDoesNotImportPackageBoundary` scans non-test files).
+
+## Forbidden dependencies
+
+EVERYTHING else — `config`, `pool`, `upstream`, `server`, `registry`, `dashboard`, `session`, `runs`, `notify`, `stealth`, `telemetry`, `logring`, `cmd/*`. The import-boundary test fails the build on any new internal import. Envelope injection (`codebuff_metadata`, forced stream, `x-freebuff-*` headers) deliberately lives in `backend/internal/upstream`.
+
+## Critical invariants
+
+- Pure: the `*Opts` variants never read the process environment, touch the filesystem, or make network calls; the only external inputs are passed in explicitly (`Options`, a `ReasoningLookupFn`, an Accumulator's per-call config). `DefaultOptions` is a deprecated compatibility shim that still reads `COMPRESS_PROMPT` / `CACHE_CONTROL_INJECTION` / `REASONING_IN_CONTENT` from the environment until callers pass config-derived options (issue #277).
+- `end_turn` injection: the proxy injects the `end_turn` tool definition to pass Codebuff's `foreign_toolset` validation (schemacache.go). Downstream parity: it MUST be stripped before emitting to clients (`StripEndTurnToolCalls`); both the OpenAI and Anthropic relays call it. An existing `end_turn` must never be duplicated.
+- Schema normalization: `$ref` inlining with cycle guard, depth cap (12 levels), per-request node budget, enum cross-type dedupe; the schema cache returns maps that callers must not mutate (mutation-safety pinned by test).
+- Stream sanitization: whitelist keys, drop empty-choice chunks, drop enrichment keys (`service_tier`, `obfuscation`, `moderation`), correct `finish_reason`/`[DONE]` handling; canonical chunks take a fast path.
+- XML extractor: pooled buffers, bounded partial-hold (repeated `<` cannot re-hold forever), blocks close on `</tool_call>`; extraction of `end_turn`-shaped blocks must never surface to clients.
+- Effort ladders delegate to `modelcat` (never a local copy).
+
+## Tests that protect it
+
+`layer_reviewfix_test.go` (import boundary — do not break), `convert_req_test.go` (whitelist, roles, effort clamp, compression, think-tag extraction), `convert_schema_test.go` (end_turn injection, schema cache, refs, budgets), `convert_stream_test.go` (SSE encode/sanitize, accumulator), `convert_xml_test.go` + `stream_completeness_test.go` (XML dialects, partial openers), `schemacache_foreign_test.go` (signature-tool pin), `effort_modelcat_test.go` (parity with modelcat), `reasoning_restore_test.go`, `toolmap_test.go` + `toolmap_coverage_test.go` (bidirectional harness mapping), `accumulator_bench_test.go` (allocation floors, pool race-freedom).
+
+## Safe modification patterns
+
+- New knobs: extend `Options` and wire from `config` — do NOT add new env reads on hot paths (`DefaultOptions` is on the deprecation path).
+- New internal import → update `layer_reviewfix_test.go` allowlist deliberately (a review event, not a routine edit).
+- Tool-map changes: keep the bidirectional mapping (client name ↔ official name); the coverage test pins the harness signature corpus — regenerate/extend it with any new harness dialect.
+- Performance-sensitive edits: run `accumulator_bench_test.go` benchmarks; the sanitize fast path must stay allocation-light.

--- a/backend/internal/pool/CONTRACT.md
+++ b/backend/internal/pool/CONTRACT.md
@@ -1,0 +1,52 @@
+# Package Contract: `backend/internal/pool`
+
+Task-local contract for agents modifying this package. Load before editing any file here. The rest of the repo's mental model is NOT required.
+
+## Purpose
+
+Multi-token front door for chat requests. Owns token selection order, session admission, run leasing, cooldowns/quarantines, per-token quota windows (RPM/RPD/daily messages), spend tracking, the bridge-mode token cache, model-lock routing, and streak-maturity automation. Port of freebuff2api-quorinex `run_manager.go` (Acquire half) with the upstream/session/runs split of this project.
+
+## Public API (stable surface)
+
+- Construction: `New(cfg, clients, sessions, reg) (*Pool, error)`, `SetConfig(*config.Config)`, `SetSessionStore(*session.Store)`, `SetNotifier(*notify.Sender)`, `Start(ctx)`, `Shutdown(ctx)`.
+- Serving: `Acquire(ctx, model) (*Lease, error)`, `AcquireBridge(ctx, clientToken, model) (*Lease, error)`, `Chat(ctx, lease, opts, body) (io.ReadCloser, error)`.
+- Lease lifecycle (all nil-safe): `LeaseRelease`, `LeaseAbandon`, `RecordRunStep`, `MarkRunFailed`, `RecordSpend`.
+- Invalidation: `InvalidateSession(WithReason)`, `InvalidateRun`, `InvalidateLeaseSession(WithReason)`, `InvalidateLeaseRun`, `InvalidateBridgeSession(WithReason)`, `InvalidateBridgeRun`.
+- Cooldowns: `CooldownToken*` / `CooldownLease*` / `CooldownBridge*` (auth / rate-limit / IP-capped / ban / country-blocked); `UnlockToken`, `LockToken`, `UnlockLockToken`, `LockBridgeEntry`, `UnlockBridgeEntry`.
+- Probes: `ProbeNewToken(ctx, token)`, `ProbeToken(ctx, idx)`.
+- Token management: `AddToken`, `RemoveLastToken`, `RemoveTokenAt`, `RemoveAllTokens`, `SwapTokens`, `MoveToken`, `TokenCount`, `SetTokenAccountInfo`, `EnsureTokenSession`.
+- Views: `Snapshot() []TokenSnapshot`, `PoolSnapshot()`, `BridgeSnapshot() []BridgeTokenSnapshot`, `BridgeCount()`, `PremiumQuotaForToken/Bridge` (+ backward-compat aliases), maturity snapshot carried on `TokenSnapshot`.
+- Maturity: `SetMaturity`, `MaturityTouchNow`; type `MaturitySnapshot`.
+- Unfit: `MarkModelUnfit`, `ClearModelUnfit(Before)`, `ModelUnfit`.
+
+## Allowed dependencies
+
+`config`, `notify`, `phasetiming`, `runs`, `session`, `upstream`, `registry`, `modelcat` (maturity.go only). Tests additionally use `testutil`, `upstream/testmock`.
+
+## Forbidden dependencies
+
+`server`, `convert`, `dashboard`, `stealth`, `ratelimit`, `logring`, `tokenestimate`, `reasoningcache`, `cmd/*`. Pool sits below `server`; `server` calls INTO pool, never the reverse. A new internal import here is a layering event — review before adding.
+
+## Critical invariants
+
+- Failover error-bucket precedence (PRD §6): ban > country-blocked > model-IP-limited > rate-limit > waiting-room > daily cap. Only when NO bucket matches any token does the pool return a combined error. A queued token surfaces 503 + Retry-After as soon as no higher bucket is populated.
+- 401 auth rejection → 30-min cooldown for that token, try the next. Run-invalid/session-invalid recoveries are NOT handled here: the caller (server) retries once via a fresh Acquire after invalidating.
+- Lease contract: caller MUST call `LeaseRelease` (or `LeaseAbandon` on client disconnect) when the request completes or fails; it decrements the run's inflight counter.
+- Swap-safety: token indexes are display positions; leases hold entry pointers, never indexes.
+- Quota semantics: RPM = ADMITTED requests (rolling 60s window); RPD = SUCCESSFUL chats in the current Pacific day (bucket rolls at Pacific midnight); `MAX_MESSAGES_PER_DAY` = rolling 24h successful chats. 0 = unlimited. RPM/RPD counters live in the ledger, never in the static cache.
+- Bridge cache: every read AND write of entries/ledgers runs under `bridgeMu`; `rpmCount`/`dayRequestCount` prune/roll in place and MUST be called under the owning lock (data-race fix 2026-09-06). Never call upstream/network while holding `bridgeMu` (evict outside the lock).
+- `roster.Load()` once per call — never cache the pointer across calls.
+- Maturity (pool/maturity.go): `MATURITY_ENABLED` default ON (global kill-switch), dry-run default (probe-only, zero session slots claimed), unmetered touch models only (premium-short gated by `MATURITY_ALLOW_PREMIUM` + per-token opt-in), jittered daily slot in the account's own timezone, restart-safe 6h throttle, stops firing after 3 consecutive non-advancing days, never touches quarantined/banned/cooling/country-blocked accounts. Touch must fail closed on priced models (`skip:touch-priced`).
+- Spend ledger records events only — the $ ceiling is enforced elsewhere (server-enforced).
+
+## Tests that protect it
+
+`pool_acquire_test.go` (selection/failover), `acquire_order_test.go` (quota-first ordering), `pool_edge_test.go`, `pool_cooldown_test.go`, `pool_quota_test.go` + `pool_quota_window_test.go` (Pacific-midnight roll), `pool_request_test.go` (RPM/RPD window semantics), `pool_bridge_test.go` + `bridge_admission_test.go` + `bridge_singleflight_test.go` + `bridge_gaps_test.go` (bridge cache/eviction), `quarantine_test.go`, `hardban_test.go`, `unfit_test.go`, `spend_test.go`, `glm_referral_test.go`, `model_locks_test.go`, `maturity_test.go`, `lifecycle_shutdown_test.go` (bridge drain outside lock), `pool_swap_test.go`, `pool_remove_test.go`, `random_rotation_test.go`, `admission_leader_election_test.go`, `session_handling_test.go`, `pool_webhook_test.go`, `quota_tracker_test.go`.
+
+## Safe modification patterns
+
+- New config knobs: `config` is a bottom layer (rejects all internal imports via `layer_imports_test.go`) — add shape-only `Validate` checks there; semantic checks (served/unmetered) live in the pool fire path + admin endpoint. Register the key in `keycatalog.go` (byte-ascending order) + `dotenvKeys`, then regen fixtures with `FP_REGEN_FIXTURE=1`.
+- Adding a ledger counter: mirror `rpmCount`/`dayRequestCount` — prune in place, expose through `roster` + bridge cache under the owning lock, and extend `pool_request_test.go` window-edge assertions.
+- `-race` does not run on Windows locally (cgo issue) — race-sensitive changes MUST be verified on Linux CI.
+- After editing struct literals: `git diff | grep '^-[^-]'` and confirm every removed line has an intended re-add (dropped fields compile as zero values).
+- Bridge-run persistence: new run managers must receive the session store via the same injection pattern as pooled entries (`SetSessionStore`); cover bridge run-resume in the persist tests.

--- a/backend/internal/pool/pool_request_test.go
+++ b/backend/internal/pool/pool_request_test.go
@@ -294,23 +294,29 @@ func TestAcquireRPMAdmitBurstIsAtomic(t *testing.T) {
 	p := newTestPoolCfg(t, func(c *config.Config) { c.MaxRequestsPerMinute = 1 }, mock)
 
 	start := make(chan struct{})
-	results := make(chan error, 2)
+	type burstResult struct {
+		lease *Lease
+		err   error
+	}
+	results := make(chan burstResult, 2)
 	for range 2 {
 		go func() {
 			<-start
-			_, err := p.Acquire(context.Background(), modelA)
-			results <- err
+			lease, err := p.Acquire(context.Background(), modelA)
+			results <- burstResult{lease, err}
 		}()
 	}
 	close(start)
 	var okCount, cappedCount int
 	for range 2 {
-		if err := <-results; err == nil {
+		res := <-results
+		if res.err == nil {
 			okCount++
-		} else if errors.Is(err, upstream.ErrRateLimited) {
+			p.LeaseRelease(res.lease) // winner: release, don't strand the run
+		} else if errors.Is(res.err, upstream.ErrRateLimited) {
 			cappedCount++
 		} else {
-			t.Fatalf("unexpected acquire error: %v", err)
+			t.Fatalf("unexpected acquire error: %v", res.err)
 		}
 	}
 	if okCount != 1 || cappedCount != 1 {
@@ -348,23 +354,29 @@ func TestBridgeRPMAdmitBurstIsAtomic(t *testing.T) {
 	p.cfg.Store(cfg)
 
 	start := make(chan struct{})
-	results := make(chan error, 2)
+	type bridgeBurstResult struct {
+		lease *Lease
+		err   error
+	}
+	results := make(chan bridgeBurstResult, 2)
 	for range 2 {
 		go func() {
 			<-start
-			_, err := p.AcquireBridge(context.Background(), "client-a", modelA)
-			results <- err
+			lease, err := p.AcquireBridge(context.Background(), "client-a", modelA)
+			results <- bridgeBurstResult{lease, err}
 		}()
 	}
 	close(start)
 	var okCount, cappedCount int
 	for range 2 {
-		if err := <-results; err == nil {
+		res := <-results
+		if res.err == nil {
 			okCount++
-		} else if errors.Is(err, upstream.ErrRateLimited) {
+			p.LeaseRelease(res.lease) // winner: release, don't strand the run
+		} else if errors.Is(res.err, upstream.ErrRateLimited) {
 			cappedCount++
 		} else {
-			t.Fatalf("unexpected bridge acquire error: %v", err)
+			t.Fatalf("unexpected bridge acquire error: %v", res.err)
 		}
 	}
 	if okCount != 1 || cappedCount != 1 {

--- a/backend/internal/server/CONTRACT.md
+++ b/backend/internal/server/CONTRACT.md
@@ -1,0 +1,47 @@
+# Package Contract: `backend/internal/server`
+
+Task-local contract for agents modifying this package. Load before editing any file here. This is the busiest package in the repo — coordinate file ownership with parallel work before touching shared files.
+
+## Purpose
+
+The HTTP surface of the bridge: OpenAI chat completions + responses, Anthropic messages, model catalog, embeddings, health, and the embedded admin dashboard. Owns client auth, request sanitization (via `convert`), the protocol-neutral completion engine (acquire → upstream → relay), retry-once recovery, protocol-aware error envelopes, SSE relays, metrics, and admin auth/config/token endpoints.
+
+## Public API (stable surface)
+
+- `Server` (atomic `cfg` pointer — `/admin/reload` swaps it mid-flight, so every handler `Load()`s once per request), `Handler()` route table, `NewServer(...)`.
+- Completion engine (`engine.go`, `engine_attempt.go`): `chatCore`, `chatAttempt`, `chatBackend` interface (pooled + bridge adapters share one recovery loop), `relayFunc`, `engine_sse.go` (`relayReadLoop`, `lineChunk`, `keepaliveInterval` 15s).
+- Per-surface handlers (protocol policy lives HERE, never in the engine): `openai.go` + `openai_stream.go` + `openai_chunk_pipeline.go` + `openai_stream_rewrite.go` + `streamxml_openai.go`; `responses.go` + `responses_stream.go`; `anthropic.go` + `anthropic_stream.go` + `anthropic_json.go` + `anthropic_count.go` + `anthropic_errors.go` + `streamxml_anthropic.go`; `models.go` + `models_codex.go`.
+- Cross-cutting: `errors.go` + `engine_helpers.go` (error class/status/envelope mapping), `middleware.go` (auth, CORS, access log, body caps), `health.go`, `gzip.go`.
+- Admin: `admin.go`, `admin_auth.go` (HMAC cookie, login rate limit, loopback gates), `admin_env.go` (config editor), `admin_handlers.go`, `admin_tokens*.go` (token management), `admin_maturity.go`, `admin_csrf_test.go` neighbors.
+- Limits: `maxRequestBody` 32MB, `maxStreamLine` 16MB scanner buffer.
+
+## Allowed dependencies
+
+`config`, `convert`, `dashboard`, `logring`, `pool`, `ratelimit`, `reasoningcache`, `registry`, `tokenestimate`, `updatecheck`, `upstream`, `phasetiming`, `session`, `runs`. Tests additionally use `testutil`. Server is the top of the internal stack and imports everything below it.
+
+## Forbidden dependencies
+
+`backend/cmd/*`, and cycles in the other direction — no internal package may import `server` (only `cmd` calls into it). A protocol-specific branch added to the shared engine is a debugging regression by definition (see below).
+
+## Critical invariants
+
+- Protocol split (engine.go header): `chatCore`/`chatAttempt`/SSE plumbing are protocol-neutral. Each surface owns its handler, wire translation, stream relay, and error envelope. An Anthropic bug must never require reading OpenAI relay code.
+- Retry-once recovery (`chatAttempt`): session/run-invalid → invalidate + fresh acquire ONCE; `session_superseded` → surface immediately, never re-admit in-request (burns a fresh daily slot into the superseding instance); `turn_spend_limited` → TERMINAL (429 + code, no Retry-After, no cooldown, no failover); auth/ban/rate-limit/ip-capped/country → cooldown + surface; retryable `UpstreamError` (e.g. deployment window) → 503, no blind retry; canceled ctx → surface, never re-acquire. Rate-limit failover (`RATE_LIMIT_FAILOVER`, default on) re-acquires once onto a healthy token — pooled only, never in bridge mode.
+- Tool Stripping Parity: the proxy-injected `end_turn` pseudo-tool MUST be stripped on EVERY relay (OpenAI, Anthropic, Responses) before emitting downstream.
+- Anthropic streaming: strictly sequential block lifecycles (`content_block_start` → deltas → `content_block_stop`); thinking blocks carry `"signature": ""`; `message_start` carries estimated input tokens; `event: ping` keepalive.
+- Error envelopes are protocol-aware: `/v1/messages` failures use the Anthropic envelope through the shared `chatCore → writeError → writeClientError` path (no parallel switch needed); OpenAI surfaces use the OpenAI shape (`refusal: null`, `logprobs: null`).
+- Request correlation: every upstream attempt shares the server's `req_id` (D1); retry chains log once with real `backoff_ms`.
+- Client disconnect cancels the upstream body read (context propagation); keepalives hold the downstream connection during long reasoning pauses.
+- Dashboard security: open mode (`ADMIN_TOKEN` unset or factory default) is loopback-only (403 remote) for config/logs/token routes; login rate limit 5 fails/min/IP; stateless HMAC cookie; CSRF double-submit on admin POSTs.
+
+## Tests that protect it
+
+Harness conformance (`conformance_pi/omp/codex/cline/kilocode/qwen/roo/aider/goose/continue/keepalive/opencode` + `harness_compatibility`), wire replays (`replay_openai/anthropic/responses/ops` incl. `TestReplayMessagesTurnSpendLimited`), engine (`chat_attempt_test`, `chat_core_snapshot_test`, `engine_helpers_test`), relays (`relay_binding/unclosed_xml/xml/protocol_fixes`, `anthropic_stream_blocks`, `stream_completeness`), surfaces (`server_chat/hybrid/bridge/api`, `agentic_mimo_e2e`, `omp_mimo_simulation`, `fallback_transparency`, `request_params`, `model_unavailable`, `health_quota`, `server_models`, `wire_metrics`, `ratelimit`, `env`, `configmeta`, `access_logs`, `gzip`, `lifecycle`), dashboard + admin (`dashboard_test/pages/edge`, `admin_auth/csrf/openmode/password/routes/restart/require_login/internal/tokens`).
+
+## Safe modification patterns
+
+- New protocol surface: own handler + stream + JSON files (mirror the openai/anthropic trio), plus a `conformance_<harness>_test.go` proving a real client works end to end — never wedge it into the engine.
+- New error class: `engine_helpers.go` errClass + status + BOTH envelopes + replay tests on both surfaces (OpenAI + Anthropic) asserting type/code/message/headers.
+- New admin route: register in the route table AND extend `admin_routes_test.go` (it pins the full table); sensitive routes go behind the loopback gate.
+- Frontend change: rebuild `backend/internal/dashboard/dist` from a clean tree (stash parallel `frontend/src/` WIP first) and commit it atomically with the source.
+- Parallel-work hazard: this package sees the heaviest concurrent editing (`admin_tokens*.go`, `dashboard_test.go`, `anthropic_errors.go` broke builds mid-work more than once). Never edit or commit files owned by a parallel session; if `go vet`/`go build` fails on files you didn't touch, re-run per-package before assuming your change broke it.

--- a/backend/internal/upstream/CONTRACT.md
+++ b/backend/internal/upstream/CONTRACT.md
@@ -1,0 +1,48 @@
+# Package Contract: `backend/internal/upstream`
+
+Task-local contract for agents modifying this package. Load before editing any file here.
+
+## Purpose
+
+The codebuff.com wire client for ONE token: session create/poll/release, run START/FINISH, chat-completions relay with the CLI request envelope required to pass the free-mode gate (`403 free_mode_cli_required`), typed error classification (mirrors proxy-freebuff's recovery matrix), TLS fingerprint stealth, CLI login flows, waiting-room ad chain, token health probes, and parsing of quota/freebucks/streak/standing payloads.
+
+## Public API (stable surface)
+
+- Construction: `New(token, cfg)`, `NewWithIndex(token, idx, cfg)`, `NewForAuth(cfg)`, `NewClientID()`; `SetTransport(rt)` (test seam, production never calls it); `SetMock` / `IsMock` (simulated upstream via `testmock`).
+- Wire calls: `ChatCompletions(ctx, ChatOptions, body) (io.ReadCloser, error)`, `CreateSession(ForModel)`, `GetSession(WithOpts)`, `ProbeAccount`, `GetStreak`, `EndSession`, `StartRun`, `FinishRun(ctx, runID, status, totalSteps, steps, errorMessage)`, `FireWaitingRoomChain`, `FetchAccountInfo`.
+- Login: `StartCLILogin`, `StartCLILoginIsolated`, `StartCLILoginWithFingerprint`, `PollCLILogin`, `ProtocolGitHubLogin` (+ `CLILoginCode/User/Status`).
+- Introspection: `TokenKey()` (sha256, safe for filenames/logs — the token itself never appears in persisted state), `BaseURL()`, `TransientRetries()`, `CapacityDeferredRetries()`, `FingerprintRotations()`, `RateLimitEvents()`, `PendingWaitingRoomChain()`, `ConsumeWaitingRoomChain()`.
+- Types: `SessionState` (+ `ModelQuota`, `FreebucksInfo` and its windows/wallet/ceiling/allowance/price-change blocks, `SessionReferral`, `SubscriptionInfo`, `AvailabilityWindow`, `SessionStanding`, `StreakInfo`, `RunStep`), `ChatOptions`, `TokenHealth` + states.
+- Errors: typed structs with sentinel matching — `ErrAuthRejected`, `ErrRateLimited` (`RateLimitError`), `ErrBanned` (`BanError`), `ErrCountryBlocked`, `ErrCredits`, `ErrIpCapped`, `ErrTurnSpendLimited` (`TurnSpendLimitError`), `SessionSupersededError`, `WaitingRoomError`, `WaitingRoomRequiredError`, `UpstreamError` (with `Retryable`), `CapacityDeferredError`, `LimitedIpError`, `SessionLimitError`.
+
+## Allowed dependencies
+
+`config`, `stealth`, `telemetry`, `logring` (wire metrics only), `login` (subpackage). Tests additionally use `testutil`, `testmock`.
+
+## Forbidden dependencies
+
+`pool`, `server`, `convert`, `dashboard`, `runs`, `session`, `registry`, `notify`, `ratelimit`, `tokenestimate`, `reasoningcache`, `modelcat` (non-test), `cmd/*`. Upstream is the leaf wire layer: session/run lifecycle and pooling orchestrate IT, never the reverse.
+
+## Critical invariants (anti-ban contract)
+
+- Session POST: bare-fetch shape — Authorization + optional `x-freebuff-model` ONLY (session.go). `GetSession` adds `x-freebuff-instance-id` (+ `x-freebuff-compact-session` when compact). Chat POST carries NO model/instance header (model rides only in body metadata).
+- `ProbeAccount`: GET with NO `x-freebuff-instance-id` — zero-cost, claims no session slot, burns no daily allowance.
+- Chat POST: pinned `ai-sdk` User-Agent, Bearer-only (never `x-codebuff-api-key`). Envelope: `codebuff_metadata`, `provider.data_collection=deny`, forced `stream:true`, JSON-quoted `"cb_easp"` stop sentinel. Other calls default to the Bun UA; `/api/auth/cli/*` uses the login UA.
+- `ACTING_USER_ID` is only safe when it equals the token's own account id; any other value impersonates a foreign user.
+- `REQUEST_TIMEOUT` bounds only the wait for response headers (TTFB) via the transport's `ResponseHeaderTimeout` — the streamed body runs until upstream EOF or caller cancel (request-context deadlines cut healthy long streams; fixed 2026-09-06).
+- Transient retries: ONLY transport-level failures (dial/TLS/reset/EOF) retry, bounded by `TRANSIENT_RETRIES`, with fingerprint rotation + 200-600ms backoff. Classified errors (429/403/401, session/run invalids, waiting room, status >= 400) and non-replayable bodies NEVER retry.
+- `turn_spend_limit` is TERMINAL: classify returns it before the retryable branch — no cooldown, no failover, no Retry-After downstream.
+- Honest `FINISH` on run termination (anti-ban); one step recorded per completed chat call; per-run step counters and trace ids stay per-run on retry onto a fresh run.
+- Dump/debug paths must never log the token (`SetTransport` is a test seam only).
+
+## Tests that protect it
+
+`client_chat_test.go` (stream survival past REQUEST_TIMEOUT, stalled-header abort, envelope wire contract, client-cancel abort), `client_retry_test.go` (flaky transport, backoff, deadline precedence), `client_session_test.go` (session lifecycle, control-timeout precedence), `tokenhealth_test.go` (health states incl. turn-spend soft), `probe_account_parity_test.go`, `wire_time_unify_test.go`, `effort_mirror_test.go`, `freebucks_parse_test.go`, `notices_test.go`, `inject_envelope_test.go`, `client_stealth_test.go` (CLI UA pin), `egress_stealth_test.go`, `egress_device_block_test.go`, `signal_guard_test.go`, `ratelimit_cooldown_test.go`, `availability_test.go`, `session_startrun_cancel_test.go`, `login/fingerprint_test.go`, `wire_metrics_test.go`, `testdata/` (email-domain lists).
+
+## Safe modification patterns
+
+- New error class: typed struct + sentinel + classify() early-return + pool fire-path case + server `errors.go` branch — all four, or the error falls through to a generic 502.
+- Wire shape changes: sync `reference/freebuff` first (`scripts/sync-upstream.sh`), cite the upstream path + SHA in the comment, pin with a parse test (see `freebucks_parse_test.go`, `probe_account_parity_test.go`).
+- Header/UA/envelope changes are ban-risk: match the CLI exactly, never invent headers, never route egress through a proxy (the upstream hard-blocks proxy/VPN/Tor).
+- New wire call: add a mock path in `testmock` first, then the client method, then the caller — never develop against the live wire.
+- Timeouts: TTFB belongs on the transport; body lifetime belongs to the caller context; control calls keep their own tight ctx deadlines.


### PR DESCRIPTION
## Contracts

Four task-local package contracts (purpose, public API, allowed/forbidden dependencies, critical invariants, protecting tests, safe modification patterns) so an agent working one package no longer needs the whole-repo mental model. AGENTS.md untouched by design.

- `pool/CONTRACT.md`: failover bucket precedence, lease contract, swap-safety, RPM/RPD semantics, bridgeMu discipline, maturity posture.
- `convert/CONTRACT.md`: purity rule + import boundary test, end_turn parity, schema caps, plural-dialect extraction.
- `upstream/CONTRACT.md`: anti-ban header contract, TTFB-only timeout, transient-retry rules, turn_spend terminal.
- `server/CONTRACT.md`: protocol split, retry-once matrix, envelope rules, dashboard security gates, parallel-work hazard note.

All claims grounded in current code (imports grepped, invariants cite files).

## Test hygiene

Releases the winning lease in `TestAcquireRPMAdmitBurstIsAtomic` / `TestBridgeRPMAdmitBurstIsAtomic` instead of stranding the run.

## Verification

- Hermetic backend suite green; `go vet` clean; `gofmt` clean (my files).
- Note: `backend/internal/archtest/` (parallel session, untracked) flags its own formatting — not mine, not in this PR.