### PR TITLE
docs: Freebucks-meter truth, retire session-count quota language

### DIFF
--- a/docs/9router-integration.md
+++ b/docs/9router-integration.md
@@ -78,6 +78,7 @@ The proxy listens on port `3457`. The Base URL in 9router depends on where 9rout
 ## 🤖 Recommended Models to Add
 
 > **📢 Freebuff Team Notice**: *"V4 Pro and GPT-5.6 Luna are 1 session a day, V4 Pro pauses at peak times, and MiniMax M3 is unavailable. MiMo 2.5 stays unlimited."*
+> *Legacy wording: "1 session a day" in the notice above is pre-meter phrasing — pooled users here are metered: priced rows bill 'N Freebucks/hr' off the wire prices map, charged once at session start; unpriced rows are unmetered.*
 
 In the 9router provider node, you can add any of these models from the proxy catalog:
 
@@ -85,9 +86,9 @@ In the 9router provider node, you can add any of these models from the proxy cat
 | :--- | :--- | :--- |
 | `deepseek/deepseek-v4-flash` | **DeepSeek V4 Flash 07/31 (Recommended)**<br>Smart & Fast · Reasoning: `high` · NEW | **Full Tier** (unmetered) |
 | `mimo/mimo-v2.5` | **MiMo 2.5**<br>Balanced · Images | **All Tiers — UNLIMITED** (default for limited tier) |
-| `openai/gpt-5.6-luna` | **GPT-5.6 Luna**<br>Strong all-around · Reasoning: `high` · Images | Full Tier (metered — Freebucks/hr at session start) |
+| `openai/gpt-5.6-luna` | **GPT-5.6 Luna**<br>Strong all-around · Reasoning: `high` · Images | Full Tier (metered — priced 'N Freebucks/hr' off the wire prices map, charged once at session start) |
 | `deepseek/deepseek-v4-pro` | **DeepSeek V4 Pro**<br>Deep reasoning · Reasoning: `high` | Full Tier (paused upstream at peak times) |
