### PR TITLE
feat(store): boot-time smart migration with version-aware status and strict no-op reboots

### DIFF
--- a/backend/internal/cli/cli_env_migrate_test.go
+++ b/backend/internal/cli/cli_env_migrate_test.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -135,5 +138,147 @@ func TestMigrateEnvToDBLegacyV4ThenImport(t *testing.T) {
 	}
 	if _, ok, err := st.GetSetting(config.MigrationMarkerRow); err != nil || !ok {
 		t.Errorf("marker missing after import: %v %v", ok, err)
+	}
+}
+
+// smartMigrateFileHash snapshots one DB file's bytes after its handle is
+// closed: a re-boot that performs zero writes hashes identically.
+func smartMigrateFileHash(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// TestSmartMigrateMarkerlessGooseDBImportsEnv pins generation (c) on a
+// goose-native file: a fresh OpenWithStatus converges with no marker, the
+// env import lands every catalog key plus the marker, and the next boot
+// imports nothing.
+func TestSmartMigrateMarkerlessGooseDBImportsEnv(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "goose-native.db")
+	st, ms, err := history.OpenWithStatus(path)
+	if err != nil {
+		t.Fatalf("OpenWithStatus: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if !ms.Fresh || ms.FromVersion != 0 {
+		t.Errorf("fresh status = %+v, want {Fresh:true FromVersion:0}", ms)
+	}
+	if _, ok, err := st.GetSetting(config.MigrationMarkerRow); err != nil || ok {
+		t.Fatalf("marker present before import: %v %v", ok, err)
+	}
+	cfg := migrateTestConfig(t)
+	n, err := migrateEnvToDB(st, cfg)
+	if err != nil {
+		t.Fatalf("migrateEnvToDB: %v", err)
+	}
+	if n != len(config.Catalog()) {
+		t.Errorf("imported %d rows, want %d (every catalog key)", n, len(config.Catalog()))
+	}
+	if v, ok, err := st.GetSetting(config.MigrationMarkerRow); err != nil || !ok || v != config.MigrationMarkerValue {
+		t.Errorf("marker after import = %q %v %v, want %q", v, ok, err, config.MigrationMarkerValue)
+	}
+	if n, err := migrateEnvToDB(st, cfg); err != nil || n != 0 {
+		t.Errorf("second migrateEnvToDB = %d, %v; want 0, nil (marker no-op)", n, err)
+	}
+}
+
+// TestSmartMigrateMarkedLatestZeroWrites pins generation (d) end to end: a
+// re-boot on a marked, latest-version file (goose converged + env imported)
+// performs zero writes — identical bytes and mode — and reports the no-op.
+func TestSmartMigrateMarkedLatestZeroWrites(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "marked.db")
+	first, _, err := history.OpenWithStatus(path)
+	if err != nil {
+		t.Fatalf("first OpenWithStatus: %v", err)
+	}
+	cfg := migrateTestConfig(t)
+	if n, err := migrateEnvToDB(first, cfg); err != nil || n == 0 {
+		_ = first.Close()
+		t.Fatalf("first migrateEnvToDB = %d, %v; want full import", n, err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	beforeHash := smartMigrateFileHash(t, path)
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %o, want 600 before the no-op re-boot", got)
+	}
+
+	second, ms, err := history.OpenWithStatus(path)
+	if err != nil {
+		t.Fatalf("second OpenWithStatus: %v", err)
+	}
+	if ms.Fresh || len(ms.Applied) != 0 || !ms.Noop {
+		t.Errorf("re-boot status = %+v, want {Fresh:false Applied:[] Noop:true}", ms)
+	}
+	if n, err := migrateEnvToDB(second, cfg); err != nil || n != 0 {
+		t.Errorf("re-boot migrateEnvToDB = %d, %v; want 0, nil (marker no-op)", n, err)
+	}
+	if v, ok, err := second.GetSetting(config.OverlayRowKey("AUTH_TOKENS")); err != nil || !ok || v != "fb-test-fake-token-1" {
+		t.Errorf("migrated AUTH_TOKENS row = %q %v %v, want the fake pool intact", v, ok, err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if got := smartMigrateFileHash(t, path); got != beforeHash {
+		t.Error("DB bytes changed across a marked latest re-boot (want zero writes)")
+	}
+	if fi, err := os.Stat(path); err != nil || fi.Mode().Perm() != 0o600 {
+		t.Errorf("DB mode changed across a marked latest re-boot: %v %o", err, fi.Mode().Perm())
+	}
+}
+
+// TestSmartMigrateEnvWinsAfterMigrate pins precedence after the import:
+// explicit process env still beats every migrated DB row at runtime, while
+// the DB row carries the effective value once the environment is cleared.
+func TestSmartMigrateEnvWinsAfterMigrate(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("AUTO_DISCOVER_TOKEN", "false")
+	t.Setenv("LOG_LEVEL", "debug")
+	cfg, err := config.LoadOpts("", config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("LoadOpts: %v", err)
+	}
+	st, err := history.Open(filepath.Join(t.TempDir(), "precedence.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if n, err := migrateEnvToDB(st, cfg); err != nil || n == 0 {
+		t.Fatalf("migrateEnvToDB = %d, %v; want full import", n, err)
+	}
+	rows, err := st.ListSettings()
+	if err != nil {
+		t.Fatalf("ListSettings: %v", err)
+	}
+	ov := config.OverlayFromRows(rows)
+
+	// DB-alone boot: the migrated row provides the effective value.
+	if err := os.Unsetenv("LOG_LEVEL"); err != nil {
+		t.Fatalf("Unsetenv: %v", err)
+	}
+	cfgDB, err := config.LoadOpts("", config.LoadOptions{Overlay: ov})
+	if err != nil {
+		t.Fatalf("LoadOpts from overlay: %v", err)
+	}
+	if cfgDB.LogLevel != "debug" {
+		t.Errorf("DB-alone LOG_LEVEL = %q, want debug (the migrated row)", cfgDB.LogLevel)
+	}
+	// Env-pinned boot: explicit process env wins over the migrated row.
+	t.Setenv("LOG_LEVEL", "warn")
+	cfgEnv, err := config.LoadOpts("", config.LoadOptions{Overlay: ov})
+	if err != nil {
+		t.Fatalf("LoadOpts with env: %v", err)
+	}
+	if cfgEnv.LogLevel != "warn" {
+		t.Errorf("env-pinned LOG_LEVEL = %q, want warn (env wins after migrate)", cfgEnv.LogLevel)
 	}
 }

--- a/backend/internal/cli/cli_serve.go
+++ b/backend/internal/cli/cli_serve.go
@@ -46,14 +46,19 @@ func Serve(configPath string, verbose bool, version string) int {
 	// DB_PATH resolves from the process environment alone, so no config is
 	// needed to open it; a failure only warns (live-only), and the same
 	// handle feeds the history wiring below (never opened twice).
+	// OpenWithStatus also detects the file's data generation for the boot
+	// smart-migration report below: fresh init, legacy pre-goose stamp, or
+	// goose-converged (see the env-to-DB block after the logger exists).
 	var histStore *history.Store
 	var bootOverlay map[string]string
+	bootMigrate := history.MigrateStatus{Applied: []int{}}
 	{
 		dbPath := history.DBPathFromEnv()
-		if st, err := history.Open(dbPath); err != nil {
+		if st, ms, err := history.OpenWithStatus(dbPath); err != nil {
 			fmt.Fprintln(os.Stderr, "freebuff-proxy: settings store unavailable; running live-only:", err)
 		} else {
 			histStore = st
+			bootMigrate = ms
 			if rows, err := st.ListSettings(); err != nil {
 				fmt.Fprintln(os.Stderr, "freebuff-proxy: settings overlay unreadable; running on file/env:", err)
 			} else if ov := config.OverlayFromRows(rows); len(ov) > 0 {
@@ -115,19 +120,40 @@ func Serve(configPath string, verbose bool, version string) int {
 			}
 		}
 	}
-	// Env-to-DB migration: the first boot with a marker-less settings table
-	// imports the just-loaded effective config (env > file > defaults) into
-	// config: overlay rows so later boots — and the dashboard — run from the
-	// DB alone. Re-runs are no-ops via the marker; explicit process env
-	// keeps winning over every migrated row at runtime. A nil store (DB
-	// failed to open above) skips silently — live-only, nothing to persist
-	// to. Key names and the row count log here, never values.
+	// Boot smart migration, in order: the store open above already ran the
+	// pending goose chain for the detected data generation ((a) no DB file:
+	// fresh init, (b) legacy pre-goose stamp: baseline + remainder, (c)
+	// goose-converged: nothing pending); the env-to-DB import below runs
+	// when the marker row is missing and no-ops once it is present (d), so
+	// a marked, latest-version boot performs zero writes. Detection is
+	// version-aware: one INFO line per applied goose version plus a
+	// from->to summary, and the same facts stay readable for the dashboard
+	// via the store's in-memory MigrateStatus (GET /admin/api/settings
+	// "migrate"). Key names and counts log here, never values.
+	envImported := 0
+	migrateFailed := false
 	if histStore != nil {
 		if n, err := migrateEnvToDB(histStore, cfg); err != nil {
+			migrateFailed = true
 			logger.Warn("env-to-DB migration failed; running on file/env/overlay", "err", err)
-		} else if n > 0 {
-			logger.Info("migrated env config to DB overlay", "keys", n, "marker", config.MigrationMarkerRow)
+		} else {
+			envImported = n
+			if n > 0 {
+				logger.Info("migrated env config to DB overlay", "keys", n, "marker", config.MigrationMarkerRow)
+			}
 		}
+		for _, v := range bootMigrate.Applied {
+			logger.Info("store migration applied", "version", v, "from_version", bootMigrate.FromVersion, "to_version", bootMigrate.ToVersion)
+		}
+		// A failed env import retries on the next boot (the marker is only
+		// set after a full import), so it poisons the no-op verdict.
+		logger.Info("smart migrate complete",
+			"from_version", bootMigrate.FromVersion,
+			"to_version", bootMigrate.ToVersion,
+			"store_applied", bootMigrate.Applied,
+			"fresh", bootMigrate.Fresh,
+			"env_imported", envImported,
+			"noop", !migrateFailed && bootMigrate.Noop && envImported == 0)
 	}
 
 	// Load the hardcoded fallback immediately so the registry is usable

--- a/backend/internal/dashboard/admin_wire.go
+++ b/backend/internal/dashboard/admin_wire.go
@@ -154,8 +154,29 @@ type SettingsEntry struct {
 
 // SettingsListResponse is the GET /admin/api/settings answer.
 type SettingsListResponse struct {
-	Degraded bool            `json:"degraded"`
-	Settings []SettingsEntry `json:"settings"`
+	Degraded bool               `json:"degraded"`
+	Settings []SettingsEntry    `json:"settings"`
+	Migrate  *MigrateStatusInfo `json:"migrate,omitempty"`
+}
+
+// MigrateStatusInfo is the boot-time smart-migration report carried on the
+// settings payload (read-cheap: the store captures it once at Open, the
+// handler serves it from memory plus the already-fetched settings rows —
+// no per-request migration work). FromVersion is the detected PRAGMA
+// user_version stamp before migration (0: fresh init, no DB file); Applied
+// lists the goose versions that actually executed that boot (empty on a
+// strict no-op re-boot); Marker reports the env-to-DB marker row
+// (config:migrated_env_v1) being present; Noop reports zero boot writes
+// (goose chain already at latest and the marker already set). Regenerate
+// data/openapi.json via go generate ./backend/internal/dashboard/ after
+// touching this shape (the emitter inlines it into SettingsListResponse).
+type MigrateStatusInfo struct {
+	FromVersion int   `json:"from_version"`
+	ToVersion   int   `json:"to_version"`
+	Applied     []int `json:"applied"`
+	Fresh       bool  `json:"fresh"`
+	Marker      bool  `json:"marker"`
+	Noop        bool  `json:"noop"`
 }
 
 // SettingsPostRequest is the POST /admin/api/settings body.

--- a/backend/internal/dashboard/data/openapi.json
+++ b/backend/internal/dashboard/data/openapi.json
@@ -399,6 +399,41 @@
           "degraded": {
             "type": "boolean"
           },
+          "migrate": {
+            "nullable": true,
+            "properties": {
+              "applied": {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              "fresh": {
+                "type": "boolean"
+              },
+              "from_version": {
+                "type": "integer"
+              },
+              "marker": {
+                "type": "boolean"
+              },
+              "noop": {
+                "type": "boolean"
+              },
+              "to_version": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "applied",
+              "fresh",
+              "from_version",
+              "marker",
+              "noop",
+              "to_version"
+            ],
+            "type": "object"
+          },
           "settings": {
             "items": {
               "properties": {

--- a/backend/internal/server/admin_settings.go
+++ b/backend/internal/server/admin_settings.go
@@ -29,10 +29,10 @@ import (
 // the effective display value plus the precedence tier that provides it.
 type settingsEntry = dashboard.SettingsEntry
 
-// settingsOverlay reads the live DB overlay (canonical key -> raw value).
-// A nil store or a read failure degrades to empty (file/env/default only);
+// settingsRows reads the raw DB settings dump (key -> raw value). A nil
+// store or a read failure degrades to empty (file/env/default only);
 // mutations 503 instead (a write must not silently land nowhere).
-func (a *adminHandlers) settingsOverlay() map[string]string {
+func (a *adminHandlers) settingsRows() map[string]string {
 	if a.settings == nil {
 		return map[string]string{}
 	}
@@ -41,7 +41,39 @@ func (a *adminHandlers) settingsOverlay() map[string]string {
 		a.logfunc().Warn("settings overlay unreadable; serving file/env/default", "err", err)
 		return map[string]string{}
 	}
-	return config.OverlayFromRows(rows)
+	return rows
+}
+
+// settingsOverlay reads the live DB overlay (canonical key -> raw value).
+// A nil store or a read failure degrades to empty (file/env/default only);
+// mutations 503 instead (a write must not silently land nowhere).
+func (a *adminHandlers) settingsOverlay() map[string]string {
+	return config.OverlayFromRows(a.settingsRows())
+}
+
+// migrateStatusInfo builds the boot smart-migration report for the settings
+// payload from the store's in-memory Open report plus the already-fetched
+// settings rows (marker presence): read-cheap, no per-request migration
+// work and no extra DB round trip beyond the rows the handler already
+// reads. Nil with a nil store (live-only boots carry no migration facts).
+func (a *adminHandlers) migrateStatusInfo(rows map[string]string) *dashboard.MigrateStatusInfo {
+	if a.settings == nil {
+		return nil
+	}
+	ms := a.settings.MigrateStatus()
+	_, marker := rows[config.MigrationMarkerRow]
+	applied := ms.Applied
+	if applied == nil {
+		applied = []int{}
+	}
+	return &dashboard.MigrateStatusInfo{
+		FromVersion: ms.FromVersion,
+		ToVersion:   ms.ToVersion,
+		Applied:     applied,
+		Fresh:       ms.Fresh,
+		Marker:      marker,
+		Noop:        ms.Noop && marker,
+	}
 }
 
 // loadConfig is the single overlay-aware reload every admin mutation and
@@ -58,7 +90,10 @@ func (a *adminHandlers) handleSettingsGet(w http.ResponseWriter, r *http.Request
 	// state honestly. Status stays 200 with the full catalog — every row
 	// still reports its effective value and tier.
 	degraded := a.settings == nil
-	overlay := a.settingsOverlay()
+	// One rows fetch feeds both the overlay and the migrate report (marker
+	// presence): no extra DB round trip beyond what the overlay already did.
+	rows := a.settingsRows()
+	overlay := config.OverlayFromRows(rows)
 	cfg := a.cfgLoad()
 	sources := config.SettingSources(a.configPath, overlay)
 	values := make(map[string]config.DataEntry, len(config.Catalog()))
@@ -80,7 +115,7 @@ func (a *adminHandlers) handleSettingsGet(w http.ResponseWriter, r *http.Request
 		})
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(dashboard.SettingsListResponse{Degraded: degraded, Settings: entries})
+	_ = json.NewEncoder(w).Encode(dashboard.SettingsListResponse{Degraded: degraded, Settings: entries, Migrate: a.migrateStatusInfo(rows)})
 }
 
 func (a *adminHandlers) handleSettingsPost(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/server/admin_settings_test.go
+++ b/backend/internal/server/admin_settings_test.go
@@ -384,3 +384,133 @@ func TestSettingsDegradedFlag(t *testing.T) {
 		t.Error("GET settings store-backed returned an empty catalog")
 	}
 }
+
+// migrateTestCookie logs into a store-backed gateway and returns the Cookie
+// header value carrying the session (mirrors settingsTestServer).
+func migrateTestCookie(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	resp := postLogin(t, ts.URL+"/admin/login", "secret")
+	defer func() { _ = resp.Body.Close() }()
+	var admin, csrf string
+	for _, c := range resp.Cookies() {
+		if c.Name == "fb_admin" {
+			admin = c.Name + "=" + c.Value
+		}
+		if c.Name == "fb_csrf" {
+			csrf = c.Value
+		}
+	}
+	if admin == "" || csrf == "" {
+		t.Fatal("login did not set fb_admin + fb_csrf cookies")
+	}
+	return admin + "; fb_csrf=" + csrf
+}
+
+// migratePayload fetches GET /admin/api/settings and returns its migrate
+// object (nil when the gateway serves live-only without a store).
+func migratePayload(t *testing.T, ts *httptest.Server, cookie string) map[string]any {
+	t.Helper()
+	code, out := settingsDo(t, http.MethodGet, ts.URL+"/admin/api/settings", cookie, "", nil)
+	if code != http.StatusOK {
+		t.Fatalf("GET settings = %d: %v", code, out)
+	}
+	raw, ok := out["migrate"]
+	if !ok || raw == nil {
+		return nil
+	}
+	mig, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("migrate = %T, want an object", raw)
+	}
+	return mig
+}
+
+// TestSettingsMigratePayloadShape pins the migrate-status readers on the
+// settings payload: from_version, applied[], noop (plus to_version, fresh,
+// marker) ride GET /admin/api/settings from the store's in-memory Open
+// report plus the marker row — read-cheap, no per-request migration work.
+func TestSettingsMigratePayloadShape(t *testing.T) {
+	t.Chdir(t.TempDir())
+	dbPath := filepath.Join(t.TempDir(), "migrate.db")
+	st, ms, err := store.OpenWithStatus(dbPath)
+	if err != nil {
+		t.Fatalf("OpenWithStatus: %v", err)
+	}
+	if ms.FromVersion != 0 || len(ms.Applied) != 4 || !ms.Fresh || ms.Noop {
+		t.Fatalf("fresh status = %+v, want {From:0 Applied:x4 Fresh:true Noop:false}", ms)
+	}
+	srv, _ := server.NewTestServerStack(t, nil, []*testutil.MockUpstream{testutil.NewMock()},
+		func(c *config.Config) { c.AdminToken = "secret" }, nil, nil, server.WithHistory(st))
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	t.Cleanup(func() { _ = st.Close() })
+	cookie := migrateTestCookie(t, ts)
+
+	// Fresh boot, marker-less: the report names the detected generation and
+	// the applied chain; the marker is absent until the env import runs.
+	mig := migratePayload(t, ts, cookie)
+	if mig == nil {
+		t.Fatal("store-backed settings has no migrate object, want the boot report")
+	}
+	if mig["from_version"] != 0.0 || mig["to_version"] != 4.0 {
+		t.Errorf("migrate from/to = %v/%v, want 0/4", mig["from_version"], mig["to_version"])
+	}
+	applied, ok := mig["applied"].([]any)
+	if !ok || len(applied) != 4 {
+		t.Fatalf("migrate applied = %v, want the 4-step chain", mig["applied"])
+	}
+	for i, v := range applied {
+		if v != float64(i+1) {
+			t.Errorf("migrate applied[%d] = %v, want %d", i, v, i+1)
+		}
+	}
+	if mig["fresh"] != true || mig["marker"] != false || mig["noop"] != false {
+		t.Errorf("migrate fresh/marker/noop = %v/%v/%v, want true/false/false", mig["fresh"], mig["marker"], mig["noop"])
+	}
+
+	// The env import flips the marker (no server restart, same handle).
+	if err := st.SetSetting(config.MigrationMarkerRow, config.MigrationMarkerValue); err != nil {
+		t.Fatalf("set marker: %v", err)
+	}
+	if mig := migratePayload(t, ts, cookie); mig["marker"] != true {
+		t.Errorf("migrate marker = %v after the import, want true", mig["marker"])
+	}
+
+	// A re-boot converges to the strict no-op shape: applied encodes [] and
+	// the marker stays set.
+	ts.Close()
+	if err := st.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	st2, ms2, err := store.OpenWithStatus(dbPath)
+	if err != nil {
+		t.Fatalf("re-OpenWithStatus: %v", err)
+	}
+	t.Cleanup(func() { _ = st2.Close() })
+	if ms2.Fresh || len(ms2.Applied) != 0 || !ms2.Noop {
+		t.Fatalf("re-boot status = %+v, want {Fresh:false Applied:[] Noop:true}", ms2)
+	}
+	srv2, _ := server.NewTestServerStack(t, nil, []*testutil.MockUpstream{testutil.NewMock()},
+		func(c *config.Config) { c.AdminToken = "secret" }, nil, nil, server.WithHistory(st2))
+	ts2 := httptest.NewServer(srv2.Handler())
+	t.Cleanup(ts2.Close)
+	mig2 := migratePayload(t, ts2, migrateTestCookie(t, ts2))
+	if mig2["marker"] != true || mig2["noop"] != true {
+		t.Errorf("re-boot migrate marker/noop = %v/%v, want true/true", mig2["marker"], mig2["noop"])
+	}
+	applied2, ok := mig2["applied"].([]any)
+	if !ok || applied2 == nil || len(applied2) != 0 {
+		t.Errorf("re-boot migrate applied = %#v, want [] (never null)", mig2["applied"])
+	}
+}
+
+// TestSettingsMigrateAbsentLiveOnly pins the degraded side: without a store
+// the settings payload carries no migrate object (there are no boot facts).
+func TestSettingsMigrateAbsentLiveOnly(t *testing.T) {
+	t.Chdir(t.TempDir())
+	ts := dashboardServer(t, "secret", nil)
+	t.Cleanup(ts.Close)
+	if mig := migratePayload(t, ts, authedCookie(t, ts)); mig != nil {
+		t.Errorf("live-only migrate = %v, want absent", mig)
+	}
+}

--- a/backend/internal/store/smartmigrate_test.go
+++ b/backend/internal/store/smartmigrate_test.go
@@ -1,0 +1,227 @@
+package store
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// fileHash snapshots one DB file's bytes after its handle is closed: a
+// re-open that performs zero writes hashes identically.
+func fileHash(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+func fileMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return fi.Mode().Perm()
+}
+
+// TestOpenWithStatusFreshInit pins generation (a): no DB file opens as a
+// fresh init running the whole goose chain, with the from-version and the
+// applied steps reported.
+func TestOpenWithStatusFreshInit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fresh.db")
+	s, st, err := OpenWithStatus(path)
+	if err != nil {
+		t.Fatalf("OpenWithStatus: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	if !st.Fresh {
+		t.Error("Fresh = false on a missing file, want true (fresh init)")
+	}
+	if st.FromVersion != 0 {
+		t.Errorf("FromVersion = %d, want 0 (no file existed)", st.FromVersion)
+	}
+	if st.ToVersion != schemaVersion {
+		t.Errorf("ToVersion = %d, want %d", st.ToVersion, schemaVersion)
+	}
+	if want := []int{1, 2, 3, 4}; !reflect.DeepEqual(st.Applied, want) {
+		t.Errorf("Applied = %v, want %v (whole chain ran)", st.Applied, want)
+	}
+	if st.Noop {
+		t.Error("Noop = true on a fresh init that created and migrated, want false")
+	}
+	// The MigrateStatus reader serves the same report from memory.
+	if got := s.MigrateStatus(); !reflect.DeepEqual(got, st) {
+		t.Errorf("MigrateStatus() = %+v, want the Open report %+v", got, st)
+	}
+	var v int
+	if err := s.db.QueryRow("PRAGMA user_version").Scan(&v); err != nil || v != schemaVersion {
+		t.Fatalf("user_version = %d, %v; want %d", v, err, schemaVersion)
+	}
+	if err := s.SetSetting("k", "v"); err != nil {
+		t.Fatalf("SetSetting on fresh file: %v", err)
+	}
+}
+
+// TestOpenWithStatusLegacyV1AppliesChain pins generation (b): a legacy
+// pre-goose v1 file auto-runs only the pending chain, keeps its rows, and
+// reports the detected from-version with the applied remainder.
+func TestOpenWithStatusLegacyV1AppliesChain(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy-v1.db")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	if _, err := raw.Exec(legacyV1Schema); err != nil {
+		t.Fatalf("v1 schema: %v", err)
+	}
+	if _, err := raw.Exec(`INSERT INTO log_entries(ts, level, msg) VALUES(1, 'INFO', 'kept')`); err != nil {
+		t.Fatalf("v1 seed: %v", err)
+	}
+	if _, err := raw.Exec(`PRAGMA user_version=1`); err != nil {
+		t.Fatalf("v1 stamp: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw close: %v", err)
+	}
+	s, st, err := OpenWithStatus(path)
+	if err != nil {
+		t.Fatalf("OpenWithStatus on v1 file: %v (want in-place migration, not rejection)", err)
+	}
+	defer func() { _ = s.Close() }()
+	if st.Fresh {
+		t.Error("Fresh = true on an existing v1 file, want false")
+	}
+	if st.FromVersion != 1 {
+		t.Errorf("FromVersion = %d, want 1 (the legacy stamp)", st.FromVersion)
+	}
+	if want := []int{2, 3, 4}; !reflect.DeepEqual(st.Applied, want) {
+		t.Errorf("Applied = %v, want %v (only the pending chain runs)", st.Applied, want)
+	}
+	if st.Noop {
+		t.Error("Noop = true after running three migrations, want false")
+	}
+	got, err := s.QueryLogs(LogFilter{})
+	if err != nil || len(got) != 1 || got[0].Msg != "kept" {
+		t.Fatalf("v1 history lost in migration: %+v %v", got, err)
+	}
+	var maxV int
+	if err := s.db.QueryRow(`SELECT MAX(version_id) FROM goose_db_version`).Scan(&maxV); err != nil || maxV != schemaVersion {
+		t.Fatalf("goose MAX(version_id) = %d, %v; want %d", maxV, err, schemaVersion)
+	}
+}
+
+// TestOpenWithStatusLegacyV4TakeoverThenNoop pins the pre-goose v4 path: the
+// first boot baselines the whole chain (a write, so not a no-op) with every
+// row intact, and the immediate re-boot is the strict no-op.
+func TestOpenWithStatusLegacyV4TakeoverThenNoop(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy-v4.db")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	if _, err := raw.Exec(legacyV4Schema); err != nil {
+		t.Fatalf("v4 schema: %v", err)
+	}
+	if _, err := raw.Exec(`INSERT INTO log_entries(ts, level, msg) VALUES(1, 'INFO', 'kept')`); err != nil {
+		t.Fatalf("v4 seed: %v", err)
+	}
+	if _, err := raw.Exec(`PRAGMA user_version=4`); err != nil {
+		t.Fatalf("v4 stamp: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw close: %v", err)
+	}
+
+	first, fst, err := OpenWithStatus(path)
+	if err != nil {
+		t.Fatalf("first OpenWithStatus: %v", err)
+	}
+	if fst.FromVersion != 4 || fst.ToVersion != schemaVersion {
+		t.Errorf("takeover from/to = %d->%d, want 4->%d", fst.FromVersion, fst.ToVersion, schemaVersion)
+	}
+	if len(fst.Applied) != 0 {
+		t.Errorf("takeover Applied = %v, want [] (chain baselined, nothing ran)", fst.Applied)
+	}
+	if fst.Noop {
+		t.Error("takeover Noop = true, want false (baseline seeding wrote)")
+	}
+	got, err := first.QueryLogs(LogFilter{})
+	if err != nil || len(got) != 1 || got[0].Msg != "kept" {
+		_ = first.Close()
+		t.Fatalf("v4 history lost in takeover: %+v %v", got, err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	second, snd, err := OpenWithStatus(path)
+	if err != nil {
+		t.Fatalf("second OpenWithStatus: %v", err)
+	}
+	defer func() { _ = second.Close() }()
+	if snd.Fresh || len(snd.Applied) != 0 || !snd.Noop {
+		t.Errorf("re-boot status = %+v, want {Fresh:false Applied:[] Noop:true}", snd)
+	}
+	if snd.Applied == nil {
+		t.Error("Applied is nil after a no-op boot, want [] (dashboard encodes null otherwise)")
+	}
+}
+
+// TestOpenSteadyStateStrictNoop pins generation (d) at the file level: a
+// re-boot on a converged file performs zero writes (identical bytes and
+// mode) and reports the no-op.
+func TestOpenSteadyStateStrictNoop(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "steady.db")
+	first, _, err := OpenWithStatus(path)
+	if err != nil {
+		t.Fatalf("first OpenWithStatus: %v", err)
+	}
+	if err := first.SetSetting("steady", "1"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	beforeHash, beforeMode := fileHash(t, path), fileMode(t, path)
+	if beforeMode != 0o600 {
+		t.Fatalf("mode = %o, want 600 before the no-op re-boot", beforeMode)
+	}
+
+	second, st, err := OpenWithStatus(path)
+	if err != nil {
+		t.Fatalf("second OpenWithStatus: %v", err)
+	}
+	if st.Fresh {
+		t.Error("Fresh = true on an existing converged file, want false")
+	}
+	if st.FromVersion != schemaVersion || st.ToVersion != schemaVersion {
+		t.Errorf("from/to = %d->%d, want %d->%d", st.FromVersion, st.ToVersion, schemaVersion, schemaVersion)
+	}
+	if len(st.Applied) != 0 {
+		t.Errorf("Applied = %v on a converged file, want []", st.Applied)
+	}
+	if !st.Noop {
+		t.Error("Noop = false on a converged re-boot, want true")
+	}
+	if got, ok, err := second.GetSetting("steady"); err != nil || !ok || got != "1" {
+		t.Errorf("row lost across re-boot: %q %v %v", got, ok, err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if got := fileHash(t, path); got != beforeHash {
+		t.Error("DB bytes changed across a no-op re-boot (want zero writes)")
+	}
+	if got := fileMode(t, path); got != beforeMode {
+		t.Errorf("DB mode = %o across a no-op re-boot, want %o (unchanged)", got, beforeMode)
+	}
+}

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -120,6 +120,40 @@ func Millis(t time.Time) int64 { return t.UnixMilli() }
 // Store wraps the history database. Zero value is unusable; Open first.
 type Store struct {
 	db *sql.DB
+	// status is the boot migration report captured by OpenWithStatus:
+	// the detected from-version plus the goose versions that actually ran.
+	// In-memory only (no DB reads); MigrateStatus returns a copy.
+	status MigrateStatus
+}
+
+// MigrateStatus is the boot-time smart-migration report for one DB file:
+// which data generation Open found and what it did to converge it.
+// FromVersion is the detected PRAGMA user_version stamp before migration
+// (0 means no DB file existed — a fresh init); ToVersion is always the
+// current schemaVersion; Applied lists the goose versions that actually
+// executed this boot (baselined versions were recorded, never run, so a
+// legacy v4 takeover reports an empty Applied); Fresh reports a fresh init;
+// Noop reports a strict no-op boot (no schema writes: an existing file
+// already at the latest version with nothing pending). Applied is never nil
+// so the dashboard payload encodes [] rather than null.
+type MigrateStatus struct {
+	FromVersion int   `json:"from_version"`
+	ToVersion   int   `json:"to_version"`
+	Applied     []int `json:"applied"`
+	Fresh       bool  `json:"fresh"`
+	Noop        bool  `json:"noop"`
+}
+
+// MigrateStatus returns the boot migration report captured at Open. It is a
+// copy over in-memory state: read-cheap (no DB I/O), safe for per-request
+// dashboard readers.
+func (s *Store) MigrateStatus() MigrateStatus {
+	if s == nil {
+		return MigrateStatus{Applied: []int{}}
+	}
+	out := s.status
+	out.Applied = append([]int{}, s.status.Applied...)
+	return out
 }
 
 // defaultDBPath is the DB file used when DB_PATH is unset: ./data/freebuff.db
@@ -142,16 +176,46 @@ func DBPathFromEnv() string {
 // place with zero data change (a legacy user_version stamp baselines the
 // matching migrations as applied; only the remainder runs); any other
 // version mismatch or unusable file returns an error and the caller runs
-// live-only. Open never fails the boot itself.
+// live-only. Open never fails the boot itself. The boot migration report is
+// discarded; OpenWithStatus keeps it.
 func Open(path string) (*Store, error) {
+	s, _, err := OpenWithStatus(path)
+	return s, err
+}
+
+// OpenWithStatus is Open plus the boot-time smart-migration report: it
+// detects the file's data generation first ((a) no DB file: fresh init,
+// (b) legacy pre-goose stamp: baseline + run the pending goose chain,
+// (c) goose-converged file: nothing pending), converges it to the latest
+// schema, and reports the detected from-version with the versions that
+// actually ran. The env-to-DB import (marker config:migrated_env_v1) runs
+// after this returns, owned by the caller (cli), so a marker-less file
+// still imports on this boot and a marked file stays a strict no-op.
+//
+// Idempotency: a re-boot on a converged file (user_version at the latest,
+// goose chain fully applied, mode already 0600) performs zero writes — the
+// version stamp, the chmod, and the goose Up are all skipped when already
+// correct, so only reads run. The 0600 enforcement itself stays: a fresh
+// create or a pre-migration 0644 file is still tightened (a chmod failure
+// fails the open and the caller degrades to live-only).
+func OpenWithStatus(path string) (*Store, MigrateStatus, error) {
+	st := MigrateStatus{ToVersion: schemaVersion, Applied: []int{}}
 	if dir := filepath.Dir(path); dir != "" {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return nil, fmt.Errorf("store: mkdir %s: %w", dir, err)
+			return nil, st, fmt.Errorf("store: mkdir %s: %w", dir, err)
 		}
+	}
+	// Fresh-init detection runs before sql.Open creates the file: a missing
+	// path means generation (a), an existing file reports its stamp below.
+	if _, err := os.Stat(path); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, st, fmt.Errorf("store: stat %s: %w", path, err)
+		}
+		st.Fresh = true
 	}
 	db, err := sql.Open("sqlite", path)
 	if err != nil {
-		return nil, fmt.Errorf("store: open %s: %w", path, err)
+		return nil, st, fmt.Errorf("store: open %s: %w", path, err)
 	}
 	for _, p := range []string{
 		"PRAGMA journal_mode=WAL",
@@ -160,51 +224,74 @@ func Open(path string) (*Store, error) {
 	} {
 		if _, err := db.Exec(p); err != nil {
 			_ = db.Close()
-			return nil, fmt.Errorf("store: %s: %w", p, err)
+			return nil, st, fmt.Errorf("store: %s: %w", p, err)
 		}
 	}
 	var v int
 	if err := db.QueryRow("PRAGMA user_version").Scan(&v); err != nil {
 		_ = db.Close()
-		return nil, fmt.Errorf("store: user_version: %w", err)
+		return nil, st, fmt.Errorf("store: user_version: %w", err)
 	}
+	st.FromVersion = v
 	switch v {
 	case 0, 1, 2, 3, schemaVersion:
 		// Fresh file or a supported legacy stamp: goose converges it.
 	default:
 		_ = db.Close()
-		return nil, fmt.Errorf("store: schema v%d unsupported (want v%d)", v, schemaVersion)
+		return nil, st, fmt.Errorf("store: schema v%d unsupported (want v%d)", v, schemaVersion)
 	}
-	if err := migrateUp(db, v); err != nil {
+	seeded := false
+	if v == schemaVersion && gooseAtLatest(db) {
+		// Steady-state re-boot: the chain is fully applied, so Up would
+		// run nothing — skip it (and the stamp below) for zero writes.
+	} else if applied, didSeed, err := migrateUp(db, v); err != nil {
 		_ = db.Close()
-		return nil, err
+		return nil, st, err
+	} else {
+		st.Applied = applied
+		seeded = didSeed
 	}
-	if _, err := db.Exec(fmt.Sprintf("PRAGMA user_version=%d", schemaVersion)); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("store: stamp version: %w", err)
+	st.Noop = !st.Fresh && len(st.Applied) == 0 && !seeded
+	// The stamp only ever moves forward: skip the write when already there
+	// (steady-state boots leave the header bytes untouched).
+	if v != schemaVersion {
+		if _, err := db.Exec(fmt.Sprintf("PRAGMA user_version=%d", schemaVersion)); err != nil {
+			_ = db.Close()
+			return nil, st, fmt.Errorf("store: stamp version: %w", err)
+		}
 	}
 	// The settings table holds secrets since the env-to-DB migration
 	// (AUTH_TOKENS, ADMIN_TOKEN, API_KEYS, WEBHOOK_URL overlay rows), so
 	// the file is kept at 0600: a fresh create inherits umask-loosened
 	// modes, and a pre-migration file may still be 0644. Best-effort is
 	// not enough for credential material — a chmod failure fails the open
-	// and the caller degrades to live-only.
-	if err := os.Chmod(path, 0o600); err != nil {
+	// and the caller degrades to live-only. Already-0600 files skip the
+	// call so steady-state boots change nothing.
+	if fi, err := os.Stat(path); err != nil {
 		_ = db.Close()
-		return nil, fmt.Errorf("store: chmod 0600 %s: %w", path, err)
+		return nil, st, fmt.Errorf("store: stat %s: %w", path, err)
+	} else if fi.Mode().Perm() != 0o600 {
+		if err := os.Chmod(path, 0o600); err != nil {
+			_ = db.Close()
+			return nil, st, fmt.Errorf("store: chmod 0600 %s: %w", path, err)
+		}
 	}
-	return &Store{db: db}, nil
+	return &Store{db: db, status: st}, st, nil
 }
 
 // migrateUp brings any supported file to the latest schema via the embedded
 // goose migrations. Pre-goose files (user_version 1..4) carry no version
 // rows, so versions at or below the baseline are recorded as applied without
 // running — their objects already exist — and only the remainder executes.
-// Every row is preserved; only DDL runs.
-func migrateUp(db *sql.DB, legacy int) error {
+// Every row is preserved; only DDL runs. It returns the versions that
+// actually executed (never nil: empty when Up ran nothing, e.g. a legacy v4
+// takeover whose whole chain baselined) and whether baseline rows were
+// seeded (a write even when nothing executed, so callers can tell a
+// first-boot takeover from a steady-state no-op).
+func migrateUp(db *sql.DB, legacy int) (applied []int, seeded bool, err error) {
 	sub, err := fs.Sub(migrationsFS, "migrations")
 	if err != nil {
-		return fmt.Errorf("store: migrations fs: %w", err)
+		return nil, false, fmt.Errorf("store: migrations fs: %w", err)
 	}
 	provider, err := goose.NewProvider(
 		goose.DialectSQLite3,
@@ -214,15 +301,15 @@ func migrateUp(db *sql.DB, legacy int) error {
 		goose.WithLogger(goose.NopLogger()),
 	)
 	if err != nil {
-		return fmt.Errorf("store: goose provider: %w", err)
+		return nil, false, fmt.Errorf("store: goose provider: %w", err)
 	}
 	if base := baselineVersion(db, legacy); base > 0 {
 		if _, err := db.Exec(gooseVersionDDL); err != nil {
-			return fmt.Errorf("store: goose version table: %w", err)
+			return nil, false, fmt.Errorf("store: goose version table: %w", err)
 		}
 		var n int
 		if err := db.QueryRow(`SELECT COUNT(*) FROM goose_db_version`).Scan(&n); err != nil {
-			return fmt.Errorf("store: goose version count: %w", err)
+			return nil, false, fmt.Errorf("store: goose version count: %w", err)
 		}
 		if n == 0 {
 			// Seed 0..base: goose's own convention inserts a zero version
@@ -232,15 +319,73 @@ func migrateUp(db *sql.DB, legacy int) error {
 			// table just made above.
 			for v := 0; v <= base; v++ {
 				if _, err := db.Exec(`INSERT INTO goose_db_version (version_id, is_applied) VALUES (?, 1)`, v); err != nil {
-					return fmt.Errorf("store: baseline goose v%d: %w", v, err)
+					return nil, false, fmt.Errorf("store: baseline goose v%d: %w", v, err)
 				}
 			}
+			seeded = true
 		}
 	}
+	// Versions present before Up are baselined-or-current (never executed
+	// this boot); the diff after Up is exactly what ran. Version 0 is
+	// goose's own bookkeeping row, never a migration step.
+	before := gooseVersions(db)
 	if _, err := provider.Up(context.Background()); err != nil {
-		return fmt.Errorf("store: migrate up: %w", err)
+		return nil, seeded, fmt.Errorf("store: migrate up: %w", err)
 	}
-	return nil
+	after := gooseVersions(db)
+	applied = []int{}
+	for v := 1; v <= schemaVersion; v++ {
+		if after[v] && !before[v] {
+			applied = append(applied, v)
+		}
+	}
+	return applied, seeded, nil
+}
+
+// gooseVersions returns the set of applied goose version_ids (the version 0
+// bookkeeping row included when present). A missing version table reads as
+// empty — the caller baselines first — and any read failure degrades the
+// same way: the Up diff then reports every present version as applied,
+// which only over-reports the log lines, never the schema.
+func gooseVersions(db *sql.DB) map[int]bool {
+	out := map[int]bool{}
+	if !hasTable(db, "goose_db_version") {
+		return out
+	}
+	rows, err := db.Query(`SELECT version_id FROM goose_db_version WHERE is_applied = 1`)
+	if err != nil {
+		return out
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var v int
+		if err := rows.Scan(&v); err != nil {
+			return map[int]bool{}
+		}
+		out[v] = true
+	}
+	return out
+}
+
+// gooseAtLatest reports whether the goose chain is fully applied (versions
+// 1..schemaVersion recorded, tip at the latest): the read-cheap gate that
+// lets steady-state boots skip Up entirely for zero writes.
+func gooseAtLatest(db *sql.DB) bool {
+	if !hasTable(db, "goose_db_version") {
+		return false
+	}
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM goose_db_version WHERE is_applied = 1 AND version_id BETWEEN 1 AND ?`, schemaVersion).Scan(&n); err != nil {
+		return false
+	}
+	if n != schemaVersion {
+		return false
+	}
+	var max int
+	if err := db.QueryRow(`SELECT MAX(version_id) FROM goose_db_version WHERE is_applied = 1`).Scan(&max); err != nil {
+		return false
+	}
+	return max == schemaVersion
 }
 
 // baselineVersion maps a legacy PRAGMA user_version stamp to the goose


### PR DESCRIPTION
Boot-time smart migration: detect any old data shape and auto-migrate to latest, so every deploy self-heals with zero operator steps.

**Generations (open -> goose up-to-latest -> env import if marker missing -> set marker):**
- (a) no DB file -> fresh init (full 00001-00004 chain, then env import)
- (b) legacy pre-goose `user_version` stamp -> baseline + pending chain automatically
- (c) goose DB without `config:migrated_env_v1` -> env-to-DB import
- (d) marker + latest goose -> strict no-op (zero writes)

**Version-aware:** `store.MigrateStatus{from_version,to_version,applied[],fresh,noop}` captured once at `OpenWithStatus`, served from memory. Boot logs one INFO line per applied goose version plus a from->to `smart migrate complete` summary (a migrate failure poisons the noop verdict). `GET /admin/api/settings` carries `migrate{from_version,applied,noop,...}` with no extra DB round trip (marker from the already-fetched rows).

**Idempotency:** user_version stamp, 0600 chmod, and goose Up are each skipped when already correct. Precedence unchanged (env wins); 0600 enforcement stays.

**Tests:** fresh/legacy-v1/v4-takeover/steady-state status, markerless goose import, marked-latest zero writes via file hash+mode (store+cli), env-wins-after-migrate, settings payload shape incl. live-only absence. No implementation-text pins; nothing found to delete.

**Verification notes for merger:**
- `gofmt` clean (checked); zero frontend files in the diff.
- Local `go test`/`go vet` intentionally NOT run (owner ban on workstation builds) — please confirm hermetic `env -u AUTH_TOKENS -u ADMIN_TOKEN go test ./backend/...` + `go vet` green here or on acerblue before merge.
- `backend/internal/dashboard/data/openapi.json` hand-updated to match the emitter output for the new optional field (no local `go run`); please run `go generate ./backend/internal/dashboard/` on Linux and confirm byte-identical.
- Do NOT merge from here; parent merges.