### PR TITLE
docs: minimal core markdown set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,10 @@ Machine-readable rules for agents working in this repo. Human overview lives in
 - Svelte 5 dashboard (`frontend/`, `freebuff-proxy-dashboard`) embedded via
   `go:embed` (`backend/internal/dashboard/assets_embed.go`) and served at `/admin`.
   Health probe: `GET /healthz` → 200.
-- Modes (`backend/internal/config/config.go`): pooled (`AUTH_TOKENS` set),
-  bridge (`AUTH_TOKENS` empty, per-request client token).
+- Modes (`backend/internal/config/config.go:HybridBridgeMode/EffectiveMode`):
+  pooled (`AUTH_TOKENS` set + `BRIDGE_ENABLED=0`), bridge (`AUTH_TOKENS`
+  empty, per-request client token), hybrid (default when `AUTH_TOKENS` set:
+  `API_KEYS` credential uses the pool, any other credential relays as bridge).
 - Freebucks meter: the wire `prices` map is the sole cost source; charge-once at
   session start; 1h sessions; `DELETE` refund; Pacific-midnight refill.
   `deepseek/deepseek-v4-flash` is an unpriced row (verified cost-0 live 2026-09-08).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# AGENTS.md — freebuff-proxy operating guide
+
+Machine-readable rules for agents working in this repo. Human overview lives in
+`README.md`; visual grammar in `DESIGN.md`; multi-agent workflow in
+`docs/AGENTIC-WORKFLOW.md`.
+
+## 1. Identity
+
+- Go 1.26 (`go.mod`) FreeBuff wire gateway. OpenAI-compatible surfaces
+  (`/v1/chat/completions`, `/v1/models` — see `backend/cmd/freebuff-proxy/e2e_test.go`,
+  `backend/internal/cli/cli_serve.go`) plus an Anthropic translation layer
+  (`backend/internal/server/anthropic*.go`).
+- Svelte 5 dashboard (`frontend/`, `freebuff-proxy-dashboard`) embedded via
+  `go:embed` (`backend/internal/dashboard/assets_embed.go`) and served at `/admin`.
+  Health probe: `GET /healthz` → 200.
+- Modes (`backend/internal/config/config.go`, `backend/internal/server/admin*.go`):
+  pooled (`AUTH_TOKENS` set), bridge (`AUTH_TOKENS` empty, per-request client
+  token), hybrid (pooled pool + bridge relay when a request carries a token).
+- Freebucks meter: the wire `prices` map is the sole cost source; charge-once at
+  session start; 1h sessions; `DELETE` refund; Pacific-midnight refill.
+  `deepseek/deepseek-v4-flash` is an unpriced row (verified cost-0 live).
+  Details: `local://upstream-delta.md` § "Corrected Freebucks mechanics statement".
+
+## 2. Topology
+
+- `backend/` — Go gateway (`cmd/`, `internal/`). `internal/` packages include
+  `server`, `pool`, `upstream`, `session`, `store`, `config`, `dashboard`,
+  `modelcat`, `registry`, `wirefacts`.
+- `frontend/` — Svelte 5 SPA. Committed bundle
+  `backend/internal/dashboard/dist` is what the binary serves.
+- `reference/freebuff` — gitignored upstream vendor clone (pinned 2e57674fc).
+  Never commit it.
+- `scripts/` — `sync-upstream.sh`, `check-upstream.sh` (canonical parity check),
+  `review-wire-drift.sh`.
+- `.github/workflows/` — `ci.yml` (jobs `test`, `frontend`), `lint.yml` (job
+  `golangci`), `codeql.yml` (job `analyze`), `dependency-review.yml`,
+  `upstream-drift.yml`, `release.yml`.
+
+## 3. Commands
+
+```sh
+# Hermetic backend tests (CI equivalent: go test -race -timeout 10m ./backend/...)
+env -u AUTH_TOKENS -u ADMIN_TOKEN go test ./backend/...
+
+# Build / vet / lint
+go build ./backend/...
+go vet ./backend/...
+golangci-lint run ./backend/...
+
+# Frontend (run inside frontend/)
+npm run check && npm run lint && npm run format:check
+npm run test:e2e          # Playwright SPA suite (needs built dist)
+npm run build             # vite build → refresh backend/internal/dashboard/dist
+```
+
+Knob chain: any `.env` knob must propagate
+dotenv → static → live → SSE hash → store refresh.
+
+## 4. Workflow (protected main)
+
+1. Feature branch off `origin/main` → PR → CI gates
+   (`test`, `frontend`, `golangci`, `analyze`/CodeQL, `dependency-review`) green →
+   squash merge. `gh pr update-branch` takes NO `--merge` flag on this host.
+2. Conventional Commits (`feat|fix|chore|docs|…(scope): subject`).
+3. Never stage/commit unless asked. Never commit secrets, `reference/`, or devdocs.
+4. No local docker. Preview on acerblue from a `/tmp` worktree (never the shared
+   checkout — it carries uncommitted user work):
+   `docker build --network=host` + compose up, then `GET /healthz` → 200.
+   Prod is VPS SG.
+5. Frontend `dist` is rebuilt and committed LAST (dist-freshness CI diffs the
+   bundle; any `src` touch after `vite build` fails it).
+6. Upstream syncs: classify wire drift BEFORE refreshing the baseline, else
+   `review-wire-drift.sh` reports all-SAME against the new anchors and hides
+   FUNCTIONAL rows. LF-normalize `snapshots.json` comparisons (CRLF checkouts
+   fake drift). Merge drift PRs serially wire → registry → dashboard.
+
+## 5. Budgets and freezes (as observed)
+
+- Autonomy under ~10-step rails; fan out via isolated lanes (see
+  `docs/AGENTIC-WORKFLOW.md` §1).
+- Request limits default 30/min, 1500/day Pacific; `SAFE_MODE=true` is the
+  anti-ban preset (`.env.example`); `COST_MODE=free`.
+- Test flake policy: single FAIL with greens before/after (e.g. wall-clock
+  quota-boot probe before ~09:05 PDT) is note-and-move-on after 2 reruns;
+  reproduce on pristine `main` before blaming the branch.
+- `archtest.test.exe` "Access is denied" on Windows is the AV block; hand-verify
+  via import grep, CI Linux is the real proof.
+- Public repo: zero secrets in code, transcripts, or comments. Rotate on
+  suspicion; test live with user-provided keys only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,13 +13,11 @@ Machine-readable rules for agents working in this repo. Human overview lives in
 - Svelte 5 dashboard (`frontend/`, `freebuff-proxy-dashboard`) embedded via
   `go:embed` (`backend/internal/dashboard/assets_embed.go`) and served at `/admin`.
   Health probe: `GET /healthz` → 200.