-| `z-ai/glm-5.2` | **GLM 5.2**<br>Top open-source agentic model | **Referral-gated** (+1 session per referral) |
+| `z-ai/glm-5.2` | **GLM 5.2**<br>Top open-source agentic model | **Referral-gated** — gated accounts earn Freebucks via the Earn page; 1-hour sessions stay the unit |
 | `minimax/minimax-m3` | **MiniMax M3** | Paused upstream (kept in the catalog, not servable) |
 Clients calling 9router address these models as `freebuff/<model-id>`, for example:
 ```json

--- a/docs/architecture/GLOSSARY.md
+++ b/docs/architecture/GLOSSARY.md
@@ -13,7 +13,7 @@ naming or update this file deliberately; never leave both in circulation.
 | **token** | One FreeBuff account credential (`cb_...`). Owns an independent daily quota and can be rate-limited or banned independently. Never printed, never persisted raw. |
 | **session** | Per-token upstream admission state (instance id, expiry, tier/country, model locks). Created by session admission POSTs, refreshed by polls, ended by DELETE or expiry. One session per token at a time. |
 | **run** | One upstream agent execution for a model, shared across requests. Started on first use, lives up to `ROTATION_INTERVAL` (default 6h), then rotated (fresh start, old one drained and FINISHed). |
-| **admission** | The upstream session-create handshake that claims the token's daily session slot and returns `rateLimitsByModel` quota data. |
+| **admission** | The upstream session-create handshake starting a billable session (charged once at session start), returning live quota/price data (`rateLimitsByModel`). |
 | **pool** | The set of pre-configured upstream tokens (`AUTH_TOKENS`) plus the state the proxy keeps per token: sessions, runs, cooldowns, quotas, spend. |
 | **pooled mode** | Requests are served from `AUTH_TOKENS`; the pool picks the token (hot-session-first, rotation policy, cooldown skip). |
 | **bridge mode** | No `AUTH_TOKENS`. Each client presents its own token as the bearer credential and the proxy relays with it, caching per-token state (LRU, 32 entries, 72h idle eviction). |

--- a/docs/client-integration.md
+++ b/docs/client-integration.md
@@ -191,7 +191,7 @@ the proxy without risking your account's trust tier.
 
 ## Access Tiers
 
-- **Full tier** (`accessTier: "full"`): Tier-1 countries (US, UK, DE, JP, CA, etc.) with residential ASN. Access to premium models (`openai/gpt-5.6-luna`, `meta/muse-spark-1.2-contributor`; 1.3 paused upstream). Metered rows spend Freebucks per hour of session, charged once when the session starts. **GLM 5.3 Flash**, DeepSeek V4 Flash, MiMo 2.5 and Solar Pro 4 are **unmetered unlimited** on full tier (GLM left the premium pool `2026-08-28`; solar graduated from trial and left the pool `2026-09-04`). Daily Freebucks allowances reset every `07:00 UTC`.
+- **Full tier** (`accessTier: "full"`): Tier-1 countries (US, UK, DE, JP, CA, etc.) with residential ASN. Access to premium models (`openai/gpt-5.6-luna`, `meta/muse-spark-1.2-contributor`; 1.3 paused upstream). Priced rows spend 'N Freebucks/hr' off the wire prices map, charged once when the session starts. **GLM 5.3 Flash**, DeepSeek V4 Flash, MiMo 2.5 and Solar Pro 4 are **unmetered unlimited** on full tier (GLM left the premium pool `2026-08-28`; solar graduated from trial and left the pool `2026-09-04`). The daily Freebucks pool refills at Pacific midnight (`07:00 UTC`); the wallet itself never self-refills.
 - **Limited tier** (`accessTier: "limited"`): Non-Tier-1 countries. All model requests coerced to `mimo/mimo-v2.5` (`MiMo 2.5`). **MiMo 2.5 stays unlimited across all tiers**.
 
 See [Getting Started — Access Tiers](getting-started.md#access-tiers-models--upstream-quotas) for how to reach full tier from a limited-tier location.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -61,7 +61,7 @@ Per-account maturity tracking with stacked model and mode selects, per-token tou
 
 ### 4. Quota Tracker
 
-- **Per-Account Cards** (`Account #1…`): Freebucks allowance windows with per-model hourly prices (cheapest first), period reset countdowns (Pacific midnight; day granularity past 24h, e.g. `27d 10h`), and entitlement tiers. Restart-restored rows are labeled last-seen until the next request refreshes them. A token with a live session keeps serving on it (already paid at session start); only fresh sessions spend Freebucks.
+- **Per-Account Cards** (`Account #1…`): Freebucks allowance windows with per-model hourly prices (cheapest first), period reset countdowns (Pacific midnight; day granularity past 24h, e.g. `27d 10h`), and entitlement tiers. Restart-restored rows are labeled last-seen until the next request refreshes them. A token with a live session keeps serving on it (admitted session bills once at session start; re-polls ride free and DELETE refunds); only fresh sessions spend Freebucks.
 
 ### 5. Models
 

