### PR TITLE
docs: restore 5 lines clobbered by range-replace edits in PR 358

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ Official reference specifications and SDKs reside in `reference/` (gitignored): 
 - **Hermetic Test Suite**: Always unset `AUTH_TOKENS` and `ADMIN_TOKEN` when running tests to avoid polluting bridge-mode test environments:
   ```bash
   env -u AUTH_TOKENS -u ADMIN_TOKEN go test ./backend/...
+  ```
 - **Anti-Ban Contract** (canonical: INV-UP-001..005):
   - Upstream session POST sends `x-freebuff-model` and `x-freebuff-instance-id`; chat POST carries **NO** model header.
   - Pinned `ai-sdk` User-Agent on chat requests; honest `FINISH` on run termination.

--- a/backend/internal/ratelimit/CONTRACT.md
+++ b/backend/internal/ratelimit/CONTRACT.md
@@ -7,6 +7,7 @@ Task-local contract for agents modifying this package. Load before editing any f
 Per-IP token-bucket rate limiter for the client-facing surface
 (`RATE_LIMIT_PER_IP`, `RATE_LIMIT_BURST`; `0` disables; burst defaults to
 2x the rate). Protects the gateway from a single abusive client; it is NOT
+upstream quota enforcement (that lives in pool cooldowns/ledgers).
 ## Public API (stable surface)
 
 - `Limiter`, `New(rate, burst, maxEntries)`, `Allow(key) (allowed,

--- a/backend/internal/telemetry/CONTRACT.md
+++ b/backend/internal/telemetry/CONTRACT.md
@@ -9,6 +9,7 @@ per-token messages/requests/runs/cooldown, per-model quota gauges
 `freebuff_proxy_quota_recent`/`_limit`), structured logging helpers, header
 and secret redaction for logs, and Prometheus label escaping. Consumers:
 server (`/metrics`), pool (quota gauges), upstream (classification lines),
+dashboard (log stream via `logring` on top).
 ## Public API (stable surface)
 
 - Logging: `NewLogger(verbose, logFile)`, `New(level, logFile, format)`,

--- a/docs/architecture/INVARIANTS.md
+++ b/docs/architecture/INVARIANTS.md
@@ -2,6 +2,7 @@
 
 Behavioral contracts that must never change accidentally. IDs group by area.
 Every invariant has: why it exists, current implementation, tests that protect
+it, what would break it. Treat this file as a contract, not prose.
 Precedence: this register is canonical. Package `CONTRACT.md` files elaborate
 the same invariants task-locally and must not contradict them; the root
 `AGENTS.md` entrypoint states them in one line each with pointers here.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -37,6 +37,7 @@ Related tests:
 | [ADR-0009](ADR-0009-reasoning-effort-cache.md) | Reasoning effort mapping and multi-turn cache | Accepted |
 | [ADR-0010](ADR-0010-release-strategy.md) | Release strategy and versioning | Accepted |
 | [ADR-0011](ADR-0011-model-catalog.md) | Model catalog, registry, and fallback resolution | Accepted |
+| [ADR-0012](ADR-0012-anti-ban-contract.md) | Anti-ban contract with upstream | Accepted |
 | [ADR-0013](ADR-0013-request-timeout-ttfb.md) | REQUEST_TIMEOUT guards TTFB only | Accepted |
 | [ADR-0014](ADR-0014-rpm-admission-atomic.md) | RPM admission counted atomically at lease grant | Accepted |
 | [ADR-0015](ADR-0015-tool-calls-plural-dialect.md) | `<tool_calls>` plural dialect extracts like singular | Accepted |


### PR DESCRIPTION
Follow-up to #358: five lines lost to over-wide PUT ranges, restored verbatim via pure inserts (this diff has 5 insertions, 0 deletions — verified with `git diff --cached | grep '^\[^-\]'`).