-- Modes (`backend/internal/config/config.go`, `backend/internal/server/admin*.go`):
-  pooled (`AUTH_TOKENS` set), bridge (`AUTH_TOKENS` empty, per-request client
-  token), hybrid (pooled pool + bridge relay when a request carries a token).
+- Modes (`backend/internal/config/config.go`): pooled (`AUTH_TOKENS` set),
+  bridge (`AUTH_TOKENS` empty, per-request client token).
 - Freebucks meter: the wire `prices` map is the sole cost source; charge-once at
   session start; 1h sessions; `DELETE` refund; Pacific-midnight refill.
-  `deepseek/deepseek-v4-flash` is an unpriced row (verified cost-0 live).
-  Details: `local://upstream-delta.md` § "Corrected Freebucks mechanics statement".
+  `deepseek/deepseek-v4-flash` is an unpriced row (verified cost-0 live 2026-09-08).
 
 ## 2. Topology
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,51 @@
+# DESIGN.md — dashboard visual grammar
+
+Minimal token/layout grammar for dashboard work. Source of truth is
+`frontend/src/app.css`; this file summarizes, it does not redefine.
+
+## Theme
+
+Dark-only (`color-scheme: dark`), "terminal cyber ops" instrument feel:
+obsidian surfaces, hairline enclosures, no shadows except the focus ring.
+
+## Tokens (`:root` in `app.css`)
+
+| Role    | Token(s)                                            | Value(s)                          |
+|---------|-----------------------------------------------------|-----------------------------------|
+| bg      | `--fp-bg`                                           | `#0b0e14`                         |
+| surface | `--fp-surface` / `--fp-surface-2` / `--fp-inset`    | `#131822` / `#161b26` / `#08090c` |
+| input   | `--fp-input-bg`                                     | `#08090c`                         |
+| border  | `--fp-border` / `--fp-border-bright`                | `#1f2633` / `#232b3b`             |
+| text    | `--fp-text` / `--fp-muted` / `--fp-dim`             | `#f4f6fb` / `#94a3b8` / `#64748b` |
+| accent  | `--fp-accent` / `--fp-accent-hover` / `--fp-accent-dim` | `#28c244` / `#00ff66` / `rgba(40,194,68,.12)` |
+| state   | `--fp-success` / `--fp-warning` / `--fp-error` / `--fp-info` | `#22c55e` / `#f59e0b` / `#ef4444` / `#38bdf8` |
+| radius  | `--fp-radius-sm` / `--fp-radius`                    | `3px` / `4px`                     |
+| motion  | `--fp-ease` / `--fp-duration` / `--fp-duration-lg`  | `cubic-bezier(.23,1,.32,1)` / `150ms` / `250ms` |
+| focus   | `--fp-ring`                                         | `0 0 0 2px bg, 0 0 0 4px accent`  |
+
+## Type
+
+- Sans: Geist (`400/500/600/700`). Mono: JetBrains Mono (`400/500/600`).
+- Numeric data is always mono + tabular (`.fp-num`, `.tabular-nums`).
+
+## Primitives (`app.css` classes)
+
+- Surfaces: `.fp-card` (defined edge, hover lifts border to `--fp-border-bright`),
+  `.fp-inset` (recessed), `.instrument-grid` (faint dot-grid backdrop).
+- Buttons ranked by importance, not color: `.fp-btn` + `.fp-btn-primary` /
+  `.fp-btn-secondary` / `.fp-btn-ghost` / `.fp-btn-danger`, `.fp-btn-sm`,
+  `.fp-copy-icon` (square icon-only tap target).
+- Inputs: `.fp-input`, `.fp-select` (number spinners hidden; custom steppers).
+- Tables: `.fp-table` — hairline rows, left text, right numbers (`.num`).
+- Status: `.led` + `.led-good` / `-warn` / `-bad` / `-info` / `-idle` /
+  `-critical` / `-accent`; `.led-pulse` (2s) for live dots.
+- Feedback: `.skeleton*` shimmer loaders; `.page-enter` page transition;
+  `.sr-only` for screen-reader text; `prefers-reduced-motion` disables animation.
+
+## Rules
+
+1. Add new UI with existing `fp-*` classes; new tokens need a companion `app.css` change.
+2. Buttons differ by rank (primary/secondary/ghost/danger), not hue.
+3. Numbers right-aligned, mono, tabular. Status is an LED dot + label, never color alone.
+4. Visible focus ring on everything (`:focus-visible`); never remove it.
+5. Respect `prefers-reduced-motion`.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ endpoints plus an embedded Svelte dashboard.
 
 - Speaks OpenAI chat (`POST /v1/chat/completions`, `GET /v1/models`) and an
   Anthropic-compatible layer, then translates to the FreeBuff wire protocol.