--- a/docs/decisions/ADR-0028-freebucks-meter.md
+++ b/docs/decisions/ADR-0028-freebucks-meter.md
@@ -1,0 +1,53 @@
+# ADR-0028 — Freebucks-meter truth in user docs
+
+Date: 2026-09-08. Status: Accepted (user-ordered).
+
+## Status
+
+Accepted (user-ordered). Companion to ADR-0027 (which drops the
+session-count quota mirror in code/dashboard); this ADR records the docs
+side of the same shift.
+
+## Issue
+
+User docs still described quota in session counts — 1 session/day, 5/5,
++1 session per referral, bonus/reward sessions, daily session slots,
+premium-pool membership as quota — while the upstream reference
+(`reference/freebuff @2e57674fc`) meters pooled users. Two meters
+coexist upstream and the wire prices map is the sole cost source: the
+picker derives everything from the session response
+(`cli/src/utils/freebucks.ts`: "`prices` is a map of model id to price,
+and the balances come with it"), with row intent typed per
+`common/src/types/freebuff-session.ts`. Count language contradicts the
+meter: sessions are 1-hour billable rows ("priced in Freebucks per hour
+of session, charged once when the session starts. Your daily Freebucks
+refill at midnight Pacific; the wallet keeps what you buy or earn."
+— `FREEBUCKS_PICKER_NOTICE`), DELETE refunds, and there are "no more
+weekly or monthly session caps."
+
+## Decision
+
+- Rewrite every session-count quota claim in user docs to meter truth:
+  priced rows read 'N Freebucks/hr' off the wire prices map; unpriced
+  rows are unmetered.
+- Sessions remain the consumption unit (1-hour rows with the admission /
+  poll / DELETE lifecycle); only the COUNT-as-quota language is retired.
+- Referral GLM rows are gated: gated accounts earn Freebucks via the
+  Earn page; no `+1 session per referral` promise on metered accounts.
+- Streak rows count down to the 7-day milestone with a completion line;
+  no bonus-session gift promise.
+- Quoted upstream notices stay verbatim, each with one trailing
+  annotation line marking the legacy wording; user quotes in
+  `rotation-lab-plan.md` stay verbatim with only our own framing
+  adjusted.
+- `docs/decisions/ADR-0004*` and `ADR-0021*` stay untouched as history.
+
+## Consequences
+
+- Tier docs, model tables, and the Quota Tracker speak prices and pool
+  refills only; future upstream pricing moves need no count-semantics
+  port.
+- Upstream refusals outside the mirrored meter surface as honest
+  upstream errors, not local fallback.
+- Follow-up slices must keep new docs on the meter; any reintroduced
+  session-count quota language contradicts this ADR.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,7 +36,7 @@ Using this proxy conflicts with Codebuff's terms of service. Upstream abuse dete
 | ✅ Do | ❌ Don't |
 |---|---|
 | **Keep `SAFE_MODE=true`** (default; anti-ban stealth: TLS fingerprint, header sanitization, request jitter, idle rotation) | **Don't** run 24/7 on heavy unattended automated tasks |
-| Use a **normal residential connection** | **Don't use a VPN / proxy / Tor**. FreeBuff determines access tier via **TCP source IP GeoIP at the Cloudflare edge** — not HTTP headers. Header spoofing (`X-Forwarded-For`, `CF-Connecting-IP`) is impossible because Cloudflare overwrites them at L4. VPN and datacenter IPs are detected via MaxMind/Spur Intelligence ASN database (`ipPrivacySignals: ["vpn"]`) and placed in a restricted cohort ($0.50/day spend ceiling, ≈1 session/day) or hard-blocked |
+| Use a **normal residential connection** | **Don't use a VPN / proxy / Tor**. FreeBuff determines access tier via **TCP source IP GeoIP at the Cloudflare edge** — not HTTP headers. Header spoofing (`X-Forwarded-For`, `CF-Connecting-IP`) is impossible because Cloudflare overwrites them at L4. VPN and datacenter IPs are detected via MaxMind/Spur Intelligence ASN database (`ipPrivacySignals: ["vpn"]`) and placed in a restricted cohort ($0.50/day spend ceiling) or hard-blocked |
 | Request **only models your tier/region offers** | **Don't request out-of-region models**: on limited-tier accounts (non-Tier-1 countries), **all model requests are coerced to `mimo/mimo-v2.5` server-side** regardless of what you send in `x-freebuff-model`. Verified via MITM: CLI sends `deepseek/deepseek-v4-flash`, server responds with `model: mimo/mimo-v2.5` in admission. This is upstream behavior, not proxy behavior |
 | Keep **one modest account** | **Don't create spam clusters**: upstream caps distinct active sessions per egress IP (`ip_capped`); accounts from the same signup network (≥8 per /24) or mailbox (≥3) are permanently capped at lower trust levels |
 | **Use one key until it is rate-limited** | **Don't rotate several healthy keys aggressively** (farming signal) |
@@ -50,24 +50,24 @@ Using this proxy conflicts with Codebuff's terms of service. Upstream abuse dete
 
 FreeBuff assigns an access tier at the Cloudflare edge based on your TCP source IP's GeoIP location:
 
-- **Full tier** (`accessTier: "full"`): Tier-1 countries (US, UK, DE, JP, CA, AU, etc.) with a residential/ISP ASN. Access to all premium models including `openai/gpt-5.6-luna`. Metered rows spend Freebucks per hour of session, charged once when the session starts. Daily Freebucks allowances reset at Pacific midnight; streaks and trust ladders can raise them further.
+- **Full tier** (`accessTier: "full"`): Tier-1 countries (US, UK, DE, JP, CA, AU, etc.) with a residential/ISP ASN. Access to all premium models including `openai/gpt-5.6-luna`. Priced rows spend 'N Freebucks/hr' off the wire prices map, charged once when the session starts. The daily Freebucks pool refills at Pacific midnight; the wallet itself never self-refills.
 - **Limited tier** (`accessTier: "limited"`): Non-Tier-1 countries (e.g. `countryCode: ID` → `countryBlockReason: "country_not_allowed"`). All model requests coerced to `mimo/mimo-v2.5` (`MiMo 2.5`). A limited daily budget on that single model (the trust ladder can raise it).
 
 ### Current Upstream Model Status & Quotas
 
 > **📢 Official Freebuff Upstream Notice** (vendor snapshot `b14414d59` · npm `0.0.168` `2026-09-05`):
 > *"Every model runs on your normal daily sessions — no per-model caps; your shared premium allowance still charges partial time, rounded up to a tenth. MiMo, DeepSeek V4 Flash and GLM 5.3 Flash are unmetered. —❤️ Freebuff Team"*
+> *Legacy wording: "daily sessions" in the notice above is pre-meter phrasing — pooled users here are metered: priced rows bill 'N Freebucks/hr' off the wire prices map, charged once at session start; unpriced rows are unmetered.*
 > (Daily Freebucks pools reset at Pacific midnight (`America/Los_Angeles`). `GPT-5.6 Luna` + `Muse Spark 1.2` are metered (`1.3` paused upstream `2026-09-07`). `GLM 5.3 Flash`, `DeepSeek V4 Flash`, `MiMo 2.5` and `Solar Pro 4` are **unmetered**; solar graduated from trial `2026-09-04`.)
 
 | Category | Model Name | Wire Model ID | Specs & Upstream Quota Policy |
 |---|---|---|---|
-| **Premium** | **GPT-5.6 Luna** | `openai/gpt-5.6-luna` | **Strong all-around**, Reasoning: `high`, Images. Metered — priced per hour of session, charged at session start. |
-| **Premium** | **Muse Spark 1.2** | `meta/muse-spark-1.2-contributor` | **Queues** — rate-limited shared ceiling (15s queue, then answers on DeepSeek V4 Flash). Meta trains on prompts/completions (Contributor discount). Context `1_000_000`. Metered — priced per hour of session, charged at session start. |
-| **Unlimited**| **Solar Pro 4** | `upstage/solar-pro4` | Graduated from trial `2026-09-04` (no longer experimental). OpenRouter BYOK (Upstage), text-only, context `500_000`. **Unmetered** — always available, no per-model cap. |
-| **Unlimited**| **GLM 5.3 Flash** | `z-ai/glm-5.3-flash` | **Deep reasoning**, Images. **Unmetered** — always available, no per-model cap (left the premium pool `2026-08-28`; default pick again since `2026-09-05`). |
+| **Premium** | **GPT-5.6 Luna** | `openai/gpt-5.6-luna` | **Strong all-around**, Reasoning: `high`, Images. Metered — priced 'N Freebucks/hr' off the wire prices map, charged once at session start. |
+| **Premium** | **Muse Spark 1.2** | `meta/muse-spark-1.2-contributor` | **Queues** — rate-limited shared ceiling (15s queue, then answers on DeepSeek V4 Flash). Meta trains on prompts/completions (Contributor discount). Context `1_000_000`. Metered — priced 'N Freebucks/hr' off the wire prices map, charged once at session start. |
+| **Unlimited**| **Solar Pro 4** | `upstage/solar-pro4` | Graduated from trial `2026-09-04` (no longer experimental). OpenRouter BYOK (Upstage), text-only, context `500_000`. **Unmetered** — unpriced row, always available, no per-model cap. |
 | **Unlimited**| **DeepSeek V4 Flash** | `deepseek/deepseek-v4-flash` | **Smart & Fast**, Reasoning: `high`. **Unmetered** — always available (peak pricing applies; default pick `2026-09-02`→`2026-09-05`). |
 | **Unlimited**| **MiMo 2.5** | `mimo/mimo-v2.5` | **Balanced**, Images. **Unlimited across all tiers** (sole active model on limited tier). |
-| **Referral** | **GLM 5.2** | `z-ai/glm-5.2` | **Top open-source agentic model**. Referral-gated (`+1/day` promo pool), 1-hour sessions. |
+| **Referral** | **GLM 5.2** | `z-ai/glm-5.2` | **Top open-source agentic model**. Referral-gated: gated accounts earn Freebucks via the Earn page; 1-hour sessions stay the unit. |
 | **Pro-only** | **Gemini 3.8 Flash** | `google/gemini-3.8-flash` | Returned `2026-09-04` behind the Pro paywall, Web-only. The proxy has no Pro surface, so this row is **not served**. |
 | **Disabled** | **MiniMax M3** | `minimax/minimax-m3` | **Withdrawn** upstream (2026-08-20). |
 | **Disabled** | **DeepSeek V4 Pro** | `deepseek/deepseek-v4-pro` | **Withdrawn** upstream (2026-08-26, cost). |

--- a/docs/maturity-plan.md
+++ b/docs/maturity-plan.md
@@ -52,9 +52,9 @@ still needs the §3 ladder experiment + 7-day soak on one token.
 
 - Streak row in CLI style: `18 day streak ●●●●●●●+` (7-dot grid,
   `+` past 7).
-- Perk note (ported logic): below 7 days →
-  `🎁 N more days to unlock +1 bonus session every day`; at 7+ →
-  `🎁 Streak perk: …` (GLM variant only when `accessTier == 'full'`).
+- Milestone note: below 7 days →
+  `{N} more day(s) to complete the 7 day streak`; at 7+ →
+  `7 day streak complete` (no perk promise — streak grants no sessions on metered accounts).
 - Zero/unavailable streak → row hidden (a lapsed user needs a first
   day, not a countdown).
 

--- a/docs/rotation-lab-plan.md
+++ b/docs/rotation-lab-plan.md
@@ -14,7 +14,9 @@ stays for reference.
 
 **Goal:** Sediakan lab studi 4 skema rotasi token agar user bebas pilih `gimana token mau dipakai` (aman vs eksperimen banned), untuk jawab pertanyaan: *“rolling per 1 session per 1 auth key lebih bagus daripada 1 auth key dihabisin 5/5 baru rolling?”*
 
-**Default aman tetap `drain`** (hot-session-first, `tok0×5 → tok1×5 …`) sesuai `acquire.go:612-765` + `README:330` + `docs/9router-integration.md:57` (NEVER round-robin — farm detection).
+Sessions below are 1-hour billable rows (priced 'N Freebucks/hr' off the wire prices map, charged once at session start) — `×5` counts consecutive session admissions per token, not a quota allowance.
+
+**Default aman tetap `drain`** (hot-session-first, `tok0×5 → tok1×5 …` consecutive session admissions per token, not a quota allowance) sesuai `acquire.go:612-765` + `README:330` + `docs/9router-integration.md:57` (NEVER round-robin — farm detection).
 
 ## Backend
 

--- a/docs/tui-research.md
+++ b/docs/tui-research.md
@@ -37,15 +37,15 @@ Sections: `PREMIUM | UNLIMITED | REFERRAL | LIMITED_OFFER` (empty filtered). Her
 
 | Data | Wire → Computed | TUI Display |
 |---|---|---|
-| `rateLimitsByModel: Record<model, FreebuffSessionRateLimit>` | `getRateLimitsByModel(session)` (`freebuff-session.ts:371`) → `getFreebuffSectionQuotas(rateLimits, accessTier)` (`freebuff-session-pools.ts`) groups by `pool` | Section header `PREMIUM — 2 of 5 used · resets in 22h` (amber when exhausted) |
-| `limit, recentCount, period, resetAt, entitlementBreakdown{base,referral,streak}` | `FreebuffSessionRateLimit` `freebuff-session.ts:223` (`limit number, recentCount number, pool?, poolLabel?`) | Row second line `Premium · 2/5 · resets Sep 2 14:00` (`rowDetails`) |
-| `referralInfo{referralCode, qualifiedCount, dailySessions, endsAt}` | `getReferralInfo(session)` | `FreebuffReferralBanner`: `Share link freebuff.com/?ref=XXX · 3 qualified · +1/day` |
+| `rateLimitsByModel: Record<model, FreebuffSessionRateLimit>` | `getRateLimitsByModel(session)` (`freebuff-session.ts:371`) → `getFreebuffSectionQuotas(rateLimits, accessTier)` (`freebuff-session-pools.ts`) groups by `pool` | Section header `PREMIUM — 2 of 5 used · resets in 22h` (amber when exhausted; pre-Freebucks count wording, kept for inventory) |
+| `limit, recentCount, period, resetAt, entitlementBreakdown{base,referral,streak}` | `FreebuffSessionRateLimit` `freebuff-session.ts:223` (`limit number, recentCount number, pool?, poolLabel?`) | Row second line `Premium · 2/5 · resets Sep 2 14:00` (`rowDetails`; pre-Freebucks count wording, kept for inventory) |
+| `referralInfo{referralCode, qualifiedCount, dailySessions, endsAt}` | `getReferralInfo(session)` | `FreebuffReferralBanner`: `Share link freebuff.com/?ref=XXX · 3 qualified · +1/day` (pre-Freebucks count wording, kept for inventory) |
 | `freebucks{balance, daily{limit,spent,remaining,resetAt}, weekly, monthly, bindingWindow}` | `getFreebucksInfo(session)` | `Freebucks $12.5 · Daily 5/20` |
 | `glmPromo{dailySessions, endsAt}` | `getGlmPromo(session)` | `GLM 2/day · ends Sep 3` |
 | `standing{cappedBy, cappedReason, blurb, nextSteps[]}` | `getStanding(session)` (`freebuff-standing.ts`) | `Trust: capped by hosting · Blurb · Next: link GitHub` |
 | `desktopSessionCounts{active, total}` | `FreebuffDesktopSessionCounts` | `Desktop 2/3 tabs` |
 | `limitedModelOffers[]{model, spotsLeft}` | `getLimitedModelOffers(session)` (`limitedModelOffers` only while global pool has capacity) | Extra row `Claude Fable 5 · 12 spots left` |
-| `streak{currentStreak, longestStreak, bonusNote}` | `useFreebuffStreakQuery` + `freebuff-streak-line.ts` | Landing header `🔥 7 day streak · +1 session` |
+| `streak{currentStreak, longestStreak, bonusNote}` | `useFreebuffStreakQuery` + `freebuff-streak-line.ts` | Landing header `🔥 7 day streak · +1 session` (pre-Freebucks perk wording, kept for inventory — streak grants no sessions on metered accounts) |
 | `subscription{plan, usage}` | `useSubscriptionQuery` / `useUsageQuery` (poll 15s/30s) | `Subscription $20 · 34/100 credits` (non-freebuff) |
 | `availability` | `getFreebuffModelUnavailableLabel(model)`, `isFreebuffModelAvailable(tier)` | Greyed row `Unavailable 9am-5pm ET` |
 | `contextWindow` | `FREEBUFF_MODEL_CONTEXT_WINDOWS[model]` | Row badge `1M` |


### PR DESCRIPTION
Session-count quota claims (1 session/day, 5/5, +1 per referral, bonus/reward sessions, daily slots) rewritten to meter truth per reference/freebuff@2e57674f (prices map sole cost source, charge-once, Pacific-midnight refill). Quotes stay verbatim + legacy annotation. New ADR-0028. ADRs 0004/0021 untouched. Docs-only, no code.