### PR TITLE
fix(upstream): send instance id on session DELETE

### DIFF
--- a/backend/internal/session/session_admission.go
+++ b/backend/internal/session/session_admission.go
@@ -359,7 +359,7 @@ func (m *Manager) releaseHeldSlotForTarget(ctx context.Context, targetModel stri
 	// DELETE first; only clear the cache when it actually succeeded — a
 	// failed release (401/transport) must keep the cached state so the
 	// caller's error path (dead-token/cleanup) can still end the session.
-	if err := m.client.EndSession(ctx); err != nil {
+	if err := m.client.EndSession(ctx, oldID); err != nil {
 		slog.Warn("session: EndSession failed on model switch (state kept)", "instance_id", oldID, "held_model", heldModel, "err", err)
 		return
 	}
@@ -551,13 +551,24 @@ func (m *Manager) refresh(ctx context.Context, requestedModel string, preemptive
 			return statusError(status, st)
 		case "model_locked":
 			// Previous session is locked to a different model.
-			// Release the old slot and retry with the desired model.
+			// Release the old slot and retry with the desired model. The
+			// DELETE carries the locked refusal's instance id when present,
+			// else the held cached id (empty only when neither exists, in
+			// which case the header is omitted).
 			m.mu.Lock()
+			heldID := ""
+			if m.state != nil {
+				heldID = m.state.instanceID
+			}
 			m.commit(nil)
 			m.mu.Unlock()
 			m.recordInvalidation(reasonModelLock)
 			m.recordModelLock(st.CurrentModel, targetModel)
-			_ = m.client.EndSession(ctx)
+			releaseID := st.InstanceID
+			if releaseID == "" {
+				releaseID = heldID
+			}
+			_ = m.client.EndSession(ctx, releaseID)
 			slog.Debug("session released on model lock, retrying", "reason", reasonModelLock, "current", st.CurrentModel, "target", targetModel)
 		case "model_unavailable":
 			// Requested model is not available; fall back to default model.
@@ -595,8 +606,7 @@ func (m *Manager) EndSession(ctx context.Context) error {
 	slog.Debug("session ended", "instance_id", instanceID, "reason", reasonEnded)
 	// A superseded DELETE is the same "slot already gone" case as
 	// session-invalid (#119): swallow both so teardown never errors on a
-	// slot another instance took over.
-	if err := m.client.EndSession(ctx); err != nil && !errors.Is(err, upstream.ErrSessionInvalid) && !errors.Is(err, upstream.ErrSessionSuperseded) {
+	if err := m.client.EndSession(ctx, instanceID); err != nil && !errors.Is(err, upstream.ErrSessionInvalid) && !errors.Is(err, upstream.ErrSessionSuperseded) {
 		return err
 	}
 	return nil
@@ -654,12 +664,11 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 	}
 	// Release the upstream slot directly (not EndSession): EndSession's CAS
 	// commit(nil) would remove the store entry we just flushed, and the
-	// DELETE is keyed on the user, not the instance (reference/freebuff
-	// session wire: DELETE = Bearer only, #120 — EndSession never sends the
-	// instance header). The cached state is kept in-memory so the store
-	// entry stays; the process is exiting.
+	// DELETE carries the held x-freebuff-instance-id (vendor parity:
+	// callFreebuffSession sends it on DELETE when known). The cached state
+	// is kept in-memory so the store entry stays; the process is exiting.
 	slog.Debug("session ended on shutdown", "instance_id", shortInstance(instanceID), "reason", reasonShutdown)
-	if err := m.client.EndSession(ctx); err != nil && !errors.Is(err, upstream.ErrSessionInvalid) && !errors.Is(err, upstream.ErrSessionSuperseded) {
+	if err := m.client.EndSession(ctx, instanceID); err != nil && !errors.Is(err, upstream.ErrSessionInvalid) && !errors.Is(err, upstream.ErrSessionSuperseded) {
 		return err
 	}
 	return nil

--- a/backend/internal/session/session_admission_test.go
+++ b/backend/internal/session/session_admission_test.go
@@ -423,6 +423,7 @@ func TestModelLockedReleasesOldSlot(t *testing.T) {
 
 	var creates, ends atomic.Int32
 	var mu sync.Mutex
+	var deleteIDs []string
 	bAttempts := 0
 	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
@@ -446,6 +447,9 @@ func TestModelLockedReleasesOldSlot(t *testing.T) {
 			_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-B","model":"model/B","expiresAt":"2030-01-01T00:00:00Z"}`)
 		case http.MethodDelete:
 			ends.Add(1)
+			mu.Lock()
+			deleteIDs = append(deleteIDs, r.Header.Get("x-freebuff-instance-id"))
+			mu.Unlock()
 			w.WriteHeader(200)
 			_, _ = io.WriteString(w, `{"status":"ended"}`)
 		default:
@@ -466,6 +470,15 @@ func TestModelLockedReleasesOldSlot(t *testing.T) {
 	}
 	if got := ends.Load(); got != 2 {
 		t.Errorf("ends = %d, want 2 (live-switch pre-release + model_locked branch release, both idempotent DELETEs)", got)
+	}
+	mu.Lock()
+	ids := append([]string(nil), deleteIDs...)
+	mu.Unlock()
+	if len(ids) != 2 {
+		t.Fatalf("DELETEs = %d, want 2", len(ids))
+	}
+	if ids[0] != "inst-A" {
+		t.Errorf("first DELETE x-freebuff-instance-id = %q, want inst-A (live-switch pre-release carries the held slot id)", ids[0])
 	}
 	if snap := mgr.Snapshot(); snap.InstanceID != "inst-B" {
 		t.Errorf("final instance = %q, want inst-B", snap.InstanceID)
@@ -865,8 +878,9 @@ func TestModelLockedFallbackInstance(t *testing.T) {
 			_, _ = io.WriteString(w, `{"status":"active","instanceId":"active-inst-456","model":"model/new"}`)
 		case http.MethodDelete:
 			mu.Lock()
-			// #120: the CLI DELETEs with Bearer only — no instance header
-			// (reference/freebuff freebuff-session-api.ts releaseFreebuffSlot).
+			// The DELETE releases the locked slot, so it carries the
+			// refusal's instance id (vendor parity: DELETE sends
+			// x-freebuff-instance-id when known).
 			deleteInstanceIDs = append(deleteInstanceIDs, r.Header.Get("x-freebuff-instance-id"))
 			mu.Unlock()
 			w.WriteHeader(http.StatusOK)
@@ -890,7 +904,7 @@ func TestModelLockedFallbackInstance(t *testing.T) {
 	if len(deleteInstanceIDs) != 1 {
 		t.Fatalf("EndSession calls = %d, want 1", len(deleteInstanceIDs))
 	}
-	if deleteInstanceIDs[0] != "" {
-		t.Errorf("DELETE x-freebuff-instance-id = %q, want absent (#120: session DELETE is Bearer-only)", deleteInstanceIDs[0])
+	if deleteInstanceIDs[0] != "locked-inst-123" {
+		t.Errorf("DELETE x-freebuff-instance-id = %q, want locked-inst-123 (model-lock release carries the refused slot id)", deleteInstanceIDs[0])
 	}
 }

--- a/backend/internal/upstream/client_chat_test.go
+++ b/backend/internal/upstream/client_chat_test.go
@@ -854,7 +854,7 @@ func TestFullChatLifecycleChained(t *testing.T) {
 	if err := client.FinishRun(ctx, runID, "completed", 3, nil, ""); err != nil {
 		t.Fatalf("FinishRun: %v", err)
 	}
-	if err := client.EndSession(ctx); err != nil {
+	if err := client.EndSession(ctx, st.InstanceID); err != nil {
 		t.Fatalf("EndSession: %v", err)
 	}
 

--- a/backend/internal/upstream/client_session_test.go
+++ b/backend/internal/upstream/client_session_test.go
@@ -39,8 +39,8 @@ func TestSessionControlCalls(t *testing.T) {
 		t.Errorf("poll status = %q", polled.Status)
 	}
 
-	// end + tolerated 404
-	if err := client.EndSession(context.Background()); err != nil {
+	// end + tolerated 404 (DELETE carries the held instance id).
+	if err := client.EndSession(context.Background(), "inst-abc-123"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -542,7 +542,7 @@ func TestEndSession404Tolerated(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := client.EndSession(context.Background()); err != nil {
+		if err := client.EndSession(context.Background(), "inst-1"); err != nil {
 			t.Errorf("EndSession 404 = %v, want nil", err)
 		}
 	})
@@ -558,8 +558,68 @@ func TestEndSession404Tolerated(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := client.EndSession(context.Background()); err == nil {
+		if err := client.EndSession(context.Background(), "inst-1"); err == nil {
 			t.Error("EndSession 500 succeeded, want error")
+		}
+	})
+}
+
+// TestEndSessionInstanceHeader pins the DELETE instance-id contract: the
+// client sends x-freebuff-instance-id when it holds one and omits the
+// header when the id is empty (the caller holds no slot).
+func TestEndSessionInstanceHeader(t *testing.T) {
+	t.Run("carries header when id known", func(t *testing.T) {
+		mock := testutil.NewMock()
+		defer mock.Close()
+		var got string
+		var sawDelete bool
+		mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodDelete {
+				sawDelete = true
+				got = r.Header.Get("x-freebuff-instance-id")
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"status":"ended"}`)
+		}
+		client, err := New("tok", testConfig(mock.URL(), nil))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := client.EndSession(context.Background(), "inst-held-1"); err != nil {
+			t.Fatal(err)
+		}
+		if !sawDelete {
+			t.Fatal("no DELETE reached the mock")
+		}
+		if got != "inst-held-1" {
+			t.Errorf("DELETE x-freebuff-instance-id = %q, want inst-held-1", got)
+		}
+	})
+	t.Run("omits header when id empty", func(t *testing.T) {
+		mock := testutil.NewMock()
+		defer mock.Close()
+		var got = "unset"
+		var sawDelete bool
+		mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodDelete {
+				sawDelete = true
+				got = r.Header.Get("x-freebuff-instance-id")
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"status":"ended"}`)
+		}
+		client, err := New("tok", testConfig(mock.URL(), nil))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := client.EndSession(context.Background(), ""); err != nil {
+			t.Fatal(err)
+		}
+		if !sawDelete {
+			t.Fatal("no DELETE reached the mock")
+		}
+		if got != "" {
+			t.Errorf("DELETE x-freebuff-instance-id = %q, want absent", got)
 		}
 	})
 }

--- a/backend/internal/upstream/mock.go
+++ b/backend/internal/upstream/mock.go
@@ -20,8 +20,9 @@ type MockUpstream interface {
 	GetSession(token, instanceID string) (*SessionState, error)
 	// Probe simulates the zero-cost token probe.
 	Probe(token string) (*SessionState, error)
-	// EndSession simulates the session DELETE.
-	EndSession(token string) error
+	// EndSession simulates the session DELETE for the instance ("" = no
+	// instance header, the caller holds no slot).
+	EndSession(token, instanceID string) error
 	// StartRun simulates an agent-run START.
 	StartRun(token, agentID string) (string, error)
 	// FinishRun simulates an agent-run FINISH.

--- a/backend/internal/upstream/session.go
+++ b/backend/internal/upstream/session.go
@@ -168,16 +168,21 @@ func (c *Client) GetStreak(ctx context.Context) (*StreakInfo, error) {
 }
 
 // EndSession DELETE /api/v1/freebuff/session; 404 is tolerated. The DELETE
-// is keyed on the user, not the instance: the CLI releases its slot with
-// Authorization only, no x-freebuff-instance-id header (#120,
-// reference/freebuff freebuff-session-api.ts releaseFreebuffSlot → DELETE).
-func (c *Client) EndSession(ctx context.Context) error {
+// carries x-freebuff-instance-id when the caller holds one (vendor parity:
+// cli/src/utils/freebuff-session-api.ts callFreebuffSession sends the
+// instance header on GET/DELETE when known; the session POST carries
+// x-freebuff-model and never the instance id). An empty instanceID omits
+// the header (the caller genuinely holds no slot).
+func (c *Client) EndSession(ctx context.Context, instanceID string) error {
 	if c.mock != nil {
-		return c.mock.EndSession(c.token)
+		return c.mock.EndSession(c.token, instanceID)
 	}
 	req, err := c.newRequest(ctx, http.MethodDelete, "/api/v1/freebuff/session", nil)
 	if err != nil {
 		return err
+	}
+	if instanceID != "" {
+		req.Header.Set("x-freebuff-instance-id", instanceID)
 	}
 
 	resp, cancel, classErr := c.do(req, c.sessionCallTimeout)

--- a/backend/internal/upstream/signal_guard_test.go
+++ b/backend/internal/upstream/signal_guard_test.go
@@ -121,7 +121,7 @@ func TestSignalGuardNoProxySignalHeaders(t *testing.T) {
 	if _, err := client.ProbeAccount(ctx); err != nil {
 		t.Fatalf("ProbeAccount: %v", err)
 	}
-	if err := client.EndSession(ctx); err != nil {
+	if err := client.EndSession(ctx, "inst-1"); err != nil {
 		t.Fatalf("EndSession: %v", err)
 	}
 	if _, err := client.StartRun(ctx, "agent-1"); err != nil {

--- a/backend/internal/upstream/testmock/mock.go
+++ b/backend/internal/upstream/testmock/mock.go
@@ -42,7 +42,7 @@ func (m *mockUpstream) Probe(token string) (*upstream.SessionState, error) {
 	return mockSessionState(token, "", false), nil
 }
 
-func (m *mockUpstream) EndSession(token string) error { return nil }
+func (m *mockUpstream) EndSession(token, instanceID string) error { return nil }
 
 func (m *mockUpstream) StartRun(token, agentID string) (string, error) {
 	return fmt.Sprintf("run-%s-%d", token, time.Now().UnixMilli()), nil


### PR DESCRIPTION
Upstream 400s instance_required without x-freebuff-instance-id on DELETE, leaving model_locked sessions behind and 502ing every cross-model request. Vendor parity: GET/DELETE carry the id when known (callFreebuffSession). POST side untouched. Regression: DELETE carries the released instance on the model-lock path.