### PR TITLE
chore(drift): refresh wire baseline for spend-ceilings onFreebucksMeter

### DIFF
--- a/scripts/wire-baseline.tsv
+++ b/scripts/wire-baseline.tsv
@@ -2,7 +2,7 @@
 3639408ac5d8 common/src/constants/foreign-client-signals.ts
 cfdbd3412df7 common/src/constants/freebuff-peak-hours.ts
 b42006247502 common/src/constants/freebuff-signup-block.ts
-89d40cb6fc87 common/src/constants/freebuff-spend-ceilings.ts
+2358dc352d90 common/src/constants/freebuff-spend-ceilings.ts
 555339c61867 common/src/constants/freebuff-standing.ts
 c2508c4590f2 common/src/tools/constants.ts
 6c7e2af63fb4 common/src/types/freebuff-session.ts


### PR DESCRIPTION
Upstream 13105816 changed exactly one wire file: freebuff-spend-ceilings.ts gains the onFreebucksMeter gate (elevated_country $1 SG + trust_level budget cohorts no longer compose for metered accounts after refusing 57 funded accounts on 2026-09-05; abuse cohorts unchanged). We enforce none of these ceilings locally (single comment notes they are server-enforced; all citations reference unchanged semantics), so this is a baseline recording only: 89d40cb6 -> 2358dc352d90. sync --check is green.