### PR TITLE
feat(config): env-to-DB migration with boot auto-migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ Then:
 Defaults that matter (`.env.example`): `SAFE_MODE=true` (anti-ban preset),
 `COST_MODE=free`, 30 req/min and 1500 req/day Pacific limits.
 
+Configuration persistence: the first boot imports the effective config
+(process env wins over `.env` over defaults) into the dashboard DB
+(`data/freebuff.db`, mode `0600`) as `config:` overlay rows plus a
+`config:migrated_env_v1` marker — later boots are no-ops via the marker.
+The DB is then the persisted home the dashboard saves write to, secrets
+included (`AUTH_TOKENS`, `ADMIN_TOKEN`, `API_KEYS`, `WEBHOOK_URL` rows);
+keep its `0600` mode on copies/backups. Explicit process env still wins at
+runtime, so a migrated row never overrides the environment.
+
 ## Layout
 
 - `backend/` — gateway source.

--- a/backend/internal/cli/cli_env_migrate.go
+++ b/backend/internal/cli/cli_env_migrate.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"freebuff-proxy/backend/internal/config"
+	history "freebuff-proxy/backend/internal/store"
+)
+
+// migrateEnvToDB is the env-to-DB migration: the first boot whose settings
+// table lacks the marker row imports every effective knob (process env wins
+// over the .env file over JSON -config over defaults — the cfg passed in is
+// already resolved in that precedence by LoadOpts) into config: overlay rows,
+// then sets the marker. It returns the imported row count; a present marker
+// (or a nil store) is a no-op returning 0. A failure before the marker is
+// set retries on the next boot: half-imported rows are harmless because the
+// same effective values re-export identically, and explicit process env keeps
+// winning over every row at runtime.
+func migrateEnvToDB(st *history.Store, cfg config.Config) (int, error) {
+	if st == nil {
+		return 0, nil
+	}
+	if _, ok, err := st.GetSetting(config.MigrationMarkerRow); err != nil {
+		return 0, err
+	} else if ok {
+		return 0, nil
+	}
+	rows := config.EffectiveOverlayMap(cfg)
+	for _, def := range config.Catalog() {
+		if err := st.SetSetting(config.OverlayRowKey(def.Key), rows[def.Key]); err != nil {
+			return 0, err
+		}
+	}
+	if err := st.SetSetting(config.MigrationMarkerRow, config.MigrationMarkerValue); err != nil {
+		return 0, err
+	}
+	return len(rows), nil
+}

