### PR TITLE
chore(vendor): rename clone specialize/freebuff to upstream/freebuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # ── third-party reference clones (CodebuffAI/freebuff, 9router, etc.) ──
 reference/
-specialize/
+/upstream/
 
 # ── stray vendor clone guard (an old arg-parser bug cloned upstream into ./main) ──
 /main/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,7 @@ Machine-readable rules for agents working in this repo. Human overview lives in
   `modelcat`, `registry`, `wirefacts`.
 - `frontend/` — Svelte 5 SPA. Committed bundle
   `backend/internal/dashboard/dist` is what the binary serves.
-- `reference/freebuff` — gitignored upstream vendor clone (pinned 2e57674fc).
-  Never commit it.
+- `upstream/freebuff` — gitignored live vendor clone of `CodebuffAI/freebuff`, never commit. Source of truth for all wire/registry/model work. Keep freshly fetched to `origin/main` before starting; pins live in `backend/internal/wirefacts/testdata/wire/snapshots.json` (`upstream_sha`) + `scripts/vendor-version.txt`, verified by `scripts/check-upstream.sh`.
 - `scripts/` — `sync-upstream.sh`, `check-upstream.sh` (canonical parity check),
   `review-wire-drift.sh`.
 - `.github/workflows/` — `ci.yml` (jobs `test`, `frontend`), `lint.yml` (job
@@ -73,6 +72,7 @@ dotenv → static → live → SSE hash → store refresh.
    `review-wire-drift.sh` reports all-SAME against the new anchors and hides
    FUNCTIONAL rows. LF-normalize `snapshots.json` comparisons (CRLF checkouts
    fake drift). Merge drift PRs serially wire → registry → dashboard.
+7. Upstream-first: start any wire/registry/model work by updating `upstream/freebuff` to latest `origin/main` (`git -C upstream/freebuff fetch origin main`, checkout `origin/main`). Nothing gates or pre-approves this update. If it moved past the recorded pins, classify with `check-upstream.sh` + `review-wire-drift.sh` and carry any port/re-pin through the drift PR flow.
 
 ## 5. Budgets and freezes (as observed)
 

--- a/backend/internal/convert/convert_req_test.go
+++ b/backend/internal/convert/convert_req_test.go
@@ -531,7 +531,7 @@ func TestClampReasoningEffort(t *testing.T) {
 func TestEffortsForModel(t *testing.T) {
 	// Every id the ServedModels gate serves, plus paused rows with frozen
 	// ladders, with its upstream-verified ladder
-	// (reference/freebuff/common/src/constants/freebuff-models.ts,
+	// (upstream/freebuff/common/src/constants/freebuff-models.ts,
 	// modelcat catalog, pinned 92c4f5e: 1.3 withdrawn 2026-09-07, 1.2 served
 	// in its place).
 	for model, want := range map[string][]string{

--- a/backend/internal/convert/effort.go
+++ b/backend/internal/convert/effort.go
@@ -88,7 +88,7 @@ const defaultReasoningEffort = "high"
 // kimi-k3-eco accept but ignore reasoning_effort, so no clamp.
 //
 // Clamping mirrors upstream's resolveFreebuffReasoningEffort
-// (reference/freebuff/common/src/constants/freebuff-models.ts): clamp-DOWN,
+// (upstream/freebuff/common/src/constants/freebuff-models.ts): clamp-DOWN,
 // keyed on the actually-served model, medium→high on DeepSeek V4 and Ox
 // Alpha. For rows with no ladder upstream returns null and passes the client
 // value through untouched (MIMO/MiniMax treat any rung as thinking-on;

--- a/backend/internal/convert/schemacache_foreign_test.go
+++ b/backend/internal/convert/schemacache_foreign_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 // The upstream free-mode gate classifies a request as third-party when it
 // offers tools but NONE of them is a signature tool — i.e. a name from
-// toolNames that is not in GENERIC_TOOL_NAMES (reference/freebuff
+// toolNames that is not in GENERIC_TOOL_NAMES (upstream/freebuff
 // common/src/constants/foreign-client-signals.ts:33-44). The proxy's
 // countermeasure is injecting end_turn (normalizeToolSchemas), which is a
 // SIGNATURE tool: end_turn ∈ toolNames and ∉ GENERIC_TOOL_NAMES, so proxied

--- a/backend/internal/modelcat/catalog_test.go
+++ b/backend/internal/modelcat/catalog_test.go
@@ -13,7 +13,7 @@ import (
 
 // The parity test below re-reads the pinned upstream snapshot
 // (backend/internal/registry/testdata/upstream/*.ts, copied from
-// reference/freebuff/common/src/constants on every sync) and asserts the
+// upstream/freebuff/common/src/constants on every sync) and asserts the
 // catalog table matches it constant-for-constant. An upstream sync that
 // changes a catalog fact WITHOUT updating this table fails here — that is
 // the drift tripwire the whole package exists to provide.

--- a/backend/internal/pool/pool_cooldown_test.go
+++ b/backend/internal/pool/pool_cooldown_test.go
@@ -587,7 +587,7 @@ func TestSessionPollSkipsWhileChatInFlight(t *testing.T) {
 }
 
 // TestSessionPollSchedule pins the liveness-poll cadence helpers
-// (reference/freebuff sdk polling-backoff.ts): the success interval is ~30s
+// (upstream/freebuff sdk polling-backoff.ts): the success interval is ~30s
 // ±20% jitter capped to remaining+1s near expiry, and the failure backoff
 // grows 20s→300s while never scheduling a retry before the server's
 // Retry-After floor.

--- a/backend/internal/pool/pool_lifecycle.go
+++ b/backend/internal/pool/pool_lifecycle.go
@@ -24,7 +24,7 @@ import (
 // this coarse grid.
 const maintainInterval = time.Minute
 
-// Session-liveness poll cadence (reference/freebuff sdk
+// Session-liveness poll cadence (upstream/freebuff sdk
 // polling-backoff.ts): while active the CLI polls the compact session every
 // 30s ±20% (24–36s), capped to remaining+1s near expiry so the poll lands
 // just after expires_at; on failure it backs off 20s → 300s (×2 per
@@ -389,7 +389,7 @@ func (p *Pool) maintainTick(ctx context.Context) {
 // in-grace ended) session is compact-polled every ~30s ±20% — capped to
 // remaining+1s near expiry — with 20s→300s failure backoff honoring the
 // server's Retry-After, mirroring the CLI's liveness fingerprint
-// (reference/freebuff sdk polling-backoff.ts). Rotation and queued-session
+// (upstream/freebuff sdk polling-backoff.ts). Rotation and queued-session
 // advance stay on the coarse maintainInterval ticker (maintainTick). The
 // poll is skipped while a chat is in flight (the upstream allows one client
 // per account at a time; a poll landing mid-chat can kick the active
@@ -431,7 +431,7 @@ func (p *Pool) sessionPollTick(ctx context.Context) {
 // sessionPollSuccessDelay returns the delay before the next liveness poll
 // after a SUCCESSFUL poll: ~30s ±20% jitter, capped so a poll near expiry
 // lands ~1s after expires_at (the CLI observes the status flip then;
-// reference/freebuff sdk polling-backoff.ts). Sessions already inside the
+// upstream/freebuff sdk polling-backoff.ts). Sessions already inside the
 // grace drain poll at the plain jittered cadence.
 func sessionPollSuccessDelay(snap session.SessionSnapshot) time.Duration {
 	d := sessionPollJittered(sessionPollBaseInterval)

--- a/backend/internal/pool/spend.go
+++ b/backend/internal/pool/spend.go
@@ -5,7 +5,7 @@ package pool
 // #122: all period boundaries are America/Los_Angeles wall-clock — 00:00
 // Pacific, Monday 00:00 Pacific, 1st 00:00 Pacific — resolving to
 // 07:00/08:00 UTC by DST, matching the CLI's getZonedDayBounds /
-// getZonedWeekBounds, reference/freebuff/common/src/util/zoned-time.ts:78-92,
+// getZonedWeekBounds, upstream/freebuff/common/src/util/zoned-time.ts:78-92,
 // and the upstream wire periods pacific_day / pacific_week), mirroring the
 // reference account quota bookkeeping (reference/freebuff-reverse
 // internal/accounts/record.go QuotaUsed/QuotaPeriodStart and
@@ -13,7 +13,7 @@ package pool
 // usage (pool.RecordSpend, fed by the server's parsed usage blocks) and
 // surfaced next to Messages24h in the healthz token snapshot.
 //
-// The account's daily spend ceilings (reference/freebuff
+// The account's daily spend ceilings (upstream/freebuff
 // freebuff-spend-ceilings.ts: $15 full / $5 limited / $1 elevated [SG/CN cohort since 2026-09: was $5] / $0.50 restricted, plus $7 full / $3 limited paid floor for flagged reasons since 6341ef3) are SERVER-enforced at Pacific midnight, and
 // the proxy cannot know which cohort (full/limited/restricted) a token's
 // account sits in — so this ledger is a token-count heuristic, not an exact
@@ -104,7 +104,7 @@ func rollBucket(used, start int64, period string, now time.Time, tokens int64) (
 // wall-clock (America/Los_Angeles): day = 00:00 Pacific, week = Monday
 // 00:00 Pacific, month = 1st 00:00 Pacific. All resolve to 07:00 UTC during
 // PDT and 08:00 UTC during PST, mirroring the CLI's getZonedDayBounds /
-// getZonedWeekBounds (reference/freebuff/common/src/util/zoned-time.ts:78-92,
+// getZonedWeekBounds (upstream/freebuff/common/src/util/zoned-time.ts:78-92,
 // weekStartsOn = Monday) and the upstream wire periods pacific_day /
 // pacific_week with resetTimeZone America/Los_Angeles. Month has no CLI
 // equivalent and uses the Pacific calendar month for consistency. time.Date
@@ -171,7 +171,7 @@ func pacificDate(t time.Time) (int, time.Month, int) {
 // boundary: midnight+1 day, Monday+7 days, 1st+1 month — calendar arithmetic
 // via AddDate, which shifts the UTC instant across DST transitions exactly
 // like the CLI's getZonedDayBounds / getZonedWeekBounds
-// (reference/freebuff/common/src/util/zoned-time.ts:78-92; AddDate
+// (upstream/freebuff/common/src/util/zoned-time.ts:78-92; AddDate
 // normalizes like Date, go/src/time/time.go). Without tzdata the boundaries
 // are derived from the exact US DST rule in Pacific wall-clock (the same
 // derivation as bucketStartFallback): a fixed-UTC AddDate window would be
@@ -231,7 +231,7 @@ func fallbackNextBoundary(start time.Time, months, days int) time.Time {
 // derives the boundary from the US DST rule (PDT = UTC-7 from the second
 // Sunday of March 09:00Z to the first Sunday of November 08:00Z; PST = UTC-8
 // otherwise) — never a fixed UTC hour, so the 07:00Z/08:00Z midnight is
-// DST-aware (#122, reference/freebuff zoned-time.ts getZonedDayBounds).
+// DST-aware (#122, upstream/freebuff zoned-time.ts getZonedDayBounds).
 func pacificDayStart(now time.Time) time.Time {
 	if loc := pacificLoc(); loc != nil {
 		y, m, d := now.In(loc).Date()

--- a/backend/internal/pool/spend_test.go
+++ b/backend/internal/pool/spend_test.go
@@ -4,7 +4,7 @@ package pool
 // wall-clock boundaries (America/Los_Angeles), DST-correct — 07:00 UTC
 // during PDT (summer) and 08:00 UTC during PST (winter) — mirroring the
 // CLI's getZonedDayBounds / getZonedWeekBounds
-// (reference/freebuff/common/src/util/zoned-time.ts:78-92, weekStartsOn =
+// (upstream/freebuff/common/src/util/zoned-time.ts:78-92, weekStartsOn =
 // Monday) and the upstream wire periods pacific_day / pacific_week with
 // resetTimeZone America/Los_Angeles. July dates exercise PDT, January
 // dates exercise PST.

--- a/backend/internal/registry/registry_test.go
+++ b/backend/internal/registry/registry_test.go
@@ -116,7 +116,7 @@ func TestFallbackMap(t *testing.T) {
 // TestFallbackParityWithPinnedUpstream guards issue #121 at the root: the
 // offline fallback must mirror the CURRENT upstream FREE_MODE_AGENT_MODELS.
 // testdata/upstream/ is a pinned snapshot of the six Codebuff source files
-// (copied from reference/freebuff/common/src/constants, the RE-verified
+// (copied from upstream/freebuff/common/src/constants, the RE-verified
 // installed CLI binary). This test parses that snapshot with the real parser
 // — the same code a live Refresh runs — and requires LoadFallback to produce
 // the identical model set, model→agent routing, and agent set. The fallback

--- a/backend/internal/runs/cooldown.go
+++ b/backend/internal/runs/cooldown.go
@@ -58,7 +58,7 @@ var maxIpCappedReAdmitsPerDay = 3
 
 // ipCappedCooldownJitter is the Â±fraction of retryAfterMs applied to the
 // ip_capped re-admission window so concurrent tokens do not re-admit in
-// lockstep (mirrors the CLI's 30sÂ±20% poll jitter; reference/freebuff
+// lockstep (mirrors the CLI's 30sÂ±20% poll jitter; upstream/freebuff
 // cli/src/hooks/use-freebuff-session.ts).
 const ipCappedCooldownJitter = 0.2
 
@@ -204,7 +204,7 @@ func (m *RunManager) CooldownIpCapped(ice *upstream.IpCappedError) {
 // ipCappedJitter returns a one-sided jitter of up to
 // ipCappedCooldownJitter (20%) of base, crypto/rand-seeded so concurrent
 // tokens never re-admit in lockstep (mirrors the CLI's 30sÂ±20% poll
-// jitter; reference/freebuff cli/src/hooks/use-freebuff-session.ts).
+// jitter; upstream/freebuff cli/src/hooks/use-freebuff-session.ts).
 func ipCappedJitter(base time.Duration) time.Duration {
 	if base <= 0 {
 		return 0

--- a/backend/internal/runs/drain.go
+++ b/backend/internal/runs/drain.go
@@ -21,7 +21,7 @@ import (
 // in-memory append (issue #114: steps are batched and sent WITH FINISH —
 // the CLI has no /steps endpoint). The context-pruner child-run job (#91)
 // was removed because the newest CLI UNTRACKS pruner runs entirely
-// (reference/freebuff packages/agent-runtime/src/run-agent-step.ts:785-795
+// (upstream/freebuff packages/agent-runtime/src/run-agent-step.ts:785-795
 // mints a local untracked run id, zero ledger POSTs).
 type asyncJobKind uint8
 

--- a/backend/internal/server/engine_attempt.go
+++ b/backend/internal/server/engine_attempt.go
@@ -270,7 +270,7 @@ func (s *Server) chatAttempt(ctx context.Context, model string, normalized []byt
 		case errors.Is(err, upstream.ErrWaitingRoomRequired):
 			// #116: 428 waiting_room_required is session-ENDING
 			// (endsTheSession:true — the seat is gone mid-chat;
-			// reference/freebuff freebuff-session.ts FREEBUFF_GATE_CODES).
+			// upstream/freebuff freebuff-session.ts FREEBUFF_GATE_CODES).
 			// Drop the cached session and re-admit ONCE for this request
 			// (mirror the ErrSessionInvalid budget: attempts > 1 surfaces
 			// the error; the WAITING_ROOM_CHAIN fires before the next
@@ -367,7 +367,7 @@ func (s *Server) chatAttempt(ctx context.Context, model string, normalized []byt
 			return nil, nil, err
 		case errors.Is(err, upstream.ErrCredits):
 			// #117: 402 is NEVER retried — the CLI throws immediately and
-			// 402 is NOT in RETRYABLE_STATUS_CODES (reference/freebuff sdk
+			// 402 is NOT in RETRYABLE_STATUS_CODES (upstream/freebuff sdk
 			// error-utils.ts line 16; run-agent-step.ts throws on 402). A
 			// blind retry would burn a fresh lease against the same quota
 			// wall (2 upstream chat POSTs). Surface for writeError, which

--- a/backend/internal/session/session.go
+++ b/backend/internal/session/session.go
@@ -178,7 +178,7 @@ type cachedState struct {
 // an active session until expiresAt-5s (the reference safety margin), or any
 // state that still holds a live instance id within the 30-minute grace drain
 // after expiry (FREEBUFF_SESSION_GRACE_MS: within grace the row
-// stays alive and chat passes — reference/freebuff freebuff-session.ts). The
+// stays alive and chat passes — upstream/freebuff freebuff-session.ts). The
 // instance-id test guards the grace extension: an ended row whose instance id
 // is gone cannot be ridden, and an expired active cache is only reusable
 // while the session survives upstream.

--- a/backend/internal/session/session_poll.go
+++ b/backend/internal/session/session_poll.go
@@ -69,7 +69,7 @@ func statusError(status string, st *upstream.SessionState) error {
 		// Distinct error: ip_capped is admission-only (too many distinct
 		// users on the egress IP) and NOT tied to a quota reset, so the
 		// cooldown is bounded to retryAfterMs only — never the
-		// Pacific-midnight lock (reference/freebuff freebuff-session.ts).
+		// Pacific-midnight lock (upstream/freebuff freebuff-session.ts).
 		retryAfter := upstream.CooldownFromMillis(float64(st.RetryAfterMs))
 		if retryAfter <= 0 {
 			retryAfter = time.Minute
@@ -174,7 +174,7 @@ func (m *Manager) pollPersisted(ctx context.Context, requestedModel string) (*up
 
 // Poll runs the periodic session-liveness poll: a compact GET with NO
 // heartbeat header — the CLI never beats (x-freebuff-heartbeat is
-// Desktop-only, reference/freebuff freebuff-models.ts:1212-1215); liveness
+// Desktop-only, upstream/freebuff freebuff-models.ts:1212-1215); liveness
 // comes from the recurring compact GET itself. It refreshes the
 // cached state the way the CLI's 30s compact poll does: statusError
 // mappings, drop-on-ban, invalidate on superseded/none, and — within the
@@ -203,7 +203,7 @@ func (m *Manager) Poll(ctx context.Context) error {
 	if err != nil {
 		// #116: 428 waiting_room_required is session-ENDING
 		// (endsTheSession:true per FREEBUFF_GATE_CODES — the seat is gone;
-		// reference/freebuff freebuff-session.ts). Drop the cached admission
+		// upstream/freebuff freebuff-session.ts). Drop the cached admission
 		// so the next EnsureSession re-admits fresh (the pool's
 		// WAITING_ROOM_CHAIN fires before the create). Any other poll error
 		// is left for the pool's failure backoff.

--- a/backend/internal/session/session_poll_test.go
+++ b/backend/internal/session/session_poll_test.go
@@ -85,7 +85,7 @@ func TestPoll(t *testing.T) {
 			t.Fatalf("Poll: %v", err)
 		}
 		// Gap #2: the CLI never beats — x-freebuff-heartbeat is
-		// Desktop-only (reference/freebuff freebuff-models.ts:1212-1215);
+		// Desktop-only (upstream/freebuff freebuff-models.ts:1212-1215);
 		// liveness comes from the recurring compact GET.
 		if gotCompact != "1" {
 			t.Errorf("x-freebuff-compact-session = %q, want 1", gotCompact)

--- a/backend/internal/tokenhealth/disposable_parity_test.go
+++ b/backend/internal/tokenhealth/disposable_parity_test.go
@@ -10,7 +10,7 @@ import (
 
 // TestDisposableEmailDomainsParity pins the Go email-domain tables to the
 // pinned upstream snapshot (backend/internal/upstream/testdata/
-// disposable-email.ts, copied from reference/freebuff common/src/util/
+// disposable-email.ts, copied from upstream/freebuff common/src/util/
 // disposable-email.ts on every sync). The test re-reads the TS, extracts the
 // three string-literal arrays, and asserts the parsed sets equal the Go tables
 // entry-for-entry. An upstream sync that changes a domain WITHOUT updating the

--- a/backend/internal/tokenhealth/tokenhealth.go
+++ b/backend/internal/tokenhealth/tokenhealth.go
@@ -1,7 +1,7 @@
 // Package tokenhealth holds the -validate-tokens report vocabulary and the
 // pure helpers that the upstream client's health probes use: the account-state
 // and email-domain-risk classifications, the email-domain lists mirroring
-// reference/freebuff common/src/util/disposable-email.ts, and the report
+// upstream/freebuff common/src/util/disposable-email.ts, and the report
 // formatting. The client-dependent probing (CheckTokenHealth/ValidateTokens/
 // FetchAccountInfo) stays in the upstream package, which imports this one for
 // the pure logic and keeps the exported symbols it needs.
@@ -125,7 +125,7 @@ func SessionStateFromStatus(status string) (TokenHealthState, string) {
 // --- email-domain classification (mirrors disposable-email.ts) ---
 
 // disposableDomains mirrors DISPOSABLE_EMAIL_DOMAINS in
-// reference/freebuff common/src/util/disposable-email.ts:31-219 — the
+// upstream/freebuff common/src/util/disposable-email.ts:31-219 — the
 // one-time inbox providers plus the farm-observed rings, exactly as curated
 // upstream (no lookalike that the upstream list deliberately excludes).
 var disposableDomains = newDomainSet(

--- a/backend/internal/upstream/ads.go
+++ b/backend/internal/upstream/ads.go
@@ -17,7 +17,7 @@ import (
 // official CLI binary the proxy emulates (reference
 // cli/src/hooks/use-gravity-ad.ts getCliAdRequestUserAgent:
 // "Freebuff-CLI/<CODEBUFF_CLI_VERSION>"; 1.0.0 = cli/package.json version
-// at reference/freebuff @19d905d).
+// at upstream/freebuff @19d905d).
 const freebuffCliUA = "Freebuff-CLI/1.0.0"
 
 const (

--- a/backend/internal/upstream/chat.go
+++ b/backend/internal/upstream/chat.go
@@ -41,7 +41,7 @@ type ChatOptions struct {
 	AgentID string
 	// StepNumber is the 1-based per-run agent step counter (CLI parity:
 	// llm_step_number is merged on every chat call, String(n);
-	// reference/freebuff agent-runtime run-agent-step.ts:1175-1177).
+	// upstream/freebuff agent-runtime run-agent-step.ts:1175-1177).
 	// Injected as codebuff_metadata["llm_step_number"] when > 0; the run
 	// manager sets it per chat call at the server construction sites.
 	StepNumber int
@@ -120,17 +120,17 @@ func (c *Client) ChatCompletions(ctx context.Context, opts ChatOptions, body []b
 		// The chat POST carries NO x-freebuff-model / x-freebuff-instance-id
 		// headers (#106): the official CLI sends exactly Authorization + the
 		// ai-sdk UA (+ optional acting-user-id) on chat
-		// (reference/freebuff model-provider.ts:146-152); the model and
+		// (upstream/freebuff model-provider.ts:146-152); the model and
 		// instance id ride only in the body metadata (injectEnvelope).
 		if c.userID != "" {
 			// The official CLI sends x-freebuff-acting-user-id on every
 			// chat call with the account's OWN id, derived from
-			// GET /api/v1/me (reference/freebuff sdk/src/run.ts:649-658;
+			// GET /api/v1/me (upstream/freebuff sdk/src/run.ts:649-658;
 			// sdk/src/impl/model-provider.ts:148-153 — agent-runs
 			// START/FINISH carry it too, database.ts:318-320/396-398).
 			// The server treats it as a trusted server-to-server header
 			// honored only when the request authenticates as the FreeBuff
-			// Web service account (reference/freebuff
+			// Web service account (upstream/freebuff
 			// common/src/constants/freebuff-models.ts:1180-1183).
 			// ACTING_USER_ID is therefore only safe when it equals the
 			// token's own account id; any other value impersonates a
@@ -158,7 +158,7 @@ func (c *Client) ChatCompletions(ctx context.Context, opts ChatOptions, body []b
 				// #105: the free-tier capacity queue asks the client to WAIT
 				// before retrying — the AI SDK absorbs the deferral silently,
 				// honoring retry-after with a 10s default
-				// (reference/freebuff sdk model-provider.ts:41-49,62-81). Sleep
+				// (upstream/freebuff sdk model-provider.ts:41-49,62-81). Sleep
 				// the parsed retry-after (floor 10s) so the same-session retry
 				// does not re-POST immediately (amplification); ctx
 				// cancellation aborts the sleep like every other upstream wait.
@@ -369,7 +369,7 @@ func injectEnvelope(body []byte, costMode string, opts ChatOptions) ([]byte, err
 		metadata["freebuff_instance_id"] = opts.SessionInstanceID
 	}
 	// llm_step_number is the 1-based per-run agent step, String(n) on the
-	// wire (#113; reference/freebuff run-agent-step.ts:1175-1177).
+	// wire (#113; upstream/freebuff run-agent-step.ts:1175-1177).
 	if opts.StepNumber > 0 {
 		metadata["llm_step_number"] = strconv.Itoa(opts.StepNumber)
 	}
@@ -385,7 +385,7 @@ func injectEnvelope(body []byte, costMode string, opts ChatOptions) ([]byte, err
 	// freebuff_reasoning_effort mirrors the normalized top-level
 	// reasoning_effort the convert layer already clamped to the model's
 	// ladder. This is the field the upstream server's effort authority
-	// actually reads (reference/freebuff freebuff-models.ts
+	// actually reads (upstream/freebuff freebuff-models.ts
 	// resolveFreebuffReasoningEffort, carried per request by the CLI as
 	// codebuff_metadata.freebuff_reasoning_effort — use-send-message.ts
 	// :602-608); a top-level reasoning_effort alone may never reach it.

--- a/backend/internal/upstream/classify.go
+++ b/backend/internal/upstream/classify.go
@@ -28,14 +28,14 @@ func classifyError(status int, body string, hdr http.Header) error {
 	switch {
 	case status == http.StatusForbidden && strings.Contains(lower, `"status":"banned"`):
 		// The canonical ban body is {"status":"banned"} (the free-session
-		// status wire shape, reference/freebuff freebuff-session.ts). Match
+		// status wire shape, upstream/freebuff freebuff-session.ts). Match
 		// the marker exactly: any 403 whose body merely mentions the word
 		// "banned" (e.g. {"error":"model temporarily banned..."}) must stay
 		// a generic 403, not trigger the ban cooldown.
 		return parseBan(body)
 	case status == http.StatusForbidden && strings.Contains(lower, `"error":"`+string(WireCodeAccountSuspended)+`"`):
 		// Hard-ban shape: 403 {"error":"account_suspended","message":"...
-		// suspended due to billing issues."} (reference/freebuff
+		// suspended due to billing issues."} (upstream/freebuff
 		// sdk run-cancellation.test.ts:314-359, api/_post.ts:298-307).
 		// Same ban class as "status":"banned": the body carries no
 		// resumes_at, so BanError.ResumesAt stays zero and CooldownBan
@@ -91,7 +91,7 @@ func classifyError(status int, body string, hdr http.Header) error {
 		// budget, but this session's row is fine (endsTheSession:false).
 		// Distinct non-invalid error: the server surfaces 409 and never
 		// refreshes/recreates the session
-		// (reference/freebuff freebuff-session.ts FREEBUFF_GATE_CODES).
+		// (upstream/freebuff freebuff-session.ts FREEBUFF_GATE_CODES).
 		return &SessionLimitError{Status: status, Body: truncate(body, 200)}
 	case status == http.StatusForbidden && strings.Contains(lower, string(WireCodeFreeModeCLIRequired)):
 		return fmt.Errorf("%w: %d %s", ErrFreeModeCLIRequired, status, truncate(body, 200))
@@ -103,7 +103,7 @@ func classifyError(status int, body string, hdr http.Header) error {
 		// rate_limited this is NOT tied to a quota reset. Cooldown is
 		// bounded by the proxy to retryAfterMs + jitter, with a per-token
 		// daily re-admission cap (3rd hit in a rolling window locks until
-		// Pacific midnight — #118) (reference/freebuff freebuff-session.ts).
+		// Pacific midnight — #118) (upstream/freebuff freebuff-session.ts).
 		return parseIpCapped(body, retryAfter)
 	case containsAny(lower, string(WireCodeWaitingRoomQueued)):
 		// 429 waiting_room_queued: transient admission race — the session
@@ -111,7 +111,7 @@ func classifyError(status int, body string, hdr http.Header) error {
 		// invalid: the row is fine, so the cached session must not be
 		// invalidated or refreshed. Surfaced as 503 waiting_room_queued +
 		// Retry-After via the shared WaitingRoomError
-		// (reference/freebuff freebuff-session.ts FREEBUFF_GATE_CODES).
+		// (upstream/freebuff freebuff-session.ts FREEBUFF_GATE_CODES).
 		return &WaitingRoomError{RetryAfter: retryAfter, Detail: truncate(body, 200)}
 	case containsAny(lower, string(WireCodeWaitingRoomRequired)):
 		// 428 waiting_room_required (issue #94): the account must walk the
@@ -151,7 +151,7 @@ func classifyError(status int, body string, hdr http.Header) error {
 	case containsAny(lower, string(WireCodeSessionSuperseded)):
 		// #119: 409 session_superseded is a TERMINAL gate rejection
 		// (endsTheSession:true — another instance took over the account;
-		// reference/freebuff freebuff-session.ts FREEBUFF_GATE_CODES).
+		// upstream/freebuff freebuff-session.ts FREEBUFF_GATE_CODES).
 		// Deliberately NOT ErrSessionInvalid: the server must never
 		// auto-reacquire in-request (auto-takeover risks ping-pong) — it
 		// surfaces 409 session_superseded and lets the NEXT request re-join

--- a/backend/internal/upstream/client.go
+++ b/backend/internal/upstream/client.go
@@ -110,7 +110,7 @@ func (c *Client) TokenKey() string {
 
 // cliUserAgent mirrors the official CLI chat user agent: the pinned
 // @codebuff/llm-providers version, NOT the CLI_VERSION knob
-// (reference/freebuff model-provider.ts:150; llm-providers package.json
+// (upstream/freebuff model-provider.ts:150; llm-providers package.json
 // 1.0.0). The upstream free-tier gate (403 free_mode_cli_required) keys on
 // the CLI request envelope (x-freebuff-* headers, codebuff_metadata, forced
 // streaming and the JSON-quoted "cb_easp" stop sentinel — see the package
@@ -125,7 +125,7 @@ const cliUserAgent = "ai-sdk/openai-compatible/1.0.0/codebuff"
 // calls carry: session POST/GET/probe/DELETE, agent-runs START/FINISH,
 // auth login code/status and usage all use bare fetch() with no UA override,
 // so Bun sends its own default `Bun/<version>`. 1.3.14 matches the pinned
-// reference/freebuff/.bun-version and the live probe.
+// upstream/freebuff/.bun-version and the live probe.
 const bunUserAgent = "Bun/1.3.14"
 
 const (

--- a/backend/internal/upstream/client_chat.go
+++ b/backend/internal/upstream/client_chat.go
@@ -57,7 +57,7 @@ func (c *Client) newRequest(ctx context.Context, method, path string, body []byt
 		req.Header.Del("Authorization")
 	}
 	// Content-Type only when a body is present (#120): the CLI sets it iff
-	// body !== undefined (reference/freebuff codebuff-api.ts:344-346), so a
+	// body !== undefined (upstream/freebuff codebuff-api.ts:344-346), so a
 	// bodyless session POST must not carry it. Chat always has a body.
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")

--- a/backend/internal/upstream/client_retry_test.go
+++ b/backend/internal/upstream/client_retry_test.go
@@ -230,7 +230,7 @@ func TestClassifyBan(t *testing.T) {
 
 // TestClassifyAccountSuspended verifies the ban-class shape: the newest
 // CLI's hard ban is 403 {"error":"account_suspended","message":"...suspended
-// due to billing issues."} (reference/freebuff sdk run-cancellation.test.ts
+// due to billing issues."} (upstream/freebuff sdk run-cancellation.test.ts
 // :314-359). It must route into the same parseBan path as "status":"banned"
 // with NO resumes_at (the permanent hard-ban shape), while near-misses stay
 // generic.

--- a/backend/internal/upstream/client_session_test.go
+++ b/backend/internal/upstream/client_session_test.go
@@ -432,7 +432,7 @@ func TestGetSessionWithOptsHeaders(t *testing.T) {
 		t.Errorf("headers: compact=%q, instance=%q (want 1 / inst-1)", gotCompact, gotInstance)
 	}
 	// Gap #2: the CLI never beats — x-freebuff-heartbeat is Desktop-only
-	// (reference/freebuff freebuff-models.ts:1212-1215), so a compact poll
+	// (upstream/freebuff freebuff-models.ts:1212-1215), so a compact poll
 	// must NOT carry it.
 	if gotHeartbeat != "" {
 		t.Errorf("x-freebuff-heartbeat = %q, want absent on compact polls", gotHeartbeat)

--- a/backend/internal/upstream/effort_mirror_test.go
+++ b/backend/internal/upstream/effort_mirror_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // The upstream server's effort authority reads
-// codebuff_metadata.freebuff_reasoning_effort (reference/freebuff
+// codebuff_metadata.freebuff_reasoning_effort (upstream/freebuff
 // freebuff-models.ts resolveFreebuffReasoningEffort; the CLI carries its
 // /reasoning pick there per request — use-send-message.ts:602-608). The proxy
 // mirrors the normalized top-level reasoning_effort into that field, and must

--- a/backend/internal/upstream/errors.go
+++ b/backend/internal/upstream/errors.go
@@ -63,7 +63,7 @@ var (
 	// over its concurrent-tab budget; this session's row is fine
 	// (endsTheSession:false). Distinct from ErrSessionInvalid so the server
 	// surfaces 409 and never refreshes/recreates the session
-	// (reference/freebuff freebuff-session.ts FREEBUFF_GATE_CODES).
+	// (upstream/freebuff freebuff-session.ts FREEBUFF_GATE_CODES).
 	ErrSessionLimitReached = errors.New("upstream session limit reached")
 	// ErrWaitingRoomRequired: 428 waiting_room_required — the account must
 	// walk the reference pre-session flow (request_ad_chain + get_streak)
@@ -74,7 +74,7 @@ var (
 	// fires before the next create. Retryable with Retry-After honored, NO
 	// token cooldown, and deliberately DISTINCT from ErrSessionInvalid:
 	// the recovery is re-admit-once, never the invalidate+refresh loop
-	// (reference/freebuff freebuff-session.ts FREEBUFF_GATE_CODES,
+	// (upstream/freebuff freebuff-session.ts FREEBUFF_GATE_CODES,
 	// send-message.ts handleFreebuffGateError).
 	ErrWaitingRoomRequired = errors.New("upstream waiting room required")
 	// ErrModelIPLimited: the egress IP cannot serve the requested model
@@ -90,7 +90,7 @@ var (
 	// NOT auto-reacquire within the same request (auto-takeover risks
 	// ping-pong with the other instance) — it drops the cached row so the
 	// NEXT request re-joins fresh and surfaces 409 session_superseded
-	// (reference/freebuff freebuff-session.ts FREEBUFF_GATE_CODES,
+	// (upstream/freebuff freebuff-session.ts FREEBUFF_GATE_CODES,
 	// send-message.ts handleFreebuffGateError, use-freebuff-session.ts
 	// nextDelayMs returns null for superseded = stop polling).
 	ErrSessionSuperseded = errors.New("upstream session superseded")
@@ -323,7 +323,7 @@ func (e *CapacityDeferredError) Unwrap() error {
 // hold an active free session on this egress IP. Admission-only — existing
 // sessions on the IP keep running, and the request succeeds once one of them
 // ends — so unlike RateLimitError it is NOT tied to a quota reset upstream.
-// RetryAfter comes from the body's retryAfterMs only (reference/freebuff
+// RetryAfter comes from the body's retryAfterMs only (upstream/freebuff
 // freebuff-session.ts). The proxy's CooldownIpCapped applies the bounded
 // re-admission policy (#118): full retryAfter + jitter per hit, with a
 // per-token daily cap that locks until the Pacific-midnight reset.

--- a/backend/internal/upstream/login/fingerprint.go
+++ b/backend/internal/upstream/login/fingerprint.go
@@ -1,5 +1,5 @@
 // Package login holds the pure helpers behind the headless OAuth login flow:
-// the device fingerprint (mirroring reference/freebuff cli/src/utils/
+// the device fingerprint (mirroring upstream/freebuff cli/src/utils/
 // fingerprint.ts), the GitHub protocol HTML form parsers and the RFC 6238 TOTP
 // code generator. The transport-coupled Client methods (StartCLILogin,
 // PollCLILogin, ProtocolGitHubLogin) stay in the upstream wire package, which
@@ -23,7 +23,7 @@ import (
 )
 
 // The login fingerprint mirrors the official CLI's enhanced device
-// fingerprint (reference/freebuff cli/src/utils/fingerprint.ts:88-128):
+// fingerprint (upstream/freebuff cli/src/utils/fingerprint.ts:88-128):
 // sha256 over a deterministic machine JSON, base64url-encoded, prefixed
 // "enhanced-" — 43 chars total suffix. It is INTENTIONALLY stable across
 // restarts (anonymous-id.ts:20-24: anti-abuse determinism), so the id is

--- a/backend/internal/upstream/session.go
+++ b/backend/internal/upstream/session.go
@@ -16,7 +16,7 @@ func (c *Client) CreateSession(ctx context.Context) (*SessionState, error) {
 // CreateSessionForModel POSTs /api/v1/freebuff/session with the requested
 // model header. The POST carries NO body and therefore no Content-Type
 // (#120): the CLI's session POST is a bare fetch with Authorization + the
-// optional x-freebuff-model header only (reference/freebuff
+// optional x-freebuff-model header only (upstream/freebuff
 // freebuff-session-api.ts callFreebuffSession; codebuff-api.ts sets the
 // same request shape).
 
@@ -43,7 +43,7 @@ func (c *Client) GetSession(ctx context.Context, instanceID string) (*SessionSta
 
 // GetSessionWithOpts polls /api/v1/freebuff/session with an optional compact
 // response header. There is deliberately NO heartbeat option: the CLI never
-// sends x-freebuff-heartbeat (Desktop-only, reference/freebuff
+// sends x-freebuff-heartbeat (Desktop-only, upstream/freebuff
 // freebuff-models.ts:1212-1215); liveness comes from the recurring compact
 // GET itself.
 func (c *Client) GetSessionWithOpts(ctx context.Context, instanceID string, compact bool) (*SessionState, error) {
@@ -216,7 +216,7 @@ func (c *Client) StartRun(ctx context.Context, agentID string) (string, error) {
 	}
 	// Dual-auth parity (current vendor wire): the agent-runtime client sends
 	// BOTH Authorization and x-codebuff-api-key (the same raw token) on its
-	// agent-runs/run POSTs (reference/freebuff packages/agent-runtime/src/
+	// agent-runs/run POSTs (upstream/freebuff packages/agent-runtime/src/
 	// llm-api/codebuff-web-api.ts:70-71,301-302); the shipped CLI confirms
 	// it. Applied AFTER newRequest's scrub, so any relayed/downstream
 	// x-codebuff-api-key copy is overwritten by the authenticated token
@@ -254,7 +254,7 @@ func (c *Client) StartRun(ctx context.Context, agentID string) (string, error) {
 }
 
 // RunStep is one agent-run step, batched in memory and sent WITH FINISH
-// (issue #114, CLI parity: reference/freebuff/sdk/src/impl/database.ts
+// (issue #114, CLI parity: upstream/freebuff/sdk/src/impl/database.ts
 // pendingAgentStepSchema — the CLI has NO /steps endpoint, so steps ride
 // the FINISH payload). The proxy records one step per completed chat call.
 type RunStep struct {
@@ -279,7 +279,7 @@ type RunStep struct {
 
 // FinishRun POSTs /api/v1/agent-runs with action FINISH, reporting the
 // run's honest terminal status and its completed steps (issue #114, CLI
-// parity: reference/freebuff/sdk/src/impl/database.ts finishAgentRun — the
+// parity: upstream/freebuff/sdk/src/impl/database.ts finishAgentRun — the
 // full payload is sent in ONE request; there is no /steps endpoint).
 // totalSteps is the step count the manager reports (len(steps) preferred,
 // falling back to the request count when no steps were recorded);
@@ -314,7 +314,7 @@ func (c *Client) FinishRun(ctx context.Context, runID, status string, totalSteps
 	}
 	// Dual-auth parity (current vendor wire): agent-runs POSTs carry BOTH
 	// Authorization and x-codebuff-api-key (the same raw token), mirroring
-	// the agent-runtime's agent-runs/run POSTs (reference/freebuff
+	// the agent-runtime's agent-runs/run POSTs (upstream/freebuff
 	// packages/agent-runtime/src/llm-api/codebuff-web-api.ts:70-71,301-302)
 	// and the shipped CLI. Set after newRequest's scrub overwrites any
 	// relayed/downstream x-codebuff-api-key copy with the authenticated

--- a/backend/internal/upstream/session_types_quota.go
+++ b/backend/internal/upstream/session_types_quota.go
@@ -4,7 +4,7 @@ import "time"
 
 // ModelQuota is one model's live session quota from the upstream
 // rateLimitsByModel map, per the official CLI wire shape
-// (reference/freebuff/common/src/types/freebuff-session.ts).
+// (upstream/freebuff/common/src/types/freebuff-session.ts).
 // Entitlement holds the per-period breakdown (base/referral/streak/promo;
 // promo is omitted by default) that sums to Limit when the server emits it.
 type ModelQuota struct {

--- a/backend/internal/upstream/session_types_standing.go
+++ b/backend/internal/upstream/session_types_standing.go
@@ -24,7 +24,7 @@ type SessionReferral struct {
 // parseFlexTime; zero when the server omits it.
 //
 // CappedBy/CappedReason name the trust cap holding the account at its level
-// (e.g. third_party_client, anonymous_network — reference/freebuff
+// (e.g. third_party_client, anonymous_network — upstream/freebuff
 // freebuff-trust.ts FreebuffStandingInfo), Blurb is the human explanation,
 // and NextSteps are the earn-back actions upstream suggests (issue #140).
 type SessionStanding struct {

--- a/backend/internal/upstream/tokenhealth.go
+++ b/backend/internal/upstream/tokenhealth.go
@@ -12,7 +12,7 @@
 // find dead or risky tokens before the pool burns requests on them.
 //
 // Email-domain lists mirror @codebuff/common/src/util/disposable-email.ts
-// (reference/freebuff common/src/util/disposable-email.ts): exact-domain or
+// (upstream/freebuff common/src/util/disposable-email.ts): exact-domain or
 // any-subdomain match, case-insensitive. Lists are deliberately curated —
 // lookalikes/substrings that are not exact entries (gmisel.com,
 // mailinator.com.evil.com) are never flagged, exactly like upstream.
@@ -401,7 +401,7 @@ func rateLimitResetHint(rle *RateLimitError) string {
 // --- email-domain classification (mirrors disposable-email.ts) ---
 
 // disposableDomains mirrors DISPOSABLE_EMAIL_DOMAINS in
-// reference/freebuff common/src/util/disposable-email.ts:31-219 — the
+// upstream/freebuff common/src/util/disposable-email.ts:31-219 — the
 // one-time inbox providers plus the farm-observed rings, exactly as curated
 // upstream (no lookalike that the upstream list deliberately excludes).
 var disposableDomains = newDomainSet(

--- a/backend/internal/upstream/tokenhealth_test.go
+++ b/backend/internal/upstream/tokenhealth_test.go
@@ -96,7 +96,7 @@ func healthClient(t *testing.T, token string, index int, baseURL string) *Client
 }
 
 // TestClassifyEmailDomain pins the port of upstream's classifier
-// (reference/freebuff common/src/util/disposable-email.ts): exact-domain or
+// (upstream/freebuff common/src/util/disposable-email.ts): exact-domain or
 // any-subdomain match, case-insensitive, and — critically — no lookalike or
 // substring that upstream itself deliberately excludes.
 func TestClassifyEmailDomain(t *testing.T) {

--- a/backend/internal/upstream/wire_helpers.go
+++ b/backend/internal/upstream/wire_helpers.go
@@ -90,7 +90,7 @@ func truncate(s string, n int) string {
 
 // truncateRunes truncates s to at most max runes without an ellipsis. The
 // CLI's FINISH errorMessage cap is 5000 chars (truncateString in
-// reference/freebuff/sdk/src/impl/database.ts), applied on the whole
+// upstream/freebuff/sdk/src/impl/database.ts), applied on the whole
 // payload — a full Go stack trace must not blow the cap.
 func truncateRunes(s string, max int) string {
 	if max <= 0 {

--- a/scripts/check-upstream.sh
+++ b/scripts/check-upstream.sh
@@ -75,8 +75,8 @@ if [[ -n "${2:-}" ]]; then
 	CLONE_DIR="$2"
 elif [[ -n "${FREEBUFF_REFERENCE_DIR:-}" ]]; then
 	CLONE_DIR="$FREEBUFF_REFERENCE_DIR"
-elif [[ -d "$REPO_ROOT/specialize/freebuff/.git" ]]; then
-	CLONE_DIR="$REPO_ROOT/specialize/freebuff"
+elif [[ -d "$REPO_ROOT/upstream/freebuff/.git" ]]; then
+	CLONE_DIR="$REPO_ROOT/upstream/freebuff"
 else
 	CLONE_DIR="$REPO_ROOT/../freebuff-reference"
 fi

--- a/scripts/repin-all.sh
+++ b/scripts/repin-all.sh
@@ -4,9 +4,9 @@
 # Usage:
 #   scripts/repin-all.sh [--dry-run] <vendor-sha> [clone-dir]
 #
-#   vendor-sha  full 40-char upstream commit SHA in specialize/freebuff
+#   vendor-sha  full 40-char upstream commit SHA in upstream/freebuff
 #   clone-dir   local reference clone (default: $FREEBUFF_REFERENCE_DIR,
-#               else <repo>/specialize/freebuff)
+#               else <repo>/upstream/freebuff)
 #   --dry-run   classify drift and print the planned refresh plus the exact
 #               gh commands for the three PRs; write nothing
 #
@@ -39,7 +39,7 @@ if [[ "${1:-}" == "--dry-run" ]]; then
   shift
 fi
 VENDOR_SHA="${1:-}"
-CLONE_DIR="${2:-${FREEBUFF_REFERENCE_DIR:-$REPO_ROOT/specialize/freebuff}}"
+CLONE_DIR="${2:-${FREEBUFF_REFERENCE_DIR:-$REPO_ROOT/upstream/freebuff}}"
 WIRE_DIR="$REPO_ROOT/backend/internal/wirefacts/testdata/wire"
 SNAPSHOTS="$WIRE_DIR/snapshots.json"
 

--- a/scripts/review-wire-drift.sh
+++ b/scripts/review-wire-drift.sh
@@ -8,7 +8,7 @@
 #   scripts/review-wire-drift.sh [baseline.tsv] [end_ref]
 #
 # Environment:
-#   FREEBUFF_REFERENCE_DIR  upstream clone (default specialize/freebuff);
+#   FREEBUFF_REFERENCE_DIR  upstream clone (default upstream/freebuff);
 #                           must have the end_ref fetched
 #   FREEBUFF_REVIEW_END_REF explicit ref/SHA to classify against (default
 #                           origin/main); a positional end_ref wins
@@ -29,7 +29,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BASELINE_FILE="${1:-$REPO_ROOT/scripts/wire-baseline.tsv}"
-CLONE_DIR="${FREEBUFF_REFERENCE_DIR:-$REPO_ROOT/specialize/freebuff}"
+CLONE_DIR="${FREEBUFF_REFERENCE_DIR:-$REPO_ROOT/upstream/freebuff}"
 
 [[ -f "$BASELINE_FILE" ]] || { echo "baseline file not found: $BASELINE_FILE" >&2; exit 2; }
 if [[ -n "${2:-}" ]]; then

--- a/scripts/sync-upstream.ps1
+++ b/scripts/sync-upstream.ps1
@@ -52,8 +52,8 @@ if (-not $CloneDir) {
     if ($env:FREEBUFF_REFERENCE_DIR) {
         $CloneDir = $env:FREEBUFF_REFERENCE_DIR
     }
-    elseif (Test-Path (Join-Path $RepoRoot "reference\freebuff\.git")) {
-        $CloneDir = Join-Path $RepoRoot "reference\freebuff"
+    elseif (Test-Path (Join-Path $RepoRoot "upstream\freebuff\.git")) {
+        $CloneDir = Join-Path $RepoRoot "upstream\freebuff"
     }
     else {
         $CloneDir = Join-Path $RepoRoot "..\freebuff-reference"

--- a/scripts/sync-upstream.sh
+++ b/scripts/sync-upstream.sh
@@ -18,7 +18,7 @@
 #
 # Arguments:
 #   ref                       Upstream branch or commit SHA (default: main)
-#   clone-dir                 Local reference clone directory (default: specialize/freebuff,
+#   clone-dir                 Local reference clone directory (default: upstream/freebuff,
 #                             $FREEBUFF_REFERENCE_DIR, or ../freebuff-reference)
 #
 # Examples:
@@ -100,8 +100,8 @@ done
 if [[ -z "$CLONE_DIR" ]]; then
 	if [[ -n "${FREEBUFF_REFERENCE_DIR:-}" ]]; then
 		CLONE_DIR="$FREEBUFF_REFERENCE_DIR"
-	elif [[ -d "$REPO_ROOT/specialize/freebuff/.git" ]]; then
-		CLONE_DIR="$REPO_ROOT/specialize/freebuff"
+	elif [[ -d "$REPO_ROOT/upstream/freebuff/.git" ]]; then
+		CLONE_DIR="$REPO_ROOT/upstream/freebuff"
 	else
 		CLONE_DIR="$REPO_ROOT/../freebuff-reference"
 	fi


### PR DESCRIPTION
Single gitignored source of truth at upstream/freebuff (.gitignore rooted /upstream/, clone ignored). 4 .sh resolvers + ps1 point there with FREEBUFF_REFERENCE_DIR-first order kept. 76 backend comment paths updated; reference/freebuff-* study dirs untouched; prose intact. AGENTS.md topology updated. Local proof limited to grep + bash -n + diff audit per no-local-bin rule; Linux CI is the test proof.