### PR TITLE
fix(release): drop deleted scripts/README.md from goreleaser archives

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,8 +49,6 @@ archives:
         dst: install.ps1
       - src: scripts/install.cmd
         dst: install.cmd
-      - src: scripts/README.md
-        dst: README.md
 checksum:
   name_template: "checksums.txt"
 


### PR DESCRIPTION
Release v1.8.10 failed at archive step: scripts/README.md was removed by the docs wipe (#421) but .goreleaser.yml still references it. All other archived files verified present.