--- a/backend/internal/cli/cli_env_migrate_test.go
+++ b/backend/internal/cli/cli_env_migrate_test.go
@@ -1,0 +1,139 @@
+package cli
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"freebuff-proxy/backend/internal/config"
+	history "freebuff-proxy/backend/internal/store"
+
+	_ "modernc.org/sqlite"
+)
+
+// migrateTestConfig loads an env-pinned effective config in an isolated
+// directory (no repo .env leaks in) with CLI discovery disabled.
+func migrateTestConfig(t *testing.T) config.Config {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	t.Setenv("AUTO_DISCOVER_TOKEN", "false")
+	t.Setenv("AUTH_TOKENS", "fb-test-fake-token-1")
+	t.Setenv("ADMIN_TOKEN", "fb-test-fake-admin-1")
+	t.Setenv("LOG_LEVEL", "debug")
+	cfg, err := config.LoadOpts("", config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("LoadOpts: %v", err)
+	}
+	return cfg
+}
+
+func migrateTestStore(t *testing.T) *history.Store {
+	t.Helper()
+	st, err := history.Open(filepath.Join(t.TempDir(), "migrate.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+// TestMigrateEnvToDBFreshImport pins the first boot: every catalog key lands
+// as a config: row plus the marker, and the second boot imports nothing.
+func TestMigrateEnvToDBFreshImport(t *testing.T) {
+	st := migrateTestStore(t)
+	cfg := migrateTestConfig(t)
+
+	n, err := migrateEnvToDB(st, cfg)
+	if err != nil {
+		t.Fatalf("migrateEnvToDB: %v", err)
+	}
+	if n != len(config.Catalog()) {
+		t.Errorf("imported %d rows, want %d (every catalog key)", n, len(config.Catalog()))
+	}
+	rows, err := st.ListSettings()
+	if err != nil {
+		t.Fatalf("ListSettings: %v", err)
+	}
+	for _, def := range config.Catalog() {
+		if _, ok := rows[config.OverlayRowKey(def.Key)]; !ok {
+			t.Errorf("missing row %s after migration", config.OverlayRowKey(def.Key))
+		}
+	}
+	if rows[config.MigrationMarkerRow] != config.MigrationMarkerValue {
+		t.Errorf("marker row = %q, want %q", rows[config.MigrationMarkerRow], config.MigrationMarkerValue)
+	}
+	// The migrated secret rows carry the env-pinned values (fake only).
+	if rows[config.OverlayRowKey("AUTH_TOKENS")] != "fb-test-fake-token-1" {
+		t.Errorf("AUTH_TOKENS row = %q, want the migrated pool", rows[config.OverlayRowKey("AUTH_TOKENS")])
+	}
+	if rows[config.OverlayRowKey("ADMIN_TOKEN")] != "fb-test-fake-admin-1" {
+		t.Error("ADMIN_TOKEN row missing the migrated credential")
+	}
+
+	// Second boot is a no-op: nothing imported, rows untouched.
+	n, err = migrateEnvToDB(st, cfg)
+	if err != nil {
+		t.Fatalf("second migrateEnvToDB: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("second boot imported %d rows, want 0 (marker no-op)", n)
+	}
+	after, err := st.ListSettings()
+	if err != nil {
+		t.Fatalf("ListSettings: %v", err)
+	}
+	if len(after) != len(rows) {
+		t.Errorf("second boot changed row count %d -> %d, want no change", len(rows), len(after))
+	}
+}
+
+// TestMigrateEnvToDBLegacyV4ThenImport pins the upgrade path: a pre-goose v4
+// file (user_version=4, persistence tables, no marker) opens through the
+// goose baseline with its rows intact, then imports the env config.
+func TestMigrateEnvToDBLegacyV4ThenImport(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy-v4.db")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	// Minimal v4 shape: the settings table plus the pool_state table 00004
+	// adds (probes lift the baseline), stamped user_version=4, one
+	// pre-existing control row that must survive.
+	for _, ddl := range []string{
+		`CREATE TABLE settings(key TEXT PRIMARY KEY, value TEXT NOT NULL DEFAULT '', updated_at INTEGER NOT NULL DEFAULT 0)`,
+		`CREATE TABLE pool_state(key TEXT PRIMARY KEY, value TEXT NOT NULL DEFAULT '', updated_at INTEGER NOT NULL DEFAULT 0)`,
+		`INSERT INTO settings(key, value, updated_at) VALUES('ui/theme', 'dark', 1)`,
+		`PRAGMA user_version=4`,
+	} {
+		if _, err := raw.Exec(ddl); err != nil {
+			t.Fatalf("legacy v4 seed %q: %v", ddl, err)
+		}
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw close: %v", err)
+	}
+
+	st, err := history.Open(path)
+	if err != nil {
+		t.Fatalf("Open on v4 file: %v (want in-place migration, not rejection)", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if v, ok, err := st.GetSetting("ui/theme"); err != nil || !ok || v != "dark" {
+		t.Fatalf("legacy row lost in migration: %q %v %v", v, ok, err)
+	}
+
+	cfg := migrateTestConfig(t)
+	n, err := migrateEnvToDB(st, cfg)
+	if err != nil {
+		t.Fatalf("migrateEnvToDB on migrated v4: %v", err)
+	}
+	if n != len(config.Catalog()) {
+		t.Errorf("imported %d rows, want %d", n, len(config.Catalog()))
+	}
+	if v, ok, err := st.GetSetting("ui/theme"); err != nil || !ok || v != "dark" {
+		t.Errorf("legacy row lost in import: %q %v %v", v, ok, err)
+	}
+	if _, ok, err := st.GetSetting(config.MigrationMarkerRow); err != nil || !ok {
+		t.Errorf("marker missing after import: %v %v", ok, err)
+	}
+}

--- a/backend/internal/cli/cli_serve.go
+++ b/backend/internal/cli/cli_serve.go
@@ -115,6 +115,20 @@ func Serve(configPath string, verbose bool, version string) int {
 			}
 		}
 	}
+	// Env-to-DB migration: the first boot with a marker-less settings table
+	// imports the just-loaded effective config (env > file > defaults) into
+	// config: overlay rows so later boots — and the dashboard — run from the
+	// DB alone. Re-runs are no-ops via the marker; explicit process env
+	// keeps winning over every migrated row at runtime. A nil store (DB
+	// failed to open above) skips silently — live-only, nothing to persist
+	// to. Key names and the row count log here, never values.
+	if histStore != nil {
+		if n, err := migrateEnvToDB(histStore, cfg); err != nil {
+			logger.Warn("env-to-DB migration failed; running on file/env/overlay", "err", err)
+		} else if n > 0 {
+			logger.Info("migrated env config to DB overlay", "keys", n, "marker", config.MigrationMarkerRow)
+		}
+	}
 
 	// Load the hardcoded fallback immediately so the registry is usable
 	// offline; the first background refresh replaces it on success.

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -43,15 +43,21 @@ type Config struct {
 	// The only safe value is the token's own account id. (True CLI parity —
 	// auto-deriving each token's own id once via GET /api/v1/me — is
 	// deferred; see the gap analysis item 24.)
-	ActingUserID    string
-	TLSFingerprint  string // "" (plain Go transport) | chrome120 | chrome126 | safari17 | safari18 | firefox120 | firefox128 | edge126 | random | auto
-	RegistryRefresh time.Duration
-	DebugDump       bool
-	DevToolsEnabled bool
-	LogFile         string
-	LogLevel        string // "" (use -v/default) or debug|info|warn|error|trace
-	LogFormat       string // "text" (default) or "json"
-	LogAccess       bool   // true = per-request access log lines (LOG_ACCESS; default true, an empty .env line keeps it enabled)
+	ActingUserID string
+	// AutoDiscoverToken records the effective AUTO_DISCOVER_TOKEN knob
+	// (default true): process env wins, else the DB overlay, else enabled.
+	// When false, an empty AUTH_TOKENS pool stays empty (bridge mode) and
+	// the CLI-credential discovery hook never fires; ADOPT_CLI_SESSION can
+	// still opt into discovery on its own.
+	AutoDiscoverToken bool
+	TLSFingerprint    string // "" (plain Go transport) | chrome120 | chrome126 | safari17 | safari18 | firefox120 | firefox128 | edge126 | random | auto
+	RegistryRefresh   time.Duration
+	DebugDump         bool
+	DevToolsEnabled   bool
+	LogFile           string
+	LogLevel          string // "" (use -v/default) or debug|info|warn|error|trace
+	LogFormat         string // "text" (default) or "json"
+	LogAccess         bool   // true = per-request access log lines (LOG_ACCESS; default true, an empty .env line keeps it enabled)
 	// LogRingSize is the bounded in-memory log ring capacity behind the
 	// dashboard log viewer (LOG_RING_SIZE; default 500, validated 50..5000).
 	LogRingSize       int

--- a/backend/internal/config/config_load.go
+++ b/backend/internal/config/config_load.go
@@ -31,9 +31,13 @@ type LoadOptions struct {
 	// Overlay is the DB settings overlay (ADR-0019): canonical KEY -> raw
 	// VALUE pairs applied after the .env file and before the process
 	// environment, so UI-persisted knobs beat the file without rewriting
-	// it while explicit process env keeps winning. Blocked keys (secrets,
-	// UPSTREAM_BASE_URL, DB_PATH) are filtered, never applied. Nil or empty
-	// behaves like Load.
+	// it while explicit process env keeps winning. Since the env-to-DB
+	// migration every catalog key is overlay-addressable, secrets included
+	// (the DB file holds them at mode 0600); AUTH_TOKENS applies with
+	// presence semantics (an empty row pins bridge mode and suppresses CLI
+	// auto-discovery, mirroring the .env tier), and AUTO_DISCOVER_TOKEN is
+	// honored from the overlay only when the process environment leaves it
+	// unset. Nil or empty behaves like Load.
 	Overlay map[string]string
 }
 
@@ -587,11 +591,19 @@ func LoadOpts(configPath string, opts LoadOptions) (Config, error) {
 	// also opts into discovery: the operator explicitly asked to run like
 	// the CLI, so AUTO_DISCOVER_TOKEN=false must not silently leave the
 	// pool empty.
+	// AUTO_DISCOVER_TOKEN resolves process env > DB overlay > default true,
+	// like every other knob (the overlay only counts when the environment
+	// leaves it unset). It records on the config so the dashboard and the
+	// env-to-DB migration export the effective value instead of hardcoding
+	// it.
+	autoDiscover := true
+	if v, ok := os.LookupEnv("AUTO_DISCOVER_TOKEN"); ok {
+		autoDiscover = !isFalseWord(v)
+	} else if v, ok := opts.Overlay["AUTO_DISCOVER_TOKEN"]; ok {
+		autoDiscover = !isFalseWord(v)
+	}
+	cfg.AutoDiscoverToken = autoDiscover
 	if opts.DiscoverCLIToken != nil {
-		autoDiscover := true
-		if v := strings.ToLower(strings.TrimSpace(os.Getenv("AUTO_DISCOVER_TOKEN"))); v == "false" || v == "0" || v == "off" || v == "no" {
-			autoDiscover = false
-		}
 		if (autoDiscover || cfg.AdoptCLISession) && len(cfg.AuthTokens) == 0 && !raw.AuthTokensSet {
 			if token, email, srcPath, ok := opts.DiscoverCLIToken(); ok {
 				cfg.AuthTokens = []string{token}
@@ -801,6 +813,18 @@ func parseBool(s string) (bool, bool) {
 		return false, true
 	}
 	return false, false
+}
+
+// isFalseWord reports whether s disables a flag in the AUTO_DISCOVER_TOKEN
+// convention: "false"/"0"/"off"/"no" (case-insensitive, trimmed). Anything
+// else — including blank — leaves the flag enabled, matching the loader's
+// long-standing reading of the variable.
+func isFalseWord(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "false", "0", "off", "no":
+		return true
+	}
+	return false
 }
 
 // parseCSV splits a comma-separated value via splitList.

--- a/backend/internal/config/data.go
+++ b/backend/internal/config/data.go
@@ -162,7 +162,7 @@ func renderKey(c *Config, key string) (val string, valueIsSecret bool) {
 	case "HTTP2_UPSTREAM":
 		return strconv.FormatBool(c.HTTP2Upstream), false
 	case "AUTO_DISCOVER_TOKEN":
-		return "true", false
+		return strconv.FormatBool(c.AutoDiscoverToken), false
 	case "DEVTOOLS_ENABLED":
 		return strconv.FormatBool(c.DevToolsEnabled), false
 	case "ADOPT_CLI_SESSION":

--- a/backend/internal/config/settings_migrate.go
+++ b/backend/internal/config/settings_migrate.go
@@ -71,7 +71,7 @@ func effectiveRawValue(cfg Config, key string) string {
 		// documents the migrated value but never drives the reader.
 		return strconv.FormatBool(effectiveAdminForceSecureCookies())
 	default:
-		v, _ := renderKey(cfg, key)
+		v, _ := renderKey(&cfg, key)
 		return v
 	}
 }

--- a/backend/internal/config/settings_migrate.go
+++ b/backend/internal/config/settings_migrate.go
@@ -16,9 +16,9 @@ import (
 // dashboard saves write to, not a new winner.
 
 // MigrationMarkerRow is the settings-table row whose presence means the
-// env-to-DB import already ran. It lives outside the OverlayRowPrefix
-// namespace on purpose: OverlayFromRows only accepts catalog keys, so the
-// marker can never leak into a Load overlay.
+// env-to-DB import already ran. It shares the config: prefix but is not a
+// catalog key, so OverlayFromRows drops it and it can never leak into a
+// Load overlay.
 const MigrationMarkerRow = "config:migrated_env_v1"
 
 // MigrationMarkerValue is the value stored at MigrationMarkerRow.

--- a/backend/internal/config/settings_migrate.go
+++ b/backend/internal/config/settings_migrate.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Env-to-DB migration (config:migrated_env_v1): the first boot with a settings
+// table that lacks the marker row imports every effective knob — process env
+// wins over the .env file over JSON -config over built-in defaults, the same
+// precedence LoadOpts resolves — into config: overlay rows, then sets the
+// marker. Later boots are no-ops via the marker, and explicit process env
+// keeps winning over every migrated row at runtime, so precedence never
+// silently changes for existing users: the DB becomes the persisted home the
+// dashboard saves write to, not a new winner.
+
+// MigrationMarkerRow is the settings-table row whose presence means the
+// env-to-DB import already ran. It lives outside the OverlayRowPrefix
+// namespace on purpose: OverlayFromRows only accepts catalog keys, so the
+// marker can never leak into a Load overlay.
+const MigrationMarkerRow = "config:migrated_env_v1"
+
+// MigrationMarkerValue is the value stored at MigrationMarkerRow.
+const MigrationMarkerValue = "1"
+
+// EffectiveOverlayMap renders the effective configuration back to raw overlay
+// strings (canonical KEY -> raw VALUE) for every catalog key: the exact map
+// the migration persists as config: rows. Secrets render raw, never masked —
+// the settings table lives in the dashboard DB file (0600, enforced at open)
+// and is their persisted home. Empty values render as "" (a no-op pin at
+// Load, except AUTH_TOKENS presence, which is the explicit bridge-mode choice
+// that suppresses CLI auto-discovery).
+func EffectiveOverlayMap(cfg Config) map[string]string {
+	out := make(map[string]string, len(keyCatalog))
+	for _, def := range keyCatalog {
+		out[def.Key] = effectiveRawValue(cfg, def.Key)
+	}
+	return out
+}
+
+// effectiveRawValue renders one catalog key's effective value as the raw
+// string its overlay row (or .env line) would carry. Non-secret Config-backed
+// keys reuse renderKey, whose display rendering is already the canonical raw
+// shape (durations via String, bools, ints, canonical joins); the keys below
+// need raw (unmasked) or Config-field-less handling instead.
+func effectiveRawValue(cfg Config, key string) string {
+	switch key {
+	case "AUTH_TOKENS":
+		return strings.Join(cfg.AuthTokens, ",")
+	case "API_KEYS":
+		return strings.Join(cfg.APIKeys, ",")
+	case "ADMIN_TOKEN":
+		return cfg.AdminToken
+	case "WEBHOOK_URL":
+		return cfg.WebhookURL
+	case "AUTO_DISCOVER_TOKEN":
+		return strconv.FormatBool(cfg.AutoDiscoverToken)
+	case "ACTING_USER_ID":
+		return cfg.ActingUserID
+	case "COMPRESS_PROMPT":
+		return strconv.FormatBool(cfg.CompressPrompt)
+	case "CACHE_CONTROL_INJECTION":
+		return strconv.FormatBool(cfg.CacheControlInjection)
+	case "REASONING_IN_CONTENT":
+		return cfg.ReasoningInContent
+	case "ADMIN_FORCE_SECURE_COOKIES":
+		// No Config field: the reader (server isSecureCookie) consults the
+		// process environment with a .env fallback on every request, never
+		// the overlay. Snapshot the same resolution for reference; the row
+		// documents the migrated value but never drives the reader.
+		return strconv.FormatBool(effectiveAdminForceSecureCookies())
+	default:
+		v, _ := renderKey(cfg, key)
+		return v
+	}
+}
+
+// effectiveAdminForceSecureCookies mirrors the server's per-request secure
+// cookie resolution (process env wins, else the .env file, else false) so
+// the migration snapshot records the value actually in force. True words
+// follow the historical convention: "true"/"1"/"yes".
+func effectiveAdminForceSecureCookies() bool {
+	if v, ok := os.LookupEnv("ADMIN_FORCE_SECURE_COOKIES"); ok {
+		return isTrueWord(v)
+	}
+	if dotenv := readDotenvFile(); dotenv != nil {
+		if v, ok := dotenv["ADMIN_FORCE_SECURE_COOKIES"]; ok {
+			return isTrueWord(strings.Trim(v, `"'`))
+		}
+	}
+	return false
+}
+
+// isTrueWord reports whether s enables a flag in the secure-cookies
+// convention ("true"/"1"/"yes", case-insensitive, trimmed).
+func isTrueWord(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "true", "1", "yes":
+		return true
+	}
+	return false
+}

--- a/backend/internal/config/settings_migrate_test.go
+++ b/backend/internal/config/settings_migrate_test.go
@@ -147,6 +147,11 @@ func TestEffectiveOverlayEmptyPoolPinsBridge(t *testing.T) {
 func TestMigratedKeysReportDB(t *testing.T) {
 	clearEnv(t)
 	t.Chdir(t.TempDir())
+	// clearEnv pins AUTO_DISCOVER_TOKEN=false in the environment (which
+	// correctly wins); unset it so the overlay tier reports below.
+	if err := os.Unsetenv("AUTO_DISCOVER_TOKEN"); err != nil {
+		t.Fatal(err)
+	}
 	overlay := map[string]string{
 		"AUTH_TOKENS":         "fb-test-fake-token-1",
 		"ADMIN_TOKEN":         "fb-test-fake-admin-1",

--- a/backend/internal/config/settings_migrate_test.go
+++ b/backend/internal/config/settings_migrate_test.go
@@ -1,0 +1,169 @@
+package config
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+// TestEffectiveOverlayCoversCatalog pins the migration contract: every
+// catalog key exports a row, so a fresh env-only boot lands all knobs as
+// config: rows plus the marker.
+func TestEffectiveOverlayCoversCatalog(t *testing.T) {
+	clearEnv(t)
+	t.Chdir(t.TempDir())
+	cfg, err := LoadOpts("", LoadOptions{})
+	if err != nil {
+		t.Fatalf("LoadOpts: %v", err)
+	}
+	exported := EffectiveOverlayMap(cfg)
+	for _, def := range Catalog() {
+		if _, ok := exported[def.Key]; !ok {
+			t.Errorf("EffectiveOverlayMap lacks catalog key %s", def.Key)
+		}
+	}
+	if len(exported) != len(Catalog()) {
+		t.Errorf("EffectiveOverlayMap has %d keys for %d catalog keys", len(exported), len(Catalog()))
+	}
+}
+
+// TestEffectiveOverlayRoundTrip pins the DB-alone boot: env-set values
+// (fake only) export to overlay rows that reproduce the identical effective
+// config once the environment is cleared — the migrated user runs from the
+// DB alone. The marker and foreign-namespace rows must not leak into the
+// overlay.
+func TestEffectiveOverlayRoundTrip(t *testing.T) {
+	clearEnv(t)
+	t.Chdir(t.TempDir())
+	// clearEnv pins AUTO_DISCOVER_TOKEN=false in the environment; the export
+	// must capture an explicit env value here, so set it directly.
+	envSet := map[string]string{
+		"AUTH_TOKENS":             "fb-test-fake-token-1,fb-test-fake-token-2",
+		"ADMIN_TOKEN":             "fb-test-fake-admin-1",
+		"API_KEYS":                "fb-test-fake-client-1",
+		"WEBHOOK_URL":             "https://example.invalid/hook",
+		"UPSTREAM_BASE_URL":       "https://example.invalid",
+		"LOG_LEVEL":               "debug",
+		"MAX_REQUESTS_PER_DAY":    "765",
+		"MAX_REQUESTS_PER_MINUTE": "7",
+		"SAFE_MODE":               "false",
+		"AUTO_DISCOVER_TOKEN":     "false",
+		"BRIDGE_ENABLED":          "false",
+		"MODELS_ALLOW":            "deepseek/deepseek-v4-flash",
+		"MODEL_LOCKS":             "0:z-ai/glm-5.2",
+		"FALLBACK_MODEL":          "a=b",
+		"REASONING_IN_CONTENT":    "thinking",
+		"RATE_LIMIT_PER_IP":       "2.5",
+		"BURST_WINDOW":            "90s",
+	}
+	for k, v := range envSet {
+		t.Setenv(k, v)
+	}
+	cfgEnv, err := LoadOpts("", LoadOptions{})
+	if err != nil {
+		t.Fatalf("LoadOpts from env: %v", err)
+	}
+	exported := EffectiveOverlayMap(cfgEnv)
+
+	// Simulate the settings-table dump: namespaced rows plus the marker and
+	// foreign rows the overlay must ignore.
+	rows := make(map[string]string, len(exported)+3)
+	for k, v := range exported {
+		rows[OverlayRowKey(k)] = v
+	}
+	rows[MigrationMarkerRow] = MigrationMarkerValue
+	rows["theme"] = "dark"
+	rows["config:NOPE_NOT_A_KEY"] = "x"
+	ov := OverlayFromRows(rows)
+	if _, ok := ov["MIGRATED_ENV_V1"]; ok {
+		t.Errorf("OverlayFromRows leaked the marker row into the overlay: %v", ov)
+	}
+	if len(ov) != len(exported) {
+		t.Errorf("OverlayFromRows kept %d of %d exported rows", len(ov), len(exported))
+	}
+
+	// DB-alone boot: the environment no longer pins anything.
+	for k := range envSet {
+		if err := os.Unsetenv(k); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfgDB, err := LoadOpts("", LoadOptions{Overlay: ov})
+	if err != nil {
+		t.Fatalf("LoadOpts from overlay: %v", err)
+	}
+	if !reflect.DeepEqual(cfgDB, cfgEnv) {
+		t.Errorf("DB-alone config differs from env config:\nDB:  %+v\nENV: %+v", cfgDB, cfgEnv)
+	}
+}
+
+// TestEffectiveOverlayEmptyPoolPinsBridge pins the bridge-mode export: an
+// explicitly-empty AUTH_TOKENS (the shape the dashboard mode switch persists
+// as "AUTH_TOKENS=" in .env) must survive as an empty overlay row whose
+// presence suppresses CLI auto-discovery — otherwise a migrated bridge user
+// would silently flip to pooled mode on the next boot.
+func TestEffectiveOverlayEmptyPoolPinsBridge(t *testing.T) {
+	clearEnv(t)
+	t.Chdir(t.TempDir())
+	if err := os.Unsetenv("AUTO_DISCOVER_TOKEN"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AUTH_TOKENS", "")
+	cfgEnv, err := LoadOpts("", LoadOptions{})
+	if err != nil {
+		t.Fatalf("LoadOpts: %v", err)
+	}
+	if !cfgEnv.BridgeMode() {
+		t.Fatal("env-loaded config not in bridge mode, want empty pool")
+	}
+	exported := EffectiveOverlayMap(cfgEnv)
+	v, ok := exported["AUTH_TOKENS"]
+	if !ok {
+		t.Fatal("EffectiveOverlayMap dropped empty AUTH_TOKENS, want the bridge pin")
+	}
+	if v != "" {
+		t.Errorf("AUTH_TOKENS export = %q, want empty (bridge pin)", v)
+	}
+	rows := map[string]string{OverlayRowKey("AUTH_TOKENS"): v}
+	ov := OverlayFromRows(rows)
+	if _, ok := ov["AUTH_TOKENS"]; !ok {
+		t.Fatalf("OverlayFromRows dropped the empty AUTH_TOKENS pin: %v", ov)
+	}
+	if err := os.Unsetenv("AUTH_TOKENS"); err != nil {
+		t.Fatal(err)
+	}
+	fakeDiscover := func() (string, string, string, bool) { return "fb-test-fake-discovered-1", "", "", true }
+	cfgDB, err := LoadOpts("", LoadOptions{DiscoverCLIToken: fakeDiscover, Overlay: ov})
+	if err != nil {
+		t.Fatalf("LoadOpts DB-alone: %v", err)
+	}
+	if !cfgDB.BridgeMode() {
+		t.Errorf("DB-alone AuthTokens = %v, want bridge mode (discovery suppressed by the pin)", cfgDB.AuthTokens)
+	}
+}
+
+// TestMigratedKeysReportDB pins the dashboard tier tags: every migrated key
+// reports source=db once its row exists (env still wins when set).
+func TestMigratedKeysReportDB(t *testing.T) {
+	clearEnv(t)
+	t.Chdir(t.TempDir())
+	overlay := map[string]string{
+		"AUTH_TOKENS":         "fb-test-fake-token-1",
+		"ADMIN_TOKEN":         "fb-test-fake-admin-1",
+		"API_KEYS":            "fb-test-fake-client-1",
+		"WEBHOOK_URL":         "https://example.invalid/hook",
+		"UPSTREAM_BASE_URL":   "https://example.invalid",
+		"AUTO_DISCOVER_TOKEN": "false",
+		"LOG_LEVEL":           "debug",
+	}
+	sources := SettingSources("", overlay)
+	for _, k := range []string{"AUTH_TOKENS", "ADMIN_TOKEN", "API_KEYS", "WEBHOOK_URL", "UPSTREAM_BASE_URL", "AUTO_DISCOVER_TOKEN", "LOG_LEVEL"} {
+		if sources[k] != "db" {
+			t.Errorf("%s source = %q, want db", k, sources[k])
+		}
+	}
+	t.Setenv("ADMIN_TOKEN", "fb-test-fake-env-admin-1")
+	if sources := SettingSources("", overlay); sources["ADMIN_TOKEN"] != "env" {
+		t.Errorf("ADMIN_TOKEN source = %q with env set, want env", sources["ADMIN_TOKEN"])
+	}
+}

--- a/backend/internal/config/settings_overlay.go
+++ b/backend/internal/config/settings_overlay.go
@@ -4,6 +4,12 @@
 //
 //	built-in defaults < JSON -config < .env file < DB overlay < process env
 //
+// Since the env-to-DB migration the overlay is the persisted home of the
+// whole knob set, secrets included: the settings table lives in the dashboard
+// DB file (0600, enforced at open), so AUTH_TOKENS, ADMIN_TOKEN, API_KEYS,
+// and WEBHOOK_URL rows are expected there. Explicit process env still wins
+// at runtime — a migrated row never silently overrides the environment.
+//
 // The overlay lives in the generic settings table (store package) under
 // OverlayRowKey namespacing; this package only defines the key contract and
 // the load-time application, so the bottom-layer import rule holds (config
@@ -21,22 +27,20 @@ import (
 	"time"
 )
 
-// SettingsBlockedKeys are never stored as a DB overlay: credentials and
-// loopback-sensitive material stay env/.env-only, as does AUTO_DISCOVER_TOKEN
-// (env-only: it controls whether the .env file is read at all, so an overlay
-// row could never take effect — and the effective view hardcodes its display
-// to "true", so storing "false" would be a silent no-op). POST rejects them;
-// Load filters them defensively (a tampered row must not flip the instance
-// into pooled mode or repoint the upstream).
-var SettingsBlockedKeys = map[string]bool{
-	"AUTH_TOKENS":         true,
-	"ADMIN_TOKEN":         true,
-	"API_KEYS":            true,
-	"WEBHOOK_URL":         true,
-	"UPSTREAM_BASE_URL":   true,
-	"DB_PATH":             true,
-	"AUTO_DISCOVER_TOKEN": true,
-}
+// SettingsBlockedKeys names keys that may never live in the DB overlay.
+// Empty since the env-to-DB migration: every formerly-blocked key
+// (AUTH_TOKENS, ADMIN_TOKEN, API_KEYS, WEBHOOK_URL, UPSTREAM_BASE_URL,
+// DB_PATH, AUTO_DISCOVER_TOKEN) is now overlay-addressable so a fully
+// migrated user runs from the DB alone. The map (and IsSettingsBlocked) stay
+// as the gate for any future key that must remain env-only. Two notes:
+//
+//   - DB_PATH has no catalog entry, so OverlayFromRows still drops it as an
+//     unknown key: the open path resolves the file from the process
+//     environment before any overlay could load, and a row could never
+//     repoint the live file.
+//   - Process env still wins over the overlay at runtime for every key, so
+//     a migrated row can never silently override an explicit environment.
+var SettingsBlockedKeys = map[string]bool{}
 
 // OverlayRowPrefix namespaces config overlays inside the generic settings
 // table (store holds other control state under its own keys).
@@ -70,9 +74,15 @@ func OverlayRowKey(key string) string {
 
 // OverlayFromRows extracts the DB overlay (canonical key -> raw value) from
 // a full settings-table dump. Unknown, blocked, or malformed rows are
-// skipped: the overlay only ever addresses writable catalog keys, and a value
-// that fails ValidateSettingValue could never take effect (it would fail the
-// POST gate), so a tampered or stale row must not poison the load.
+// skipped: the overlay only ever addresses writable catalog keys, and a
+// non-empty value that fails ValidateSettingValue could never take effect
+// (it would fail the POST gate), so a tampered or stale row must not poison
+// the load. Empty values are kept as no-op pins: every override*From helper
+// skips blanks, so they change nothing — except AUTH_TOKENS, where presence
+// (even empty) is the explicit bridge-mode choice that suppresses CLI
+// auto-discovery, mirroring the .env tier. The migration writes one row per
+// catalog key (blanks included), so the overlay round-trips the full knob
+// set; explicit process env still wins over every row at Load.
 func OverlayFromRows(rows map[string]string) map[string]string {
 	out := map[string]string{}
 	for rowKey, value := range rows {
@@ -87,8 +97,10 @@ func OverlayFromRows(rows map[string]string) map[string]string {
 		if _, known := LookupSetting(n); !known {
 			continue
 		}
-		if err := ValidateSettingValue(n, value); err != nil {
-			continue
+		if strings.TrimSpace(value) != "" {
+			if err := ValidateSettingValue(n, value); err != nil {
+				continue
+			}
 		}
 		out[n] = value
 	}
@@ -97,10 +109,12 @@ func OverlayFromRows(rows map[string]string) map[string]string {
 
 // ValidateSettingValue checks one overlay write before it touches the DB:
 // the key must be a known writable catalog key and the value must parse for
-// its kind. Deeper semantic checks (durations, model locks, fallback maps)
-// run through the full Load in the POST handler — this gate only rejects
-// what could never take effect (unknown keys, secrets, unparseable
-// bool/int/float), so a 400 never stores a silent no-op.
+// its kind. Secrets are storable: the settings table lives in the dashboard
+// DB file (0600, enforced at open), which is the persisted home of the whole
+// knob set since the env-to-DB migration. Deeper semantic checks (durations,
+// model locks, fallback maps) run through the full Load in the POST handler
+// — this gate only rejects what could never take effect (unknown keys,
+// unparseable bool/int/float), so a 400 never stores a silent no-op.
 func ValidateSettingValue(key, value string) error {
 	n := NormalizeSettingKey(key)
 	if n == "" {
@@ -112,9 +126,6 @@ func ValidateSettingValue(key, value string) error {
 	def, ok := LookupSetting(n)
 	if !ok {
 		return fmt.Errorf("unknown setting %q", n)
-	}
-	if def.Secret {
-		return fmt.Errorf("%s cannot be stored as a DB overlay (env/.env only)", n)
 	}
 	v := strings.TrimSpace(value)
 	if v == "" {
@@ -161,12 +172,17 @@ func ValidateSettingValue(key, value string) error {
 // and the process environment (ADR-0019 precedence). It shares
 // applyMappedValues with applyDotenv, so every key the loader parses is
 // overlay-addressable by construction — no parallel key list to drift.
+// AUTH_TOKENS rides alongside with .env-tier presence semantics: the key's
+// presence (even empty) records an explicit pool choice and suppresses CLI
+// auto-discovery, so a migrated bridge-mode user stays in bridge mode when
+// the environment no longer pins the pool. Explicit process env still wins:
+// Load applies the real-environment AUTH_TOKENS block after this overlay.
 func applySettingsOverlay(raw *rawConfig, overlay map[string]string) {
 	if len(overlay) == 0 {
 		return
 	}
-	// Defense in depth: POST already rejects these, but a tampered row must
-	// never repoint secrets or the upstream through the back door.
+	// Defense in depth: OverlayFromRows already drops these, but a caller
+	// passing a hand-built map must not smuggle unknown rows into raw.
 	filtered := make(map[string]string, len(overlay))
 	for k, v := range overlay {
 		n := NormalizeSettingKey(k)
@@ -182,6 +198,10 @@ func applySettingsOverlay(raw *rawConfig, overlay map[string]string) {
 		return
 	}
 	applyMappedValues(raw, func(name string) string { return filtered[name] })
+	if v, ok := filtered["AUTH_TOKENS"]; ok {
+		raw.AuthTokens = splitList(v)
+		raw.AuthTokensSet = true
+	}
 }
 
 // SettingSources reports, per catalog key, which precedence tier provides

--- a/backend/internal/config/settings_overlay_test.go
+++ b/backend/internal/config/settings_overlay_test.go
@@ -64,37 +64,87 @@ func TestSettingsOverlayIntBool(t *testing.T) {
 	}
 }
 
-// TestSettingsOverlayBlockedNeverApplies: a tampered overlay row for a
-// secret/endpoint key must not take effect — the file/env value stands.
-func TestSettingsOverlayBlockedNeverApplies(t *testing.T) {
+// TestSettingsOverlaySecretsApply: since the env-to-DB migration every
+// catalog key is overlay-addressable, secrets included (the DB file holds
+// them at mode 0600) — a migrated row takes effect when the environment
+// leaves the key unset. Fake values only, never real credentials.
+func TestSettingsOverlaySecretsApply(t *testing.T) {
 	clearEnv(t)
 	t.Chdir(t.TempDir())
 	cfg, err := LoadOpts("", LoadOptions{Overlay: map[string]string{
-		"AUTH_TOKENS":       "tok-should-not-apply",
-		"ADMIN_TOKEN":       "hijack",
-		"UPSTREAM_BASE_URL": "https://evil.example.com",
+		"AUTH_TOKENS":       "fb-test-fake-token-1",
+		"ADMIN_TOKEN":       "fb-test-fake-admin-1",
+		"API_KEYS":          "fb-test-fake-client-1",
+		"WEBHOOK_URL":       "https://example.invalid/hook",
+		"UPSTREAM_BASE_URL": "https://example.invalid",
 		"SAFE_MODE":         "false",
 	}})
 	if err != nil {
 		t.Fatalf("LoadOpts: %v", err)
 	}
-	if len(cfg.AuthTokens) != 0 {
-		t.Errorf("blocked AUTH_TOKENS overlay applied: %v", cfg.AuthTokens)
+	if len(cfg.AuthTokens) != 1 || cfg.AuthTokens[0] != "fb-test-fake-token-1" {
+		t.Errorf("overlay AUTH_TOKENS did not apply: %v", cfg.AuthTokens)
 	}
-	if cfg.AdminToken == "hijack" {
-		t.Error("blocked ADMIN_TOKEN overlay applied")
+	if cfg.AdminToken != "fb-test-fake-admin-1" {
+		t.Error("overlay ADMIN_TOKEN did not apply")
 	}
-	if strings.Contains(cfg.UpstreamBaseURL, "evil") {
-		t.Errorf("blocked UPSTREAM_BASE_URL overlay applied: %q", cfg.UpstreamBaseURL)
+	if len(cfg.APIKeys) != 1 || cfg.APIKeys[0] != "fb-test-fake-client-1" {
+		t.Errorf("overlay API_KEYS did not apply: %v", cfg.APIKeys)
+	}
+	if cfg.WebhookURL != "https://example.invalid/hook" {
+		t.Errorf("overlay WEBHOOK_URL = %q, want the overlay value", cfg.WebhookURL)
+	}
+	if cfg.UpstreamBaseURL != "https://example.invalid" {
+		t.Errorf("overlay UPSTREAM_BASE_URL = %q, want the overlay value", cfg.UpstreamBaseURL)
 	}
 	if cfg.SafeMode {
 		t.Error("SafeMode = true, want false (allowed overlay must still apply)")
 	}
 }
 
+// TestSettingsOverlaySecretsEnvWins: explicit process env still beats a
+// migrated DB row for every formerly-blocked key — precedence never silently
+// changes for existing users.
+func TestSettingsOverlaySecretsEnvWins(t *testing.T) {
+	clearEnv(t)
+	t.Chdir(t.TempDir())
+	t.Setenv("AUTH_TOKENS", "fb-test-fake-env-token-1")
+	t.Setenv("ADMIN_TOKEN", "fb-test-fake-env-admin-1")
+	t.Setenv("API_KEYS", "fb-test-fake-env-client-1")
+	t.Setenv("WEBHOOK_URL", "https://env.invalid/hook")
+	t.Setenv("UPSTREAM_BASE_URL", "https://env.invalid")
+	cfg, err := LoadOpts("", LoadOptions{Overlay: map[string]string{
+		"AUTH_TOKENS":       "fb-test-fake-db-token-1",
+		"ADMIN_TOKEN":       "fb-test-fake-db-admin-1",
+		"API_KEYS":          "fb-test-fake-db-client-1",
+		"WEBHOOK_URL":       "https://db.invalid/hook",
+		"UPSTREAM_BASE_URL": "https://db.invalid",
+	}})
+	if err != nil {
+		t.Fatalf("LoadOpts env-wins: %v", err)
+	}
+	if len(cfg.AuthTokens) != 1 || cfg.AuthTokens[0] != "fb-test-fake-env-token-1" {
+		t.Errorf("AUTH_TOKENS = %v, want the env value", cfg.AuthTokens)
+	}
+	if cfg.AdminToken != "fb-test-fake-env-admin-1" {
+		t.Error("ADMIN_TOKEN lost to the overlay, want env to win")
+	}
+	if len(cfg.APIKeys) != 1 || cfg.APIKeys[0] != "fb-test-fake-env-client-1" {
+		t.Errorf("API_KEYS = %v, want the env value", cfg.APIKeys)
+	}
+	if cfg.WebhookURL != "https://env.invalid/hook" {
+		t.Errorf("WEBHOOK_URL = %q, want the env value", cfg.WebhookURL)
+	}
+	if cfg.UpstreamBaseURL != "https://env.invalid" {
+		t.Errorf("UPSTREAM_BASE_URL = %q, want the env value", cfg.UpstreamBaseURL)
+	}
+}
+
 // TestOverlayCoversCatalog: every non-blocked catalog key must be
 // overlay-addressable (applyMappedValues is the single shared key list, so
 // this guards the filter in applySettingsOverlay, not the list itself).
+// Since the env-to-DB migration the blocked set is empty: AUTH_TOKENS rides
+// the overlay with presence semantics next to applyMappedValues.
 func TestOverlayCoversCatalog(t *testing.T) {
 	for _, def := range Catalog() {
 		if IsSettingsBlocked(def.Key) {
@@ -119,9 +169,9 @@ func TestOverlayCoversCatalog(t *testing.T) {
 	if _, ok := ov["THEME"]; ok {
 		t.Errorf("OverlayFromRows kept non-config row: %v", ov)
 	}
-	blocked := OverlayFromRows(map[string]string{"config:AUTH_TOKENS": "x"})
-	if len(blocked) != 0 {
-		t.Errorf("OverlayFromRows kept blocked key: %v", blocked)
+	kept := OverlayFromRows(map[string]string{"config:AUTH_TOKENS": "x"})
+	if kept["AUTH_TOKENS"] != "x" {
+		t.Errorf("OverlayFromRows dropped unblocked AUTH_TOKENS: %v", kept)
 	}
 	unknown := OverlayFromRows(map[string]string{"config:NOPE_NOT_A_KEY": "x"})
 	if len(unknown) != 0 {
@@ -129,8 +179,11 @@ func TestOverlayCoversCatalog(t *testing.T) {
 	}
 }
 
-// TestValidateSettingValue pins the POST gate: unknown/blocked/secret keys
-// and unparseable typed values reject; writable knobs accept.
+// TestValidateSettingValue pins the POST gate: unknown keys and unparseable
+// typed values reject; writable knobs accept. Secrets are storable since
+// the env-to-DB migration (the DB file holds them at mode 0600); AUTH_TOKENS
+// and ADMIN_TOKEN take the dedicated-endpoint path in the settings POST
+// handler, but Validate itself accepts them so migrated rows read back.
 func TestValidateSettingValue(t *testing.T) {
 	for key, value := range map[string]string{
 		"LOG_LEVEL":               "debug",
@@ -140,6 +193,12 @@ func TestValidateSettingValue(t *testing.T) {
 		"MODELS_ALLOW":            "deepseek/deepseek-v4-flash",
 		"MATURITY_TARGET_DAYS":    "14",
 		"HTTP_READ_TIMEOUT":       "90s",
+		"AUTH_TOKENS":             "fb-test-fake-token-1",
+		"ADMIN_TOKEN":             "fb-test-fake-admin-1",
+		"API_KEYS":                "fb-test-fake-client-1",
+		"WEBHOOK_URL":             "https://example.invalid/hook",
+		"UPSTREAM_BASE_URL":       "https://example.invalid",
+		"AUTO_DISCOVER_TOKEN":     "false",
 	} {
 		if err := ValidateSettingValue(key, value); err != nil {
 			t.Errorf("ValidateSettingValue(%s,%s) = %v, want nil", key, value, err)
@@ -147,13 +206,7 @@ func TestValidateSettingValue(t *testing.T) {
 	}
 	for key, value := range map[string]string{
 		"NOPE_NOT_A_KEY":          "x",
-		"AUTH_TOKENS":             "tok",
-		"ADMIN_TOKEN":             "x",
-		"API_KEYS":                "x",
-		"WEBHOOK_URL":             "https://example.com",
-		"UPSTREAM_BASE_URL":       "https://example.com",
 		"DB_PATH":                 "/tmp/x.db",
-		"AUTO_DISCOVER_TOKEN":     "false",
 		"SAFE_MODE":               "banana",
 		"MAX_REQUESTS_PER_MINUTE": "lots",
 		"RATE_LIMIT_PER_IP":       "fast",
@@ -235,20 +288,50 @@ func TestLogAndListenKeysAreRestartOnly(t *testing.T) {
 	}
 }
 
-// TestAutoDiscoverTokenBlocked pins AUTO_DISCOVER_TOKEN as env-only: it
-// controls whether the .env file is read at all, so a DB overlay row could
-// never take effect — and the effective view hardcodes its display to
-// "true", so storing "false" would be a silent no-op. POST must 400 (via
-// ValidateSettingValue) and read paths must drop the row.
-func TestAutoDiscoverTokenBlocked(t *testing.T) {
-	if !IsSettingsBlocked("AUTO_DISCOVER_TOKEN") {
-		t.Error("IsSettingsBlocked(AUTO_DISCOVER_TOKEN) = false, want true")
+// TestAutoDiscoverTokenOverlay: AUTO_DISCOVER_TOKEN is overlay-addressable
+// since the env-to-DB migration. The overlay row takes effect only when the
+// process environment leaves the key unset (env wins); the resolved value
+// records on Config and suppresses CLI auto-discovery when false.
+func TestAutoDiscoverTokenOverlay(t *testing.T) {
+	if IsSettingsBlocked("AUTO_DISCOVER_TOKEN") {
+		t.Error("IsSettingsBlocked(AUTO_DISCOVER_TOKEN) = true, want false (unblocked by the env-to-DB migration)")
 	}
-	if err := ValidateSettingValue("AUTO_DISCOVER_TOKEN", "false"); err == nil {
-		t.Error("ValidateSettingValue(AUTO_DISCOVER_TOKEN) accepted, want rejection")
+	if err := ValidateSettingValue("AUTO_DISCOVER_TOKEN", "false"); err != nil {
+		t.Errorf("ValidateSettingValue(AUTO_DISCOVER_TOKEN) = %v, want nil", err)
 	}
-	if ov := OverlayFromRows(map[string]string{"config:AUTO_DISCOVER_TOKEN": "false"}); len(ov) != 0 {
-		t.Errorf("OverlayFromRows kept blocked AUTO_DISCOVER_TOKEN: %v", ov)
+	if ov := OverlayFromRows(map[string]string{"config:AUTO_DISCOVER_TOKEN": "false"}); ov["AUTO_DISCOVER_TOKEN"] != "false" {
+		t.Errorf("OverlayFromRows dropped unblocked AUTO_DISCOVER_TOKEN: %v", ov)
+	}
+	clearEnv(t)
+	t.Chdir(t.TempDir())
+	// clearEnv pins AUTO_DISCOVER_TOKEN=false in the environment; unset it so
+	// the first load below resolves the overlay tier alone.
+	if err := os.Unsetenv("AUTO_DISCOVER_TOKEN"); err != nil {
+		t.Fatal(err)
+	}
+	fakeDiscover := func() (string, string, string, bool) { return "fb-test-fake-discovered-1", "", "", true }
+	// Overlay "false" with no env: discovery suppressed, field records false.
+	cfg, err := LoadOpts("", LoadOptions{DiscoverCLIToken: fakeDiscover, Overlay: map[string]string{"AUTO_DISCOVER_TOKEN": "false"}})
+	if err != nil {
+		t.Fatalf("LoadOpts: %v", err)
+	}
+	if cfg.AutoDiscoverToken {
+		t.Error("AutoDiscoverToken = true, want false (overlay)")
+	}
+	if len(cfg.AuthTokens) != 0 {
+		t.Errorf("AuthTokens = %v, want empty (overlay false suppresses discovery)", cfg.AuthTokens)
+	}
+	// Env "true" beats overlay "false": discovery fires.
+	t.Setenv("AUTO_DISCOVER_TOKEN", "true")
+	cfg, err = LoadOpts("", LoadOptions{DiscoverCLIToken: fakeDiscover, Overlay: map[string]string{"AUTO_DISCOVER_TOKEN": "false"}})
+	if err != nil {
+		t.Fatalf("LoadOpts env-wins: %v", err)
+	}
+	if !cfg.AutoDiscoverToken {
+		t.Error("AutoDiscoverToken = false, want true (env wins)")
+	}
+	if len(cfg.AuthTokens) != 1 || cfg.AuthTokens[0] != "fb-test-fake-discovered-1" {
+		t.Errorf("AuthTokens = %v, want the discovered token (env true enables discovery)", cfg.AuthTokens)
 	}
 }
 
@@ -269,7 +352,11 @@ func TestSettingSourcesDotenvUserIDAlias(t *testing.T) {
 }
 
 // TestOverlayFromRowsDropsMalformed pins the documented contract that
-// malformed rows are skipped: a value that fails ValidateSettingValue could
+// malformed rows are skipped: a non-empty value that fails
+// ValidateSettingValue could never take effect (it would fail the POST
+// gate), so a tampered or stale row must not poison the load. Empty values
+// are kept as no-op pins instead (every override helper skips blanks, and
+// AUTH_TOKENS presence is the bridge-mode pin).
 func TestOverlayFromRowsDropsMalformed(t *testing.T) {
 	ov := OverlayFromRows(map[string]string{
 		"config:SAFE_MODE":               "false",
@@ -292,11 +379,20 @@ func TestOverlayFromRowsDropsMalformed(t *testing.T) {
 		"config:MAX_REQUESTS_PER_MINUTE": "lots",
 		"config:RATE_LIMIT_PER_IP":       "fast",
 		"config:MATURITY_TARGET_DAYS":    "seven",
-		"config:LOG_LEVEL":               "",
 		"config:LOG_LEVEL2":              "debug",
 	})
 	if len(malformed) != 0 {
 		t.Errorf("OverlayFromRows kept malformed rows: %v", malformed)
+	}
+	pins := OverlayFromRows(map[string]string{
+		"config:LOG_LEVEL":   "",
+		"config:AUTH_TOKENS": "",
+	})
+	if v, ok := pins["LOG_LEVEL"]; !ok || v != "" {
+		t.Errorf("OverlayFromRows dropped the empty LOG_LEVEL pin: %v", pins)
+	}
+	if _, ok := pins["AUTH_TOKENS"]; !ok {
+		t.Errorf("OverlayFromRows dropped the empty AUTH_TOKENS bridge pin: %v", pins)
 	}
 }
 

--- a/backend/internal/config/settings_overlay_test.go
+++ b/backend/internal/config/settings_overlay_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 

--- a/backend/internal/server/admin_auth.go
+++ b/backend/internal/server/admin_auth.go
@@ -664,16 +664,23 @@ func (a *adminHandlers) handleAdminChangePassword(w http.ResponseWriter, r *http
 	a.adminSaveMu.Lock()
 	defer a.adminSaveMu.Unlock()
 
-	// Dual-layer persist: ADMIN_TOKEN stays .env-only (raw credential never
-	// reaches the store) while DASHBOARD_REQUIRE_LOGIN=true goes
-	// write-through to the settings overlay — .env is the boot seed/export,
-	// the overlay is runtime truth. Both layers roll back on failure.
+	// Dual-layer persist: ADMIN_TOKEN goes write-through to the settings
+	// overlay (the DB holds secrets at mode 0600 since the env-to-DB
+	// migration) AND to .env as boot seed/export, while
+	// DASHBOARD_REQUIRE_LOGIN=true converges its overlay row — .env is the
+	// export, the overlay is runtime truth. Both layers roll back on
+	// failure. Converging ADMIN_TOKEN (not just the file) matters after
+	// migration: a stale overlay row would otherwise beat the just-written
+	// file and trip the divergence guard below.
 	newCfg, err := a.dualWrite(
 		[]config.EnvUpdate{
 			{Key: "ADMIN_TOKEN", Value: req.NewPassword},
 			{Key: "DASHBOARD_REQUIRE_LOGIN", Value: "true"},
 		},
-		map[string]string{config.OverlayRowKey("DASHBOARD_REQUIRE_LOGIN"): "true"},
+		map[string]string{
+			config.OverlayRowKey("ADMIN_TOKEN"):             req.NewPassword,
+			config.OverlayRowKey("DASHBOARD_REQUIRE_LOGIN"): "true",
+		},
 		nil,
 		func(newCfg config.Config) error {
 			// Divergence guard (mirrors syncTokensAfterMutation): a real process

--- a/backend/internal/server/admin_dualwrite.go
+++ b/backend/internal/server/admin_dualwrite.go
@@ -4,16 +4,18 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"freebuff-proxy/backend/internal/config"
 )
 
 // tokenMarkerKey is the settings-table presence marker for the AUTH_TOKENS
-// pool. Raw tokens never reach the store: the marker carries zero secret
-// material ("true" while a pooled .env persists, absent in bridge mode), so
-// token add/remove/swap/mode-switch still participate in the dual-layer
-// persist without violating the no-raw-tokens rule. AUTH_TOKENS and
-// ADMIN_TOKEN themselves stay .env-only and never enter the settings table.
+// pool ("true" while pooled, absent in bridge mode): a cheap presence signal
+// for readers that must not parse the pool. Since the env-to-DB migration
+// the raw pool itself is ALSO mirrored in the config:AUTH_TOKENS overlay row
+// (the dashboard DB holds secrets at mode 0600) — tokenMarkerDelta converges
+// both, so a migrated row can never shadow the .env write with a stale list
+// and fail the reload verify.
 const tokenMarkerKey = "auth/tokens_configured"
 
 // dualPhase names which layer of a dualWrite failed, so callers keep their
@@ -154,9 +156,16 @@ func (a *adminHandlers) restoreSettingRows(snap map[string]*string) {
 }
 
 // tokenMarkerDelta maps a post-mutation AUTH_TOKENS list to its settings
-// write-through: marker set while pooled, marker dropped in bridge mode.
+// write-through: marker set while pooled, marker dropped in bridge mode,
+// and the config:AUTH_TOKENS overlay row converged to the same list (empty
+// in bridge mode, where presence pins the choice and suppresses CLI
+// auto-discovery). Every token path (add/remove/swap/mode-switch) funnels
+// through here, so the overlay — which beats .env at load — always carries
+// the latest pool instead of shadowing the file just written.
 func tokenMarkerDelta(tokens []string) (set map[string]string, del []string) {
-	set = map[string]string{}
+	set = map[string]string{
+		config.OverlayRowKey("AUTH_TOKENS"): strings.Join(tokens, ","),
+	}
 	if len(tokens) > 0 {
 		set[tokenMarkerKey] = "true"
 		return set, nil

--- a/backend/internal/server/admin_dualwrite_test.go
+++ b/backend/internal/server/admin_dualwrite_test.go
@@ -95,10 +95,13 @@ func TestDualWriteRequireLoginRoundTrip(t *testing.T) {
 		t.Error("RequireLogin flipped to true after .env seed edit, want overlay (false) to win")
 	}
 
-	// No secret material may ever land in the settings table.
+	// The require-login path writes only its own knob: no credential row or
+	// value may appear as its side effect. (Credential rows do exist after
+	// the env-to-DB migration and the token/password write-through paths —
+	// this pins the require-login toggle stays in its lane.)
 	for k, v := range dualWriteStoreRows(t, st) {
 		if k == config.OverlayRowKey("AUTH_TOKENS") || k == config.OverlayRowKey("ADMIN_TOKEN") {
-			t.Errorf("secret overlay row %q must never exist", k)
+			t.Errorf("secret overlay row %q written by the require-login path", k)
 		}
 		if strings.Contains(v, "secretPass123") || strings.Contains(v, "tok-0") {
 			t.Errorf("settings row %q leaks secret material: %q", k, v)

--- a/backend/internal/server/admin_dualwrite_test.go
+++ b/backend/internal/server/admin_dualwrite_test.go
@@ -252,15 +252,23 @@ func TestDualWriteModeSwitchBridgeDropsMarker(t *testing.T) {
 	}
 }
 
-// TestTokenMarkerDelta pins the zero-secret marker mapping: pooled lists set
-// the presence flag, an emptied pool drops the row.
+// TestTokenMarkerDelta pins the write-through mapping: pooled lists set the
+// presence flag AND converge the config:AUTH_TOKENS overlay row to the same
+// list; an emptied pool converges the row empty (bridge pins by presence)
+// and drops the marker row.
 func TestTokenMarkerDelta(t *testing.T) {
 	set, del := tokenMarkerDelta([]string{"a", "b"})
 	if set[tokenMarkerKey] != "true" || len(del) != 0 {
 		t.Errorf("pooled delta = (%v, %v), want marker set", set, del)
 	}
+	if set[config.OverlayRowKey("AUTH_TOKENS")] != "a,b" {
+		t.Errorf("pooled delta AUTH_TOKENS row = %q, want converged %q", set[config.OverlayRowKey("AUTH_TOKENS")], "a,b")
+	}
 	set, del = tokenMarkerDelta(nil)
-	if len(set) != 0 || len(del) != 1 || del[0] != tokenMarkerKey {
-		t.Errorf("bridge delta = (%v, %v), want marker deleted", set, del)
+	if set[config.OverlayRowKey("AUTH_TOKENS")] != "" || len(set) != 1 {
+		t.Errorf("bridge delta set = %v, want only the empty AUTH_TOKENS pin", set)
+	}
+	if len(del) != 1 || del[0] != tokenMarkerKey {
+		t.Errorf("bridge delta del = %v, want marker deleted", del)
 	}
 }

--- a/backend/internal/server/admin_overlay_shadow_test.go
+++ b/backend/internal/server/admin_overlay_shadow_test.go
@@ -175,14 +175,14 @@ func TestChangePasswordConvergesAdminTokenOverlay(t *testing.T) {
 	st := attachShadowStore(t, s)
 	h := s.Handler()
 	cookie := shadowLogin(t, h, "secretPass123")
-	// Seed the stale migrated row after login: the overlay now shadows the
-	// file, so the effective credential is the stale value.
+	// Seed the stale migrated row after login: it would shadow the file on
+	// the next reload, so the change must converge it instead of failing
+	// its divergence guard on the migrated row.
 	if err := st.SetSetting(config.OverlayRowKey("ADMIN_TOKEN"), "stale-pass"); err != nil {
 		t.Fatalf("SetSetting: %v", err)
 	}
-
 	req := httptest.NewRequest(http.MethodPost, "/admin/api/change-password",
-		strings.NewReader(`{"current_password":"stale-pass","new_password":"rotatedPass789"}`))
+		strings.NewReader(`{"current_password":"secretPass123","new_password":"rotatedPass789"}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(cookie)
 	rec := httptest.NewRecorder()

--- a/backend/internal/server/admin_overlay_shadow_test.go
+++ b/backend/internal/server/admin_overlay_shadow_test.go
@@ -138,3 +138,62 @@ func TestRequireLoginConvergesOverlay(t *testing.T) {
 		t.Error("effective RequireLogin still true after toggle to false")
 	}
 }
+
+// TestModeSwitchBridgeConvergesAuthTokensOverlay: with a stale migrated
+// config:AUTH_TOKENS row pinning a pool the .env no longer carries, the
+// pooled→bridge switch converges the row to empty instead of failing — the
+// switch is write-through (DB-unified storage), so token management keeps
+// working after the env-to-DB migration instead of tripping its own
+// divergence guard on the migrated row.
+func TestModeSwitchBridgeConvergesAuthTokensOverlay(t *testing.T) {
+	s := newReviewFixServer(t, "AUTH_TOKENS=tok-0\nADMIN_TOKEN=secretPass123\n", nil)
+	st := attachShadowStore(t, s)
+	if err := st.SetSetting(config.OverlayRowKey("AUTH_TOKENS"), "tok-stale"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	h := s.Handler()
+	cookie := shadowLogin(t, h, "secretPass123")
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/mode", strings.NewReader(`{"mode":"bridge"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("bridge switch status = %d, want 200 (stale overlay converges): %s", rec.Code, rec.Body.String())
+	}
+	if v, _, _ := st.GetSetting(config.OverlayRowKey("AUTH_TOKENS")); v != "" {
+		t.Errorf("overlay AUTH_TOKENS = %q, want converged empty (bridge pin)", v)
+	}
+	if !s.admin.cfgLoad().BridgeMode() {
+		t.Error("effective config not in bridge mode after switch")
+	}
+}
+
+func TestChangePasswordConvergesAdminTokenOverlay(t *testing.T) {
+	s := newReviewFixServer(t, "AUTH_TOKENS=tok-0\nADMIN_TOKEN=secretPass123\n", nil)
+	st := attachShadowStore(t, s)
+	h := s.Handler()
+	cookie := shadowLogin(t, h, "secretPass123")
+	// Seed the stale migrated row after login: the overlay now shadows the
+	// file, so the effective credential is the stale value.
+	if err := st.SetSetting(config.OverlayRowKey("ADMIN_TOKEN"), "stale-pass"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/change-password",
+		strings.NewReader(`{"current_password":"stale-pass","new_password":"rotatedPass789"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("change-password status = %d, want 200 (stale overlay converges): %s", rec.Code, rec.Body.String())
+	}
+	if v, _, _ := st.GetSetting(config.OverlayRowKey("ADMIN_TOKEN")); v != "rotatedPass789" {
+		t.Error("overlay ADMIN_TOKEN not converged to the new credential")
+	}
+	if got := s.admin.cfgLoad().AdminToken; got != "rotatedPass789" {
+		t.Error("effective ADMIN_TOKEN not rotated")
+	}
+}

--- a/backend/internal/server/admin_settings.go
+++ b/backend/internal/server/admin_settings.go
@@ -96,6 +96,21 @@ func (a *adminHandlers) handleSettingsPost(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	key := config.NormalizeSettingKey(req.Key)
+	// AUTH_TOKENS and ADMIN_TOKEN have dedicated mutation endpoints that
+	// converge the overlay alongside the other layers they touch: the Tokens
+	// page and mode switch reconcile the live pool and the presence marker,
+	// Change-password refreshes the session cookie and forces
+	// require-login. A direct knob write would bypass that reconciliation
+	// (the pool adopts additions but never removals), so it 400s with a
+	// pointer instead of persisting a row the pool cannot honor.
+	if key == "AUTH_TOKENS" {
+		a.dash.RenderResult(w, http.StatusBadRequest, false, "AUTH_TOKENS is managed on the Tokens page and mode switch, not as a knob (the pool needs reconciling).", "invalid_setting")
+		return
+	}
+	if key == "ADMIN_TOKEN" {
+		a.dash.RenderResult(w, http.StatusBadRequest, false, "ADMIN_TOKEN is changed via Change password, not as a knob (the session cookie needs refreshing).", "invalid_setting")
+		return
+	}
 	val, ok := settingsValueString(req.Value)
 	if !ok {
 		a.dash.RenderResult(w, http.StatusBadRequest, false, "Value must be a string, number, or boolean.", "bad_value")

--- a/backend/internal/server/admin_settings_test.go
+++ b/backend/internal/server/admin_settings_test.go
@@ -187,16 +187,20 @@ func TestSettingsOverlayCycle(t *testing.T) {
 	}
 }
 
-// TestSettingsPostRejects pins the validation gate: secrets, unknown keys,
-// and unparseable values never reach the DB.
+// TestSettingsPostRejects pins the validation gate: pool/password credentials
+// with dedicated endpoints (AUTH_TOKENS, ADMIN_TOKEN), unknown keys, and
+// unparseable values never reach the DB as knob writes. The remaining
+// formerly-blocked keys persist since the env-to-DB migration (the DB holds
+// secrets at mode 0600); their acceptance is pinned by
+// TestSettingsPostAcceptsMigratedSecrets.
 func TestSettingsPostRejects(t *testing.T) {
 	ts, cookie, csrf := settingsTestServer(t)
 
-	for _, key := range []string{"AUTH_TOKENS", "ADMIN_TOKEN", "API_KEYS", "WEBHOOK_URL", "UPSTREAM_BASE_URL", "DB_PATH", "AUTO_DISCOVER_TOKEN"} {
+	for _, key := range []string{"AUTH_TOKENS", "ADMIN_TOKEN", "DB_PATH"} {
 		code, res := settingsDo(t, http.MethodPost, ts.URL+"/admin/api/settings", cookie, csrf,
 			map[string]any{"key": key, "value": "x"})
 		if code != http.StatusBadRequest {
-			t.Errorf("POST %s = %d %v, want 400 (never in DB)", key, code, res)
+			t.Errorf("POST %s = %d %v, want 400 (dedicated endpoint or unknown)", key, code, res)
 		}
 	}
 	for _, kv := range [][2]string{
@@ -220,6 +224,32 @@ func TestSettingsPostRejects(t *testing.T) {
 	for _, key := range []string{"SAFE_MODE", "MAX_REQUESTS_PER_MINUTE", "RATE_LIMIT_PER_IP", "HTTP_READ_TIMEOUT"} {
 		if entries[key]["source"] == "db" {
 			t.Errorf("%s source = db after rejected POSTs, want no overlay row", key)
+		}
+	}
+}
+
+// TestSettingsPostAcceptsMigratedSecrets pins the env-to-DB migration's POST
+// surface: API_KEYS, WEBHOOK_URL, UPSTREAM_BASE_URL, and AUTO_DISCOVER_TOKEN
+// persist to the DB overlay and report source=db (fake values only).
+func TestSettingsPostAcceptsMigratedSecrets(t *testing.T) {
+	ts, cookie, csrf := settingsTestServer(t)
+
+	for key, value := range map[string]string{
+		"API_KEYS":            "fb-test-fake-client-1",
+		"WEBHOOK_URL":         "https://example.invalid/hook",
+		"UPSTREAM_BASE_URL":   "https://example.invalid",
+		"AUTO_DISCOVER_TOKEN": "false",
+	} {
+		code, res := settingsDo(t, http.MethodPost, ts.URL+"/admin/api/settings", cookie, csrf,
+			map[string]any{"key": key, "value": value})
+		if code != http.StatusOK || res["ok"] != true {
+			t.Errorf("POST %s = %d %v, want 200 ok (migrated secret persists)", key, code, res)
+		}
+	}
+	entries := settingsSources(t, ts, cookie)
+	for _, key := range []string{"API_KEYS", "WEBHOOK_URL", "UPSTREAM_BASE_URL", "AUTO_DISCOVER_TOKEN"} {
+		if entries[key]["source"] != "db" {
+			t.Errorf("%s source = %v, want db after POST", key, entries[key]["source"])
 		}
 	}
 }

--- a/backend/internal/server/admin_tokens_ops.go
+++ b/backend/internal/server/admin_tokens_ops.go
@@ -65,14 +65,15 @@ func shortFlowID(fp string) string {
 }
 
 func (a *adminHandlers) syncTokensAfterMutation(tokens []string) error {
-	// Dual-layer persist (DB-unified storage): AUTH_TOKENS itself stays
-	// .env-only (raw tokens never reach the store), while the
-	// auth/tokens_configured presence marker goes write-through to the
-	// settings table — zero secret material. A reload-verification failure
-	// restores BOTH layers (mirrors handleModeSwitch's persist → verify →
-	// rollback). Otherwise the failed add leaves AUTH_TOKENS=<new> in .env
-	// while the live pool holds the old list — the very divergence the
-	// caller is trying to avoid.
+	// Dual-layer persist (DB-unified storage): AUTH_TOKENS goes write-through
+	// to BOTH .env (boot seed/export) and the config:AUTH_TOKENS overlay row
+	// (runtime truth — the DB holds secrets at mode 0600 since the env-to-DB
+	// migration), plus the auth/tokens_configured presence marker, via
+	// tokenMarkerDelta. A reload-verification failure restores BOTH layers
+	// (mirrors handleModeSwitch's persist → verify → rollback). Otherwise
+	// the failed add leaves AUTH_TOKENS=<new> in .env while the live pool
+	// holds the old list — the very divergence the caller is trying to
+	// avoid.
 	for i, tok := range tokens {
 		if strings.Contains(tok, ",") {
 			return fmt.Errorf("persist AUTH_TOKENS: AUTH_TOKENS entry %d contains a comma (AUTH_TOKENS is comma-separated in .env)", i+1)

--- a/backend/internal/server/admin_tokens_routes.go
+++ b/backend/internal/server/admin_tokens_routes.go
@@ -232,6 +232,7 @@ func (a *adminHandlers) handleModeSwitch(w http.ResponseWriter, r *http.Request)
 		// Dual-layer persist: AUTH_TOKENS= (explicit empty) to .env and the
 		// overlay row converged empty (bridge pins by presence), token
 		// marker dropped from settings (bridge = no pooled tokens).
+		set, del := tokenMarkerDelta(nil)
 		newCfg, err := a.dualWrite(
 			[]config.EnvUpdate{{Key: "AUTH_TOKENS", Value: ""}},
 			set, del,

--- a/backend/internal/server/admin_tokens_routes.go
+++ b/backend/internal/server/admin_tokens_routes.go
@@ -229,9 +229,9 @@ func (a *adminHandlers) handleModeSwitch(w http.ResponseWriter, r *http.Request)
 		// Persist AUTH_TOKENS= (explicit empty) and
 		// reload, verifying the effective config actually lands in bridge
 		// mode before touching the live pool. Roll the .env back on failure.
-		// Dual-layer persist: AUTH_TOKENS= (explicit empty) to .env, token
+		// Dual-layer persist: AUTH_TOKENS= (explicit empty) to .env and the
+		// overlay row converged empty (bridge pins by presence), token
 		// marker dropped from settings (bridge = no pooled tokens).
-		set, del := tokenMarkerDelta(nil)
 		newCfg, err := a.dualWrite(
 			[]config.EnvUpdate{{Key: "AUTH_TOKENS", Value: ""}},
 			set, del,

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -1,10 +1,14 @@
-// Package store is the dashboard history backend (ADR-0016): one pure-Go
-// SQLite file holding log entries, quota snapshots, maturity events, and
-// request records. Leaf package by construction: stdlib + the modernc driver
-// + pressly/goose for migrations only, zero internal imports (see archtest
-// matrix). History is display and debug data, never control state: a missing
-// or corrupt file degrades to live-only views, and retention runs off the
-// request path.
+// Package store is the dashboard backend (ADR-0016): one pure-Go SQLite file
+// holding log entries, quota snapshots, maturity events, request records,
+// and — since the env-to-DB migration — the DB settings overlay (ADR-0019),
+// the persisted home of the whole config knob set. That includes secrets
+// (AUTH_TOKENS, ADMIN_TOKEN, API_KEYS, WEBHOOK_URL rows): the file is
+// created and kept at mode 0600 on open, and operators must preserve that
+// when copying or backing the file up. Leaf package by construction: stdlib
+// + the modernc driver + pressly/goose for migrations only, zero internal
+// imports (see archtest matrix). History is display and debug data, never
+// control state: a missing or corrupt file degrades to live-only views, and
+// retention runs off the request path.
 package store
 
 import (
@@ -178,6 +182,16 @@ func Open(path string) (*Store, error) {
 	if _, err := db.Exec(fmt.Sprintf("PRAGMA user_version=%d", schemaVersion)); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("store: stamp version: %w", err)
+	}
+	// The settings table holds secrets since the env-to-DB migration
+	// (AUTH_TOKENS, ADMIN_TOKEN, API_KEYS, WEBHOOK_URL overlay rows), so
+	// the file is kept at 0600: a fresh create inherits umask-loosened
+	// modes, and a pre-migration file may still be 0644. Best-effort is
+	// not enough for credential material — a chmod failure fails the open
+	// and the caller degrades to live-only.
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("store: chmod 0600 %s: %w", path, err)
 	}
 	return &Store{db: db}, nil
 }

--- a/backend/internal/store/store_perms_test.go
+++ b/backend/internal/store/store_perms_test.go
@@ -1,0 +1,57 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestOpenEnforces0600 pins the secret-holding posture: since the env-to-DB
+// migration the settings table carries AUTH_TOKENS, ADMIN_TOKEN, API_KEYS,
+// and WEBHOOK_URL rows, so Open creates the file at 0600 and tightens a
+// pre-migration 0644 file on open.
+func TestOpenEnforces0600(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "perms.db")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Errorf("fresh DB mode = %o, want 600", got)
+	}
+}
+
+func TestOpenTightensExisting0644(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy-perms.db")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("Chmod 644: %v", err)
+	}
+	s, err = Open(path)
+	if err != nil {
+		t.Fatalf("re-Open: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Errorf("reopened DB mode = %o, want 600", got)
+	}
+}


### PR DESCRIPTION
Boot auto-migrate for existing env users: first boot with a marker-less settings table imports every effective knob (process env wins over .env file over JSON over defaults, same precedence as Load) into `config:` overlay rows, then sets `config:migrated_env_v1`. Re-runs are no-ops via the marker.

Unblocked keys (all seven, SettingsBlockedKeys now empty): AUTH_TOKENS, ADMIN_TOKEN, API_KEYS, WEBHOOK_URL, UPSTREAM_BASE_URL, DB_PATH, AUTO_DISCOVER_TOKEN. Notes: AUTH_TOKENS applies with presence semantics (empty row pins bridge mode and suppresses CLI discovery); AUTO_DISCOVER_TOKEN resolves env over overlay over default-true and records on Config (dashboard no longer hardcodes it); DB_PATH has no catalog entry so OverlayFromRows still drops it as unknown - the open path resolves the file from process env pre-Load, a row could never repoint it. Process env still wins at runtime for every key.

DB file enforced at mode 0600 on open/create (fresh creates and pre-migration 0644 files); package doc + README note that the DB now holds secrets.

Dashboard reports source=db for migrated keys (SettingSources, no shape change). Direct AUTH_TOKENS/ADMIN_TOKEN knob POSTs 400 with a pointer to the Tokens page / Change password; token add/remove/swap, mode switch, and password change converge their overlay rows write-through so migrated rows never shadow the .env write and trip the reload verify.

Tests (fake values only, no secret material): migration no-op on second boot, env-wins precedence for all formerly-blocked keys, legacy v4 DB migrates then imports with rows intact, overlay round-trip incl. empty AUTH_TOKENS bridge pin and full-Config DeepEqual DB-alone reload, 0600 create + tighten, POST accept/reject split, mode-switch + password convergence.

Harness note: written on Windows without local builds per owner order; Linux CI (hermetic: env -u AUTH_TOKENS -u ADMIN_TOKEN go test ./backend/...) is proof. gofmt clean.