-- Runs in pooled or bridge mode:
-  - **Pooled** — set `AUTH_TOKENS`; the proxy multiplexes its token pool.
-  - **Bridge** — leave `AUTH_TOKENS` empty; each request carries its own token.
+- Runs in pooled, bridge, or hybrid mode (`EffectiveMode`):
+  - **Pooled** — `AUTH_TOKENS` set + `BRIDGE_ENABLED=0`; pool only.
+  - **Bridge** — `AUTH_TOKENS` empty; each request carries its own token.
+  - **Hybrid** (default with `AUTH_TOKENS`) — `API_KEYS` credential uses the
+    pool, any other credential relays upstream as a bridge token.
 - Dashboard at `/admin` (Svelte SPA embedded in the binary).
 - Freebucks metering follows the wire `prices` map: charged once per session-hour
   at session start, refunded on early `DELETE`, refilled on a Pacific-midnight

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# freebuff-proxy
+
+Go wire gateway in front of FreeBuff, with OpenAI-compatible and Anthropic
+endpoints plus an embedded Svelte dashboard.
+
+## What it is
+
+- Speaks OpenAI chat (`POST /v1/chat/completions`, `GET /v1/models`) and an
+  Anthropic-compatible layer, then translates to the FreeBuff wire protocol.
+- Runs in pooled, bridge, or hybrid mode:
+  - **Pooled** — set `AUTH_TOKENS`; the proxy multiplexes its token pool.
+  - **Bridge** — leave `AUTH_TOKENS` empty; each request carries its own token.
+  - **Hybrid** — pooled pool plus per-request bridge relay when a token is supplied.
+- Dashboard at `/admin` (Svelte SPA embedded in the binary).
+- Freebucks metering follows the wire `prices` map: charged once per session-hour
+  at session start, refunded on early `DELETE`, refilled on a Pacific-midnight
+  cadence.
+
+## Quickstart
+
+```sh
+cp .env.example .env   # then edit: AUTH_TOKENS, ADMIN_TOKEN, ...
+go build ./backend/...
+go run ./backend/cmd/freebuff-proxy
+```
+
+Then:
+
+- `GET http://localhost:3457/healthz` → 200
+- `GET http://localhost:3457/v1/models` → live model list
+- `http://localhost:3457/admin` → dashboard
+
+Defaults that matter (`.env.example`): `SAFE_MODE=true` (anti-ban preset),
+`COST_MODE=free`, 30 req/min and 1500 req/day Pacific limits.
+
+## Layout
+
+- `backend/` — gateway source.
+- `frontend/` — dashboard SPA source.
+- `scripts/` — upstream sync / drift tooling.
+- `docs/` — agent workflow notes.
+
+## Contributing
+
+Protected `main`: branch → PR → green CI → squash merge, Conventional Commits.
+See `AGENTS.md` for the full operating guide. Never commit secrets.

