### PR TITLE
test(maturity): restore header overflow assertion

### DIFF
--- a/frontend/e2e/maturity.spec.ts
+++ b/frontend/e2e/maturity.spec.ts
@@ -329,5 +329,13 @@ test.describe("account maturity", () => {
     await expect(timeline).toBeVisible();
     await expect(timeline.getByText("admit ok")).toBeVisible();
     // Long descriptions must wrap instead of clipping header actions
+    // (Pips 0/7 case): no card header may overflow horizontally.
+    const overflow = await page.evaluate(
+      () =>
+        Array.from(document.querySelectorAll("section.fp-card header")).filter(
+          (el) => el.scrollWidth > el.clientWidth + 1,
+        ).length,
+    );
+    expect(overflow).toBe(0);
   });
 });


### PR DESCRIPTION
The always-expanded rewrite dropped the scrollWidth overflow evaluate the clipping test promises. Restores it verbatim. 7/7 maturity e2e.