### PR TITLE
chore(vendor): move freebuff reference clone to specialize/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # ── third-party reference clones (CodebuffAI/freebuff, 9router, etc.) ──
 reference/
+specialize/
 
 # ── stray vendor clone guard (an old arg-parser bug cloned upstream into ./main) ──
 /main/

--- a/scripts/check-upstream.sh
+++ b/scripts/check-upstream.sh
@@ -75,8 +75,8 @@ if [[ -n "${2:-}" ]]; then
 	CLONE_DIR="$2"
 elif [[ -n "${FREEBUFF_REFERENCE_DIR:-}" ]]; then
 	CLONE_DIR="$FREEBUFF_REFERENCE_DIR"
-elif [[ -d "$REPO_ROOT/reference/freebuff/.git" ]]; then
-	CLONE_DIR="$REPO_ROOT/reference/freebuff"
+elif [[ -d "$REPO_ROOT/specialize/freebuff/.git" ]]; then
+	CLONE_DIR="$REPO_ROOT/specialize/freebuff"
 else
 	CLONE_DIR="$REPO_ROOT/../freebuff-reference"
 fi

--- a/scripts/repin-all.sh
+++ b/scripts/repin-all.sh
@@ -4,9 +4,9 @@
 # Usage:
 #   scripts/repin-all.sh [--dry-run] <vendor-sha> [clone-dir]
 #
-#   vendor-sha  full 40-char upstream commit SHA in reference/freebuff
+#   vendor-sha  full 40-char upstream commit SHA in specialize/freebuff
 #   clone-dir   local reference clone (default: $FREEBUFF_REFERENCE_DIR,
-#               else <repo>/reference/freebuff)
+#               else <repo>/specialize/freebuff)
 #   --dry-run   classify drift and print the planned refresh plus the exact
 #               gh commands for the three PRs; write nothing
 #
@@ -39,7 +39,7 @@ if [[ "${1:-}" == "--dry-run" ]]; then
   shift
 fi
 VENDOR_SHA="${1:-}"
-CLONE_DIR="${2:-${FREEBUFF_REFERENCE_DIR:-$REPO_ROOT/reference/freebuff}}"
+CLONE_DIR="${2:-${FREEBUFF_REFERENCE_DIR:-$REPO_ROOT/specialize/freebuff}}"
 WIRE_DIR="$REPO_ROOT/backend/internal/wirefacts/testdata/wire"
 SNAPSHOTS="$WIRE_DIR/snapshots.json"
 

--- a/scripts/review-wire-drift.sh
+++ b/scripts/review-wire-drift.sh
@@ -8,7 +8,7 @@
 #   scripts/review-wire-drift.sh [baseline.tsv] [end_ref]
 #
 # Environment:
-#   FREEBUFF_REFERENCE_DIR  upstream clone (default reference/freebuff);
+#   FREEBUFF_REFERENCE_DIR  upstream clone (default specialize/freebuff);
 #                           must have the end_ref fetched
 #   FREEBUFF_REVIEW_END_REF explicit ref/SHA to classify against (default
 #                           origin/main); a positional end_ref wins
@@ -29,7 +29,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BASELINE_FILE="${1:-$REPO_ROOT/scripts/wire-baseline.tsv}"
-CLONE_DIR="${FREEBUFF_REFERENCE_DIR:-$REPO_ROOT/reference/freebuff}"
+CLONE_DIR="${FREEBUFF_REFERENCE_DIR:-$REPO_ROOT/specialize/freebuff}"
 
 [[ -f "$BASELINE_FILE" ]] || { echo "baseline file not found: $BASELINE_FILE" >&2; exit 2; }
 if [[ -n "${2:-}" ]]; then

--- a/scripts/sync-upstream.sh
+++ b/scripts/sync-upstream.sh
@@ -18,7 +18,7 @@
 #
 # Arguments:
 #   ref                       Upstream branch or commit SHA (default: main)
-#   clone-dir                 Local reference clone directory (default: reference/freebuff,
+#   clone-dir                 Local reference clone directory (default: specialize/freebuff,
 #                             $FREEBUFF_REFERENCE_DIR, or ../freebuff-reference)
 #
 # Examples:
@@ -100,8 +100,8 @@ done
 if [[ -z "$CLONE_DIR" ]]; then
 	if [[ -n "${FREEBUFF_REFERENCE_DIR:-}" ]]; then
 		CLONE_DIR="$FREEBUFF_REFERENCE_DIR"
-	elif [[ -d "$REPO_ROOT/reference/freebuff/.git" ]]; then
-		CLONE_DIR="$REPO_ROOT/reference/freebuff"
+	elif [[ -d "$REPO_ROOT/specialize/freebuff/.git" ]]; then
+		CLONE_DIR="$REPO_ROOT/specialize/freebuff"
 	else
 		CLONE_DIR="$REPO_ROOT/../freebuff-reference"
 	fi


### PR DESCRIPTION
Moves the untracked freebuff vendor clone from reference/freebuff to specialize/freebuff as the CLI source of truth; rewires the 4 sync scripts' default clone path; adds specialize/ to .gitignore. Go references are provenance comments only.