### PR TITLE
WebUI-first management with minimal headless CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ For a guided walkthrough, read [Getting Started](docs/getting-started.md) (5 min
 - **CLI Impersonation**: egress presents as the official FreeBuff CLI — `Freebuff-CLI/1.0.0` ads-API User-Agent with a **Chrome/124 body UA**, `ai-sdk/openai-compatible/1.0.0/codebuff` chat UA, Bun/1.3.14 on session/auth endpoints, and your real device timezone/locale.
 - **Subagent-Ready Concurrency**: Single-flight session refresh prevents race conditions during high-volume tool-calling loops.
 - **Safe Mode**: On by default: anti-ban presets (TLS stealth, header sanitization, jitter, idle rotation).
-- **Operational Tooling**: `-doctor` diagnostics (config, port, DNS/TLS, registry; zero-cost per-token validity probes run by default), `-test-token` (zero-cost probe on the first token, prints live quota, exit 0/1 for installers and scripts), `-setup` interactive client configuration, and a SHA-256-verified `-update` self-updater.
+- **Management (dashboard first)**: daily work happens in `/admin` (tokens, config, logs, metrics, quota, setup copy blocks, update notice). The same checks stay scriptable headless: `-doctor` diagnostics (config, port, DNS/TLS, registry; zero-cost per-token validity probes run by default), `-test-token` and `-validate-tokens` (zero-cost probes with exit codes for installers and scripts), `-setup` interactive client configuration, and a SHA-256-verified `-update` self-updater. `-help` groups every flag with its dashboard twin.
 - **Quota Transparency**: Live per-model quota (from the upstream `rateLimitsByModel` admission payload) is surfaced in `GET /healthz` (per-token `quota` map) and `GET /metrics` (`freebuff_proxy_quota_recent` / `freebuff_proxy_quota_limit` gauges).
 
 ## How It Works
@@ -253,21 +253,24 @@ curl http://127.0.0.1:3457/healthz
 
 ## Command-Line Interface
 
-| Flag | Description |
-|---|---|
-| *(none)* | Run the proxy |
-| `-config <path>` | Load an optional JSON config file (keys mirror env names) |
-| `-v` | Verbose (debug) logging |
-| `-version` | Print version and exit |
-| `-doctor` | Run configuration and environment diagnostics: config, port, DNS/TLS reachability, model registry, plus a zero-cost validity probe per token |
-| `-test-token` | Probe the first configured token with a zero-cost upstream GET probe (no session claimed); prints `token OK` and live quota, exits `0`, or exits `1` (for installers/scripts) |
-| `-update` | Self-update from the latest GitHub release (SHA-256 verified against `checksums.txt`) |
-| `-setup` | Interactive client setup (detects installed clients) |
-| `-yes` | Auto-confirm `-setup` prompts |
-| `-refresh-token N` | Re-authenticate token #N in `.env` via the headless GitHub login flow and exit. Interactive: prints a login URL and polls. With `-yes` and `GITHUB_USER` / `GITHUB_PASSWORD` / `GITHUB_TOTP` set: protocol login |
-| `-install-service` | Register the current binary as a background service and start it: Task Scheduler on Windows (per-user, no admin), systemd `--user` unit on Linux, launchd LaunchAgent on macOS. Resolves `.env` from your platform config directory (a `./.env` in the working directory still wins), and auto-starts on logon/boot |
-| `-uninstall-service` | Stop and unregister the background service (idempotent) |
-| `-service-status` | Check whether the service is registered and running; exits `0` when registered, `1` when not (scriptable) |
+Daily management lives in the dashboard (`/admin`; see [Admin Dashboard](#admin-dashboard) and the [Dashboard Guide](docs/dashboard.md)). The CLI stays fully working as the headless and bootstrap path: no flag was removed or renamed, and every exit code still scripts the same way. `-help` prints the same Serve / Advanced grouping shown here.
+
+| Flag | Dashboard twin | Description |
+|---|---|---|
+| *(none)* | Overview, Tokens, Settings, Logs, Setup | Run the proxy; manage it from `/admin` |
+| `-config <path>` | Settings page, raw `.env` editor, `POST /admin/reload` | Load an optional JSON config file (keys mirror env names) |
+| `-v` | Logs viewer, Settings log level | Verbose (debug) logging |
+| `-version` | Overview status line | Print version and exit |
+| `-doctor` | `POST /admin/diag` (needs a running server) | Run configuration and environment diagnostics: config, port, DNS/TLS reachability, model registry, plus a zero-cost validity probe per token |
+| `-test-token` | Tokens page per-token Test, `POST /admin/tokens/test-all` | Probe the first configured token with a zero-cost upstream GET probe (no session claimed); prints `token OK` and live quota, exits `0`, or exits `1` (for installers/scripts) |
+| `-validate-tokens[=tok1,tok2]` | `POST /admin/tokens/test-all` (needs a running server) | Validate every configured token with non-mutating upstream probes, print a health report, and exit `0` (healthy) / `1` (banned, invalid, or disposable mailbox) / `2` (config error); a comma-separated list overrides `AUTH_TOKENS` |
+| `-refresh-token N` | Tokens page login wizard (adds a pool token; it does not re-auth slot N in place) | Re-authenticate token #N in `.env` via the headless login flow and exit. Interactive: prints a login URL and polls. With `-yes` and `GITHUB_USER` / `GITHUB_PASSWORD` / `GITHUB_TOTP` set: protocol login |
+| `-setup` | Setup page copy blocks (no file writes) | Interactive client setup (detects installed clients) |
+| `-yes` | None (headless modifier for `-setup` and `-refresh-token`) | Auto-confirm prompts |
+| `-update` | Overview update badge (release link plus restart; the dashboard never swaps the binary) | Self-update from the latest GitHub release (SHA-256 verified against `checksums.txt`) |
+| `-install-service` | None (a browser tab cannot register OS services) | Register the current binary as a background service and start it: Task Scheduler on Windows (per-user, no admin), systemd `--user` unit on Linux, launchd LaunchAgent on macOS. Resolves `.env` from your platform config directory (a `./.env` in the working directory still wins), and auto-starts on logon/boot |
+| `-uninstall-service` | None (a browser tab cannot remove OS services) | Stop and unregister the background service (idempotent) |
+| `-service-status` | None (headless check for scripts) | Check whether the service is registered and running; exits `0` when registered, `1` when not (scriptable) |
 
 ---
 

--- a/backend/cmd/freebuff-proxy/main.go
+++ b/backend/cmd/freebuff-proxy/main.go
@@ -45,21 +45,72 @@ func (f *tokenListFlag) Set(s string) error {
 // mode flags, while Set still accepts the comma-separated override.
 func (f *tokenListFlag) IsBoolFlag() bool { return true }
 
+// printGroupedHelp renders --help dashboard-first: serve flags up top, then
+// the headless and bootstrap flags as advanced. Flag names, defaults, and
+// exit codes are unchanged; only the grouping and the dashboard pointers are
+// new (issue #359, docs plus help strings only).
+func printGroupedHelp() {
+	fmt.Fprintln(os.Stderr, "Usage: freebuff-proxy [flags]")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Daily management lives in the dashboard (/admin). The flags below stay fully")
+	fmt.Fprintln(os.Stderr, "working as the headless and bootstrap path; nothing was removed or renamed.")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Serve (default, no flag runs the proxy):")
+	printHelpFlag("config")
+	printHelpFlag("v")
+	printHelpFlag("version")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Advanced (headless-only; dashboard twin noted per flag):")
+	printHelpFlag("doctor")
+	printHelpFlag("test-token")
+	printHelpFlag("validate-tokens")
+	printHelpFlag("refresh-token")
+	printHelpFlag("setup")
+	printHelpFlag("yes")
+	printHelpFlag("update")
+	printHelpFlag("install-service")
+	printHelpFlag("uninstall-service")
+	printHelpFlag("service-status")
+}
+
+// printHelpFlag prints one registered flag in the same shape as the standard
+// flag package (placeholder plus usage line). The usage strings carry the
+// dashboard twin, so the grouping here only orders them.
+func printHelpFlag(name string) {
+	f := flag.Lookup(name)
+	if f == nil {
+		return
+	}
+	placeholder, usage := flag.UnquoteUsage(f)
+	if bf, ok := f.Value.(interface{ IsBoolFlag() bool }); ok && bf.IsBoolFlag() {
+		placeholder = ""
+	}
+	if f.Name == "refresh-token" {
+		usage += fmt.Sprintf(" (default %s)", f.DefValue)
+	}
+	if placeholder != "" {
+		fmt.Fprintf(os.Stderr, "  -%s %s\n    \t%s\n", f.Name, placeholder, usage)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "  -%s\n    \t%s\n", f.Name, usage)
+}
+
 func main() {
-	configPath := flag.String("config", "", "path to an optional JSON config file (keys mirror env names)")
-	verbose := flag.Bool("v", false, "verbose (debug) logging")
-	showVersion := flag.Bool("version", false, "print version and exit")
-	showDoctor := flag.Bool("doctor", false, "run environment and configuration diagnostics")
-	showUpdate := flag.Bool("update", false, "check for and download the latest release update")
-	showSetup := flag.Bool("setup", false, "run interactive client configuration helper")
-	testToken := flag.Bool("test-token", false, "probe the first configured token with a zero-cost GET probe (no session consumed) and exit 0/1")
+	configPath := flag.String("config", "", "path to an optional JSON config file (keys mirror env names). Dashboard: Settings page plus raw .env editor; apply with POST /admin/reload")
+	verbose := flag.Bool("v", false, "verbose (debug) logging. Dashboard: Logs viewer plus the Settings log level")
+	showVersion := flag.Bool("version", false, "print version and exit. Dashboard: Overview status line shows the same version")
+	showDoctor := flag.Bool("doctor", false, "run environment and configuration diagnostics. Dashboard: POST /admin/diag covers the same checks on a running server")
+	showUpdate := flag.Bool("update", false, "check for and download the latest release update. Dashboard: Overview update badge shows the release link plus restart; the dashboard never swaps the binary")
+	showSetup := flag.Bool("setup", false, "run interactive client configuration helper (writes client files). Dashboard: Setup page shows copy blocks only, no file writes")
+	testToken := flag.Bool("test-token", false, "probe the first configured token with a zero-cost GET probe (no session consumed) and exit 0/1. Dashboard: Tokens page per-token Test plus POST /admin/tokens/test-all on a running server")
 	validateTokens := &tokenListFlag{}
-	flag.Var(validateTokens, "validate-tokens", "validate every configured token with non-mutating upstream probes, print a health report, and exit 0 (healthy) / 1 (banned, invalid, or disposable mailbox) / 2 (config error); a comma-separated list overrides AUTH_TOKENS (-validate-tokens=tok1,tok2)")
-	installService := flag.Bool("install-service", false, "register the current binary as a background service and start it (Task Scheduler / systemd --user / launchd)")
-	uninstallService := flag.Bool("uninstall-service", false, "stop and unregister the background service")
-	serviceStatus := flag.Bool("service-status", false, "check whether the background service is registered and running (exit 0 registered, 1 not)")
-	autoYes := flag.Bool("yes", false, "auto-confirm prompts during setup")
-	refreshToken := flag.Int("refresh-token", -1, "re-authenticate token #N in .env via the headless GitHub login flow and exit (interactive: start → print login URL → poll; with -yes and GITHUB_USER/GITHUB_PASSWORD/GITHUB_TOTP set: protocol login)")
+	flag.Var(validateTokens, "validate-tokens", "validate every configured token with non-mutating upstream probes, print a health report, and exit 0 (healthy) / 1 (banned, invalid, or disposable mailbox) / 2 (config error); a comma-separated list overrides AUTH_TOKENS (-validate-tokens=tok1,tok2). Dashboard: POST /admin/tokens/test-all on a running server")
+	installService := flag.Bool("install-service", false, "register the current binary as a background service and start it (Task Scheduler / systemd --user / launchd). No dashboard twin: a browser tab cannot register OS services")
+	uninstallService := flag.Bool("uninstall-service", false, "stop and unregister the background service. No dashboard twin: a browser tab cannot remove OS services")
+	serviceStatus := flag.Bool("service-status", false, "check whether the background service is registered and running (exit 0 registered, 1 not). No dashboard twin: headless-only check for scripts")
+	autoYes := flag.Bool("yes", false, "auto-confirm prompts during setup. Headless-only modifier for -setup and -refresh-token")
+	refreshToken := flag.Int("refresh-token", -1, "re-authenticate token #N in .env via the headless login flow and exit (interactive: start, print login URL, poll; with -yes and GITHUB_USER/GITHUB_PASSWORD/GITHUB_TOTP set: protocol login). Dashboard: Tokens page login wizard adds a pool token; it does not re-auth slot N in place")
+	flag.Usage = printGroupedHelp
 	flag.Parse()
 
 	if w := cli.ModeFlagsExclusiveWarning(*showDoctor, *showUpdate, *showSetup, *testToken, *installService, *uninstallService, *serviceStatus, validateTokens.set); w != "" {

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -4,6 +4,14 @@ The embedded admin web UI gives you live relay state, per-token quotas, an in-br
 
 Built with **Svelte 5 + Tailwind CSS v4** and self-hosted **IBM Plex Sans & IBM Plex Mono** typography, it follows an **"instrument panel"** design system: a dense, dark-mode-only operational console with hairline borders, tabular-numeric metrics, and live LED status indicators. It is embedded directly into the Go binary at build time (`//go:embed`) with zero runtime Node.js or external CDN dependencies.
 
+## Management policy (WebUI-first, issue #359)
+
+The dashboard (`/admin`) is the default daily path. The CLI stays fully working as the headless and bootstrap path.
+
+- Frozen flag set: no flag is removed or renamed, and every exit code keeps scripting the same way.
+- Dashboard-canonical: token add/remove/swap/test/lock, config edit plus reload, restart, logs, metrics, quota, maturity, setup copy blocks, and the update notice live in `/admin`.
+- Hide, never delete: pre-serve checks (`-doctor`, `-test-token`, `-validate-tokens`), OS service registration (`-install-service`, `-uninstall-service`, `-service-status`), slot re-auth (`-refresh-token`), client-file setup (`-setup`), and the binary swap (`-update`) stay on the CLI because a browser tab cannot do them. `-help` groups them as advanced with the dashboard twin noted per flag.
+
 ---
 
 ## Access

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,7 +90,7 @@ Stay on limited tier but maximize throughput. Set `AUTH_TOKENS=token1,token2,tok
 > two or more tokens are configured. For full-trust isolation, route distinct
 > accounts through distinct residential exits (Option A per machine).
 
-See the [Getting Started — Access Tiers](#access-tiers--workarounds) section for per-model quota pools and effort ladders.
+See the [Getting Started — Access Tiers](#access-tiers-models--upstream-quotas) section for per-model quota pools and effort ladders.
 
 **Do NOT use any of these — they trigger the restricted cohort or an outright ban:**
 - Commercial VPN (NordVPN, ExpressVPN, Surfshark, etc.)
@@ -160,7 +160,7 @@ VERSION=$(git describe --tags 2>/dev/null || echo dev) docker compose up -d --bu
 
 ## Step 2: Verify It Works
 
-Run the diagnostic tool or curl:
+Dashboard first: on a running proxy, open `http://127.0.0.1:3457/admin` — the Overview smoke test plus **Tokens → Test All** (`POST /admin/tokens/test-all`) run the same zero-cost per-token validity probe as the CLI, and the Overview diagnostics card (`POST /admin/diag`) covers the same checks as `-doctor`. CLI second, for headless or pre-serve checks:
 
 ```bash
 # Diagnostic doctor check: config, port, DNS/TLS, registry, plus a
@@ -194,9 +194,11 @@ curl http://localhost:3457/v1/models
 Point your AI tool to:
 - **Base URL:** `http://localhost:3457/v1`
 - **API Key:** `not-needed` (or your token in bridge mode)
-- **Model:** `deepseek/deepseek-v4-flash` (full-tier only — limited-tier IPs are coerced to `mimo/mimo-v2.5`; see [Access Tiers](#access-tiers--workarounds))
+- **Model:** `deepseek/deepseek-v4-flash` (full-tier only — limited-tier IPs are coerced to `mimo/mimo-v2.5`; see [Access Tiers](#access-tiers-models--upstream-quotas))
 
-Fastest path: run `./freebuff-proxy -setup` to write the client config automatically.
+Dashboard first: the **Setup** page (`http://127.0.0.1:3457/admin/setup`) shows per-model copy blocks for every harness — copy, no file writes.
+
+CLI second: run `./freebuff-proxy -setup` to write the client config files automatically.
 
 See the [Client Integration Guide](client-integration.md) for copy-paste config for OpenCode, pi, 9router, LiteLLM, and more.
 
@@ -220,14 +222,16 @@ git checkout <previous-tag>
 docker compose up -d --build
 ```
 
+Dashboard twin: the Overview page shows an update badge with the release link when a newer release exists — the dashboard never swaps the binary, so perform the swap with the commands above, then restart the proxy.
+
 ## Troubleshooting
 
-Run `./freebuff-proxy -doctor` to diagnose problems automatically.
+Dashboard first: the Overview diagnostics card (`POST /admin/diag`) runs the same checks on a live server. CLI second: run `./freebuff-proxy -doctor` to diagnose problems automatically (also works pre-serve).
 
 | Error / Symptom | Cause & Fix |
 |---|---|
 | `403` + `free_mode_cli_required` | The request was missing the CLI system prompt marker or envelope. The proxy injects this automatically. Update to the latest version. |
-| `502` + `upstream_auth_rejected` | Token in `.env` is expired or invalid. Catch it before the first chat: `./freebuff-proxy -test-token` (or `-doctor`) probes the token with a zero-cost GET request and fails with a clear message. Then re-run `freebuff` to log in and update `AUTH_TOKENS`, or swap the token live on the dashboard Tokens page (no restart). |
+| `502` + `upstream_auth_rejected` | Token in `.env` is expired or invalid. Catch it before the first chat: dashboard first — **Tokens → Test All** (`POST /admin/tokens/test-all`); CLI second — `./freebuff-proxy -test-token` (or `-doctor`) probes the token with a zero-cost GET request and fails with a clear message. Then re-run `freebuff` to log in and update `AUTH_TOKENS`, or swap the token live on the dashboard Tokens page (no restart). |
 | Connection refused | Proxy is not running, or in Docker without `LISTEN_ADDR=:3457`. |
 | `403 account_banned` | Account suspended upstream. Token is dead; use a new established account. |
 | `502` + `free_mode_legacy_luna_agent` | The conversation uses a retired Luna agent. Start a new conversation. The proxy automatically retries with a fresh session. |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,7 +18,7 @@ Two ground rules before you start.
 
 ## 0. The binary, the version, the config
 
-Start by confirming you have a real build and it can see its config.
+Dashboard first (running proxy): the Overview status line shows the same version, and the diagnostics card (`POST /admin/diag`) covers the same checks as `-doctor`. CLI second (also works pre-serve):
 
 ```
 ./freebuff-proxy -version
@@ -170,9 +170,7 @@ running an older binary; these routes landed in the v0.9.8 cycle.
 
 ### The zero-cost probe
 
-`-test-token` verifies the first configured token without consuming a
-session slot. It is the fastest health signal for "is my account even
-alive".
+Dashboard first: **Tokens → Test All** (`POST /admin/tokens/test-all`) on the running proxy probes every token the same zero-cost way. CLI second: `-test-token` verifies the first configured token without consuming a session slot — the fastest headless signal for "is my account even alive".
 
 ```
 ./freebuff-proxy -test-token
@@ -197,6 +195,8 @@ the old session-handshake probes cost a slot per run, so they were gated
 behind a flag; the GET probe removed that cost entirely. The only case
 that skips probing is bridge mode, where the proxy holds no tokens to
 check.
+
+Dashboard first: the Overview diagnostics card (`POST /admin/diag`) runs the same checks on a live server. CLI second (also works pre-serve):
 
 ```
 ./freebuff-proxy -doctor
@@ -254,6 +254,8 @@ Task Scheduler at logon with limited privileges; you see the task under
 `schtasks /query /tn "freebuff-proxy"` if you want to inspect it.
 `-uninstall-service` reverses it.
 
+No dashboard twin: a browser tab cannot register OS services — install, status, and uninstall stay on the CLI.
+
 Linux:
 
 ```
@@ -266,6 +268,8 @@ Status comes from `systemctl --user is-active freebuff-proxy`, logs from
 `journalctl --user -u freebuff-proxy -n 50 -e`. The unit sets its working
 directory to the binary's location, so `.env` must live next to the
 binary, not in your shell's home.
+
+No dashboard twin here either: a browser tab cannot register OS services — the systemd unit stays a CLI path.
 
 ## 7. The restart and the upgrade
 
@@ -291,11 +295,13 @@ Tokens page remains the live path for add/remove and mode switch — those
 take effect immediately and persist to `AUTH_TOKENS` in `.env` (surviving
 a restart), no restart needed.
 
-Self-update is `./freebuff-proxy -update`, which checks GitHub and
+Dashboard first: the Overview update badge links the release when a newer one exists — the dashboard never swaps the binary. CLI second: self-update with `./freebuff-proxy -update`, which checks GitHub and
 replaces the binary with the latest release. It skips the swap if the
 checksum does not match. On Windows the swap defers until the current
 process exits, so do not be surprised if the command exits before the
 file changes.
+
+Apply the swap above, then restart the proxy to run the new binary.
 
 ## 8. Reading failures: the error taxonomy
 
@@ -323,7 +329,7 @@ sit still on quota days.
 Run through this in order when you are unsure. Each line is one command
 or one glance.
 
-1. `./freebuff-proxy -doctor` → no `[FAIL]` (token probe lines all `[ok]`).
+1. Overview diagnostics card (`POST /admin/diag`) shows no failures — or CLI second: `./freebuff-proxy -doctor` → no `[FAIL]` (token probe lines all `[ok]`).
 2. `curl http://127.0.0.1:3457/healthz` → JSON, `SessionStatus: active`,
    `UsagePct` under 100.
 3. `curl /v1/models` → non-empty model list.
@@ -332,7 +338,7 @@ or one glance.
 6. Dashboard Tokens page → `Account #1, #2, …` rows listed, at-risk cards
    render when present, no ERROR spam in logs.
 7. Logs show startup banner with `auth_tokens=N` matching your `.env`.
-8. `-test-token` exits 0 with `token OK`. (A quota 429 exits 1 — that is
+8. **Tokens → Test All** (`POST /admin/tokens/test-all`) all green — or CLI second: `-test-token` exits 0 with `token OK`. (A quota 429 exits 1 — that is
    a quota day, not a proxy fault; the checklist then reads as "healthy
    but quota-spent".)
 

--- a/docs/user-lifecycle.md
+++ b/docs/user-lifecycle.md
@@ -89,9 +89,7 @@ keeps it alive, and logs to `/tmp/freebuff-proxy.{log,err}`.
 
 ## 2. First run
 
-`-doctor` is the sanity check (config, port, DNS/TLS, registry, per-token
-zero-cost probes). `-setup` is the interactive client configurator (Continue /
-opencode / aider) — it does **not** write the proxy `.env`.
+Dashboard first (running proxy): the Overview diagnostics card (`POST /admin/diag`) is the sanity check, and the **Setup** page shows copy blocks for every client. CLI second: `-doctor` is the headless sanity check (config, port, DNS/TLS, registry, per-token zero-cost probes), and `-setup` is the interactive client configurator (Continue / opencode / aider) — it does **not** write the proxy `.env`.
 
 ```bash
 ./freebuff-proxy -doctor
@@ -116,6 +114,8 @@ Summary: 10 passed, 0 warnings, 0 failed
 A missing token or unreachable upstream is reported honestly: warnings do not
 change the exit code (still `0`); a config error or failed reachability check
 makes it exit `1`.
+
+Dashboard first: the **Setup** page (`http://127.0.0.1:3457/admin/setup`) shows per-model copy blocks — copy, no file writes. CLI second (writes client files):
 
 ```bash
 ./freebuff-proxy -setup
@@ -145,9 +145,13 @@ Start the proxy:
 
 ## 3. Add tokens
 
-Add a token to `.env` (`AUTH_TOKENS` is a comma-separated list) by heads-up
-generation, or in the dashboard. Edit the `.env` directly and reload, or use
-the dashboard Tokens page (in-browser OAuth login wizard, then **Add Token**).
+Dashboard first: open `http://127.0.0.1:3457/admin`, log in with `ADMIN_TOKEN`, then use the Tokens page (in-browser OAuth login wizard, then **Add Token**). CLI second: generate heads-up and append to `.env` (`AUTH_TOKENS` is a comma-separated list), then reload.
+
+**Dashboard** — open `http://127.0.0.1:3457/admin`, log in with `ADMIN_TOKEN`,
+then **Tokens → Add Token to Pool**. The wizard runs the same headless OAuth
+flow and persists the token to `.env`. The `/admin/tokens/*` routes are
+session-cookie dashboard endpoints (they return an HTMX fragment, not a JSON
+API), so a human uses the dashboard; a script uses `gen-token.* --append`.
 
 **CLI generate (headless OAuth)**
 
@@ -160,12 +164,6 @@ the dashboard Tokens page (in-browser OAuth login wizard, then **Add Token**).
 Browser login...
 Token cb_... added to ~/.config/freebuff-proxy/.env
 ```
-
-**Dashboard** — open `http://127.0.0.1:3457/admin`, log in with `ADMIN_TOKEN`,
-then **Tokens → Add Token to Pool**. The wizard runs the same headless OAuth
-flow and persists the token to `.env`. The `/admin/tokens/*` routes are
-session-cookie dashboard endpoints (they return an HTMX fragment, not a JSON
-API), so a human uses the dashboard; a script uses `gen-token.* --append`.
 
 `AUTH_TOKENS=` empty means bridge mode (clients bring their own token).
 
@@ -208,8 +206,7 @@ data: {"type":"message_stop"}
 
 ## 5. Monitor
 
-Health is a single JSON read: `GET /healthz` returns `status`, `mode`, model
-count, per-token snapshot (incl. per-model `quota`), and `bridge_tokens`.
+Dashboard first: the admin dashboard at `http://127.0.0.1:3457/admin` gives the live overview (token risk cards), Traces (per-request routing outcome), Logs, Metrics, and Prometheus `GET /metrics`. CLI second: health is a single JSON read — `GET /healthz` returns `status`, `mode`, model count, per-token snapshot (incl. per-model `quota`), and `bridge_tokens`.
 
 ```bash
 curl -s http://127.0.0.1:3457/healthz
@@ -221,11 +218,8 @@ curl -s http://127.0.0.1:3457/healthz
  "bridge_tokens":0,"bridge_entries":[]}
 ```
 
-The admin dashboard at `http://127.0.0.1:3457/admin` gives the live overview
-(token risk cards), Traces (per-request routing outcome), Logs, Metrics, and
-Prometheus `GET /metrics` for `freebuff_proxy_quota_recent`/`_limit`. If the
-port is bound non-loopback and `ADMIN_TOKEN` is unset, sensitive dashboard
-routes require a loopback client.
+The quota gauges live at `GET /metrics` as `freebuff_proxy_quota_recent`/`_limit`.
+If the port is bound non-loopback and `ADMIN_TOKEN` is unset, sensitive dashboard routes require a loopback client.
 
 ## 6. Edit config
 
@@ -254,8 +248,7 @@ page (**Remove** pops the last token; the pool is construction-fixed, so an
 `.env` edit adds/removes on the next reload or restart). The `/admin/tokens/*`
 routes are session-cookie dashboard endpoints (HTMX fragment, not a JSON API).
 
-`-refresh-token N` re-authenticates a stale token in `.env` via the headless
-GitHub login flow:
+Dashboard first: the Tokens page OAuth login wizard mints a fresh token in the browser and persists it to `.env`. CLI second: `-refresh-token N` re-authenticates a stale token in `.env` via the headless GitHub login flow:
 
 ```bash
 ./freebuff-proxy -refresh-token 0
@@ -265,8 +258,7 @@ GitHub login flow:
 
 Each model's live session quota surfaces on `/healthz` (per-token `quota`
 map) and `/metrics` (`freebuff_proxy_quota_recent` / `freebuff_proxy_quota_limit`).
-`-test-token` gives a one-shot, zero-cost read that prints the quota and exits
-`0` (healthy) or `1` (bad).
+Dashboard first: the Quota Tracker page plus **Tokens → Test All** (`POST /admin/tokens/test-all`) give the same live read in the browser. CLI second: `-test-token` gives a one-shot, zero-cost read that prints the quota and exits `0` (healthy) or `1` (bad).
 
 ```bash
 ./freebuff-proxy -test-token
@@ -283,8 +275,7 @@ account out.
 
 ## 9. Update
 
-**Self-updater** (SHA-256 verified against the release `checksums.txt`; a
-release without the checksums manifest is refused).
+Dashboard first: the Overview update badge links the release when a newer one exists — the dashboard never swaps the binary. CLI second: **self-updater** (SHA-256 verified against the release `checksums.txt`; a release without the checksums manifest is refused).
 
 ```bash
 ./freebuff-proxy -update

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -404,6 +404,7 @@ if (Test-Path -LiteralPath $exe) {
 }
 
 Write-Host "Next steps:" -ForegroundColor Cyan
+Write-Host "  Open the dashboard first: http://localhost:3457/admin - finish tokens plus config there"
 Write-Host "  1. 1-Click Client Setup:   cd `"$Dir`"; .\freebuff-proxy.exe -setup"
 Write-Host "  2. Start the proxy server: cd `"$Dir`"; .\start-proxy.cmd"
 Write-Host "     (or run freebuff-proxy.exe directly; the runtime finds its config in %APPDATA%\freebuff-proxy)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -808,6 +808,7 @@ if [ -n "${BIN:-}" ] && [ -x "$BIN" ]; then
 fi
 
 c "Next steps:"
+echo "  Open the dashboard first: http://localhost:3457/admin - finish tokens plus config there"
 if [ "$METHOD" = "docker" ]; then
   echo "  1. View container status:  cd $REPO_DIR && docker compose ps"
   echo "  2. Follow container logs:  docker compose logs -f"


### PR DESCRIPTION
Makes the embedded dashboard (/admin) the default daily path and reframes the CLI as the headless/bootstrap path. Closes #359.

## Scope (docs plus help strings only)

- Grouped `--help`: Serve flags vs Advanced with per-flag dashboard twin noted (or no-twin stated for service registration).
- README CLI table gains a Dashboard twin column plus the missing `-validate-tokens` row; dashboard-first intro.
- Freeze note under the dashboard Management policy: frozen flag set, dashboard-canonical rule, hide-never-delete.
- Operator docs (getting-started, testing, user-lifecycle) read dashboard-first with CLI fallback; installer next-steps prepend the dashboard step.

Zero behavior change: same flags, defaults, exit codes, dispatch order. No new dependency, no visual change.

## Verification

- Hermetic `go test ./backend/...`: all packages ok.
- `gofmt -l backend`: clean.
- Diff: 8 files, +132/-67, one backend package (help strings only).
- No test pins the new help text.