--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ endpoints plus an embedded Svelte dashboard.
 
 - Speaks OpenAI chat (`POST /v1/chat/completions`, `GET /v1/models`) and an
   Anthropic-compatible layer, then translates to the FreeBuff wire protocol.
-- Runs in pooled, bridge, or hybrid mode:
+- Runs in pooled or bridge mode:
   - **Pooled** — set `AUTH_TOKENS`; the proxy multiplexes its token pool.
   - **Bridge** — leave `AUTH_TOKENS` empty; each request carries its own token.
-  - **Hybrid** — pooled pool plus per-request bridge relay when a token is supplied.
 - Dashboard at `/admin` (Svelte SPA embedded in the binary).
 - Freebucks metering follows the wire `prices` map: charged once per session-hour
   at session start, refunded on early `DELETE`, refilled on a Pacific-midnight

--- a/docs/AGENTIC-WORKFLOW.md
+++ b/docs/AGENTIC-WORKFLOW.md
@@ -1,0 +1,86 @@
+# Agentic workflow
+
+How multi-agent work runs in this repo. Distilled from the workflow-skills
+verdicts (`agent://WorkflowSkills`, 2026-09-08) and session lessons; each
+practice names the pain it answers.
+
+## 1. One slice = one lane + explicit file ownership
+
+Pain: parallel subagents on one tree clobbered each other (uncommitted
+dashboard edits lost).
+Practice: every fan-out slice gets its own `git worktree` (or OMP/orca lane)
+plus a declared file set; message siblings via `hub` before touching shared
+files (`server`, contract surfaces); the coordinator integrates serially.
+Never build a deploy from a dirty checkout — use the acerblue `/tmp` worktree
+pattern (`AGENTS.md` §4).
+
+## 2. Classify drift BEFORE refreshing baselines
+
+Pain: refreshing the baseline first makes `review-wire-drift.sh` report
+all-SAME against the new anchors and hides FUNCTIONAL rows; CRLF checkouts
+fake drift in LF-normalized `snapshots.json`.
+Order: `sync-upstream.sh --check` (read-only) → `review-wire-drift.sh`
+classify → refresh pins/baseline → `check-upstream.sh` (canonical parity proof)
+→ full tests + dist rebuild. LF-normalize before comparing hashes. Merge drift
+PRs serially wire → registry → dashboard with green CI between each. Vendor pin:
+2e57674fc; fresh 89703d78 verified zero functional drift (`local://upstream-delta.md`).
+
+## 3. Visual gate on every dashboard slice
+
+Pain: e2e-green agents shipped truncation, overflow, and unequal boxes; a
+mock-harness review (52 screenshots) found 9 gaps e2e missed.
+Gate: mock-harness screenshots at 1600 / 1280 / 390 viewport widths, reviewed
+with own eyes before merge; per-page locator discipline (never blanket-replace
+locators across specs); `vite build` before screenshots (e2e serves committed
+`dist` via serve-static, so `src` edits are invisible until built); rebuild +
+commit `dist` LAST (dist-freshness CI check).
+
+## 4. Secret hygiene as a hard gate
+
+Pain: a pooled test key and the dashboard password once leaked into a chat
+transcript (rotation required).
+Gate: never take passwords/keys into subagent transcripts; test live with
+user-provided keys only, then rotate; never commit secrets/`reference/`/devdocs;
+pre-push scan per `public-repo-publish-hygiene` (gitleaks + trufflehog); GitHub
+push protection stays on. Agents must NOT self-scan by reading credential files.
+
+## 5. Merge / CI resilience
+
+Pain: transient `gh merge` 502s, BEHIND blocks, wall-clock flakes, AV blocks.
+Protocol: 502 on merge usually started a background merge — poll state before
+retrying; BEHIND `mergeStateStatus` blocks squash — `gh pr update-branch`
+(no `--merge` flag here) + re-green, merges run serially; a lone FAIL with
+greens around it is note-and-move-on after 2 reruns, and any pool failure is
+first reproduced on pristine `main`; `archtest.test.exe` access-denied is the
+Windows AV block — hand-verify via import grep, CI Linux is proof.
+Triage CI blocker-first (build > lint > types > tests) and never claim green
+without a fresh run.
+
+## Skill table
+
+Have locally — use, do not install:
+
+| Need | Skill | Location |
+|---|---|---|
+| Lanes | using-git-worktrees / worktrees / orca-workspace-protocol | `~/.agents/skills/` / opencode / managed |
+| Fan-out | dispatching-parallel-agents / subagent-driven-development / executing-plans | `~/.agents/skills/` |
+| Evidence | verification-before-completion / pr-status-triage | `~/.agents/skills/` |
+| Invariants/TDD | tdd / test-driven-development / golang-testing / golang-security | `~/.agents/skills/` |
+| Debug | systematic-debugging / diagnosing-bugs | `~/.agents/skills/` |
+| E2E/visual | webapp-testing / web-design-reviewer / agent-browser | `~/.agents/skills/` |
+| Frontend | frontend-design / svelte5-best-practices / svelte-code-writer | `~/.agents/skills/` |
+| Review | code-review / quality-code-review / receiving-code-review | `~/.agents/skills/` |
+| Secrets | public-repo-publish-hygiene (managed) / security-review / git-guardrails-claude-code | managed / opencode / `~/.agents/skills/` |
+| Merge | resolving-merge-conflicts / finishing-a-development-branch / git-workflow | `~/.agents/skills/` |
+| Docs | update-docs / find-docs / adr-skill / write-guide | `~/.agents/skills/` |
+
+Install (into `~/.agents/skills/`, never the repo; audit SKILL.md first):
+
+| Need | Skill | Install |
+|---|---|---|
+| Runner-side visual regression (`toHaveScreenshot`, masking, baselines) | testdino-hq/playwright-skill | `npx skills add testdino-hq/playwright-skill` |
+| Secret scanning CLI | GitGuardian/agent-skills (ggshield) | `npx skills add GitGuardian/agent-skills` |
+| Contract tests (`can-i-deploy`) | contract-test-validator | `npx skills add jeremylongshore/claude-code-plugins-plus-skills --skill contract-test-validator --agent claude-code` |
+
+Deliberately not installed: upstream-drift (project scripts ARE the skill);
+docs-as-code (covered by update-docs/find-docs/adr-skill above).

