### PR TITLE
fix(dashboard): favicon matches green signal theme

### DIFF
--- a/backend/internal/dashboard/dist/index.html
+++ b/backend/internal/dashboard/dist/index.html
@@ -8,7 +8,7 @@
     <title>freebuff-proxy · admin</title>
     <link
       rel="icon"
-      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23F5A623'/%3E%3Cpath d='M18 6 9 18h5l-1 8 9-12h-5z' fill='%230A0F18'/%3E%3C/svg%3E"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%2328C244'/%3E%3Cpath d='M18 6 9 18h5l-1 8 9-12h-5z' fill='%230B0E14'/%3E%3C/svg%3E"
     />
     <script type="module" crossorigin src="/admin/assets/index-B7QCLb3Z.js"></script>
     <link rel="stylesheet" crossorigin href="/admin/assets/index-B-RhgAcf.css">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,7 @@
     <title>freebuff-proxy · admin</title>
     <link
       rel="icon"
-      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23F5A623'/%3E%3Cpath d='M18 6 9 18h5l-1 8 9-12h-5z' fill='%230A0F18'/%3E%3C/svg%3E"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%2328C244'/%3E%3Cpath d='M18 6 9 18h5l-1 8 9-12h-5z' fill='%230B0E14'/%3E%3C/svg%3E"
     />
   </head>
   <body>

--- a/frontend/src/lib/Sidebar.svelte
+++ b/frontend/src/lib/Sidebar.svelte
@@ -189,7 +189,7 @@
   aria-label="Sidebar"
 >
   <nav class="flex-1 flex flex-col px-3 pt-5 pb-3" aria-label="Main navigation">
-    <!-- Brand mark: amber bolt matching the favicon -->
+    <!-- Brand mark: signal-green bolt matching the favicon -->
     <a
       href={adminRoot}
       class="flex items-center gap-3 px-2 group"


### PR DESCRIPTION
Inline data-URI favicon still used amber #F5A623 after the green theme landed (--fp-accent #28C244). Swaps rect fill to #28C244 and bolt to --fp-bg #0B0E14, updates the stale amber comment in Sidebar.svelte (brand SVGs already bind var(--fp-accent)), dist rebuilt last so dist-freshness holds.