--- a/docs/AGENTIC-WORKFLOW.md
+++ b/docs/AGENTIC-WORKFLOW.md
@@ -1,8 +1,7 @@
 # Agentic workflow
 
-How multi-agent work runs in this repo. Distilled from the workflow-skills
-verdicts (`agent://WorkflowSkills`, 2026-09-08) and session lessons; each
-practice names the pain it answers.
+How multi-agent work runs in this repo. Distilled from 2026-09-08 session
+verdicts and lessons; each practice names the pain it answers.
 
 ## 1. One slice = one lane + explicit file ownership
 
@@ -23,7 +22,7 @@ Order: `sync-upstream.sh --check` (read-only) → `review-wire-drift.sh`
 classify → refresh pins/baseline → `check-upstream.sh` (canonical parity proof)
 → full tests + dist rebuild. LF-normalize before comparing hashes. Merge drift
 PRs serially wire → registry → dashboard with green CI between each. Vendor pin:
-2e57674fc; fresh 89703d78 verified zero functional drift (`local://upstream-delta.md`).
+2e57674fc; fresh-vendor check 2026-09-08 found zero functional drift.
 
 ## 3. Visual gate on every dashboard slice
 


### PR DESCRIPTION
Minimal core docs rewrite on zero-md main (49b5001): exactly 4 files, no code/backend/frontend edits.

Per-file sources:
- AGENTS.md: machine operating guide. Identity/topology/commands grounded in repo code (go.mod, backend/internal/config/config.go, backend/internal/server/admin files, backend/internal/dashboard/assets_embed.go, backend/cmd/freebuff-proxy/e2e_test.go, .env.example, .github/workflows, Taskfile.yml). Freebucks mechanics from local upstream-delta.md corrected-mechanics section. Workflow/budgets from session-known workflow encoded in the ticket.
- README.md: public front. Modes from config.go BridgeMode/HybridBridgeMode plus admin.go and .env.example; endpoints and ports from cli_serve.go and e2e_test.go; no secrets.
- DESIGN.md: token/type/primitive values transcribed from frontend/src/app.css root block and fp- classes only.
- docs/AGENTIC-WORKFLOW.md: the 5 practices plus condensed skill table from the WorkflowSkills verdicts (agent payload 2026-09-08), adapted with repo file mappings; install rows kept exact.

Verification: 4 files only, 272 insertions, git status clean. Do NOT merge, do NOT deploy.