### PR TITLE
feat(pool): nightly streak touch runs admit-turn-release

### DIFF
--- a/backend/internal/pool/maturity.go
+++ b/backend/internal/pool/maturity.go
@@ -28,6 +28,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -533,8 +534,10 @@ func (p *Pool) maturityAccountAdvance(idx int, tok *tokenEntry, cached *upstream
 }
 
 // maturityFire performs one touch: dry-run probes (zero-cost, never claims
-// a slot); live mode admits the touch model through the token's own session
-// manager — wire-identical to a user opening the CLI. It reports whether
+// a slot); live mode runs admit → one minimal turn → release through the
+// token's own session manager and upstream client — wire-identical to a user
+// opening the CLI and sending one message, because upstream advances streaks
+// on agent-run message rows, not bare admission. It reports whether
 // the touch was rate-limited (429): the nightly walk aborts on the first
 // 429 and backs off. The IsServedModel honeypot rejection and the
 // fail-closed priced-touch skips above stay untouched.
@@ -581,7 +584,7 @@ func (p *Pool) maturityFire(ctx context.Context, dryRun bool, touchModel string,
 		action = "probe"
 		_, err = tok.client.ProbeAccount(fire)
 	} else {
-		_, err = tok.session.EnsureSessionForModel(fire, model)
+		err = p.maturityTouchRun(fire, tok, model, idx, label, now)
 	}
 	result := "ok"
 	if err != nil {
@@ -610,6 +613,127 @@ func (p *Pool) maturityFire(ctx context.Context, dryRun bool, touchModel string,
 	p.logger.Info("pool: maturity touch fired", "token", idx+1, "token_label", label,
 		"action", action, "model", model, "streak", cached.Streak)
 	return false
+}
+
+const (
+	// maturityTouchPrompt is the trivial touch-turn user message: it exists
+	// only to leave one agent-run message row upstream (bare admission
+	// leaves none, so it never advances the streak).
+	maturityTouchPrompt = "ping"
+	// maturityRefundReplays bounds the pending-refund DELETE replay loop
+	// after a touch release: the manager parks a pending receipt for later
+	// EndSessions anyway, so the touch replays inline a few times and leaves
+	// the rest to that path.
+	maturityRefundReplays = 3
+)
+
+// maturityTouchRun performs the live streak touch: admit the touch model,
+// run one minimal agent turn bound to the session instance (effort none —
+// the reasoning_effort key stays absent, the silent-turn contract), finish
+// the run, then release the session with pending-refund replay. The turn is
+// the load-bearing step: upstream advances streaks on agent-run message
+// rows, not bare admission.
+//
+// The turn rides the token's upstream client directly — never Pool.Chat —
+// so it cannot feed the Pacific-day activity ledger (recordDayRequest): the
+// client-active skip stays a pure client-traffic signal. A failed turn keeps
+// the admitted session for real traffic to reuse (the old admit-only
+// behavior); only a successful turn releases it, through the session
+// manager's real refund handler (the vendor port's recordReleaseReceipt +
+// RefreshRefund), never a body-discarding DELETE.
+func (p *Pool) maturityTouchRun(ctx context.Context, tok *tokenEntry, model string, idx int, label string, now time.Time) error {
+	instanceID, err := tok.session.EnsureSessionForModel(ctx, model)
+	if err != nil {
+		return err
+	}
+	agentID := ""
+	if p.reg != nil {
+		if a, aerr := p.reg.AgentForModel(model); aerr == nil {
+			agentID = a
+		}
+	}
+	if agentID == "" {
+		p.logger.Warn("pool: maturity touch has no agent for model, keeping session for reuse",
+			"token", idx+1, "token_label", label, "model", model)
+		return fmt.Errorf("pool: maturity touch: no agent for model %s", model)
+	}
+	runID, err := tok.client.StartRun(ctx, agentID)
+	if err != nil {
+		return err
+	}
+	turnErr := p.maturityTouchTurn(ctx, tok, model, agentID, runID, instanceID)
+	finStatus := "completed"
+	if turnErr != nil {
+		finStatus = "failed"
+	}
+	step := upstream.RunStep{
+		ID:         fmt.Sprintf("maturity-touch-%d", now.UnixNano()),
+		StepNumber: 1,
+		Status:     finStatus,
+		StartTime:  now.UTC().Format(time.RFC3339Nano),
+	}
+	// Every START gets its FINISH (the runs drain path does the same): the
+	// failure path still closes the run, best-effort, without masking the
+	// turn error.
+	ferr := tok.client.FinishRun(ctx, runID, finStatus, 1, []upstream.RunStep{step}, "")
+	if turnErr != nil {
+		return turnErr
+	}
+	if ferr != nil {
+		return ferr
+	}
+	if rerr := p.maturityReleaseTouch(ctx, tok, label, idx); rerr != nil {
+		// The streak goal (one message row) is already met and the manager
+		// keeps any parked refund replayable — release trouble stays
+		// warn-only.
+		p.logger.Warn("pool: maturity touch release troubled, streak turn already landed",
+			"token", idx+1, "token_label", label, "err", rerr)
+	}
+	return nil
+}
+
+// maturityTouchTurn sends the one minimal touch turn: a trivial prompt with
+// no reasoning_effort key (effort none), bound to the admitted instance and
+// the fresh run. The response body is drained (bounded) and closed; only its
+// 2xx matters — the message row it leaves upstream is the streak advance.
+func (p *Pool) maturityTouchTurn(ctx context.Context, tok *tokenEntry, model, agentID, runID, instanceID string) error {
+	body, err := json.Marshal(map[string]any{
+		"model":    model,
+		"stream":   false,
+		"messages": []map[string]string{{"role": "user", "content": maturityTouchPrompt}},
+	})
+	if err != nil {
+		return err
+	}
+	rc, err := tok.client.ChatCompletions(ctx, upstream.ChatOptions{
+		Model:             model,
+		RunID:             runID,
+		SessionInstanceID: instanceID,
+		AgentID:           agentID,
+		StepNumber:        1,
+	}, body)
+	if err != nil {
+		return err
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(rc, 64*1024))
+	_ = rc.Close()
+	return nil
+}
+
+// maturityReleaseTouch releases the touch session through the session
+// manager — the port's real refund handler — then replays a parked
+// pending-refund DELETE inline (bounded): a settled replay records
+// lastRefund, a still-pending one stays parked for a later EndSession.
+func (p *Pool) maturityReleaseTouch(ctx context.Context, tok *tokenEntry, label string, idx int) error {
+	if err := tok.session.EndSession(ctx); err != nil {
+		return err
+	}
+	for i := 0; i < maturityRefundReplays && tok.session.Snapshot().PendingRefund != ""; i++ {
+		if err := tok.session.RefreshRefund(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // maturityGuardTouchModel fails a misconfigured unmetered touch model

--- a/backend/internal/pool/maturity_touch_test.go
+++ b/backend/internal/pool/maturity_touch_test.go
@@ -1,0 +1,212 @@
+package pool
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"freebuff-proxy/backend/internal/testutil"
+)
+
+// touchRunSatisfied is the run check: upstream advances streaks on agent-run
+// message rows, not bare admission, so a touch counts only when it STARTed a
+// run, sent at least one chat turn, and FINISHed the run. Probe-only and
+// admit-only touches leave all three counters at zero.
+func touchRunSatisfied(mock *testutil.MockUpstream) bool {
+	return len(mock.StartedRunsSnapshot()) > 0 &&
+		len(mock.RecordedChatBodiesSnapshot()) > 0 &&
+		len(mock.FinishedRunsSnapshot()) > 0
+}
+
+// A live touch runs admit → one minimal turn → release: the stub sees the
+// session create, the run START, the bound chat turn, the FINISH, and the
+// session DELETE, while the Pacific-day activity ledger stays empty (the
+// turn rides the upstream client directly, never Pool.Chat).
+func TestMaturityLiveTouchAdmitsTurnReleases(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	p := newMaturityPool(t, mock, false)
+	now := windowNow()
+	seedStreak(p, 0, 2, false, now)
+	if err := p.SetMaturity(0, true, 7, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	setMaturitySlot(p, 0, now.Add(-time.Hour), laDay(now))
+
+	p.maturityTickAt(context.Background(), now)
+
+	if !touchRunSatisfied(mock) {
+		t.Fatalf("run check unsatisfied: starts=%d chats=%d finishes=%d, want all >=1 (admit-turn-release)",
+			len(mock.StartedRunsSnapshot()), len(mock.RecordedChatBodiesSnapshot()), len(mock.FinishedRunsSnapshot()))
+	}
+	if got := mock.SessionCreatesSnapshot(); got != 1 {
+		t.Errorf("SessionCreates = %d, want 1 (one admit)", got)
+	}
+	if got := mock.SessionProbesSnapshot(); got != 0 {
+		t.Errorf("SessionProbes = %d, want 0 (live touch never probes)", got)
+	}
+	starts := mock.StartRequestsSnapshot()
+	if len(starts) != 1 || starts[0].AgentID == "" {
+		t.Errorf("START requests = %+v, want one with a resolved agent id", starts)
+	}
+	if len(starts) == 1 && len(starts[0].AncestorRunIDs) != 0 {
+		t.Errorf("START ancestorRunIds = %v, want empty (fresh run)", starts[0].AncestorRunIDs)
+	}
+	// The turn binds the admitted instance and the fresh run, with effort
+	// none (no reasoning_effort key at either level: the silent-turn
+	// contract is key-absent).
+	turn := mock.LastChatBody()
+	var payload struct {
+		Metadata map[string]any `json:"codebuff_metadata"`
+	}
+	if err := json.Unmarshal([]byte(turn), &payload); err != nil {
+		t.Fatalf("turn body is not JSON: %v", err)
+	}
+	if got, _ := payload.Metadata["freebuff_instance_id"].(string); got != mock.InstanceID {
+		t.Errorf("turn freebuff_instance_id = %q, want %q (admitted instance)", got, mock.InstanceID)
+	}
+	if got, _ := payload.Metadata["run_id"].(string); got != "run-0001" {
+		t.Errorf("turn run_id = %q, want run-0001 (fresh run)", got)
+	}
+	if _, ok := payload.Metadata["freebuff_reasoning_effort"]; ok {
+		t.Error("turn carries freebuff_reasoning_effort, want absent (effort none)")
+	}
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(turn), &raw); err != nil {
+		t.Fatalf("turn body is not a JSON object: %v", err)
+	}
+	if _, ok := raw["reasoning_effort"]; ok {
+		t.Error("turn carries top-level reasoning_effort, want absent (effort none)")
+	}
+	fin := mock.FinishedRunsSnapshot()
+	if len(fin) != 1 || fin[0].RunID != "run-0001" || fin[0].Status != "completed" || fin[0].TotalSteps != 1 {
+		t.Errorf("finished runs = %+v, want one completed run-0001 with totalSteps 1", fin)
+	}
+	if len(fin) == 1 && (len(fin[0].Steps) != 1 || fin[0].Steps[0].StepNumber != 1) {
+		t.Errorf("finished steps = %+v, want the one completed turn step", fin[0].Steps)
+	}
+	if got := mock.SessionEndsSnapshot(); got < 1 {
+		t.Errorf("SessionEnds = %d, want >=1 (touch releases its session)", got)
+	}
+	action, result := maturityResult(p, 0)
+	if action != "admit" || result != "ok" {
+		t.Errorf("last touch = %q/%q, want admit/ok", action, result)
+	}
+	// The touch rides the upstream client directly, never Pool.Chat: the
+	// Pacific-day activity ledger stays empty so automation never self-skips
+	// via skip:client-active.
+	if got := p.dayRequestCount(0); got != 0 {
+		t.Errorf("dayRequestCount = %d, want 0 (touch never feeds the activity ledger)", got)
+	}
+}
+
+// A dry-run touch probes only: no run starts, no turn, no finish — the run
+// check stays unsatisfied and the activity ledger stays empty.
+func TestMaturityProbeTouchSatisfiesNoRun(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	p := newMaturityPool(t, mock, true)
+	now := windowNow()
+	seedStreak(p, 0, 2, false, now)
+	if err := p.SetMaturity(0, true, 7, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	setMaturitySlot(p, 0, now.Add(-time.Hour), laDay(now))
+
+	p.maturityTickAt(context.Background(), now)
+
+	if touchRunSatisfied(mock) {
+		t.Error("probe touch satisfies the run check, want no run without admit-turn-release")
+	}
+	if got := mock.SessionProbesSnapshot(); got != 1 {
+		t.Errorf("SessionProbes = %d, want 1 (dry-run probe)", got)
+	}
+	if got := p.dayRequestCount(0); got != 0 {
+		t.Errorf("dayRequestCount = %d, want 0 (probe never feeds the activity ledger)", got)
+	}
+	action, result := maturityResult(p, 0)
+	if action != "probe" || result != "ok" {
+		t.Errorf("last touch = %q/%q, want probe/ok", action, result)
+	}
+}
+
+// Bare admission leaves no agent-run row: admitting without a turn does not
+// satisfy the run check. This pins the premise the triple is built on.
+func TestMaturityBareAdmissionSatisfiesNoRun(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	p := newMaturityPool(t, mock, false)
+
+	toks := p.roster.Load()
+	if _, err := (*toks)[0].session.EnsureSessionForModel(context.Background(), modelB); err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+
+	if touchRunSatisfied(mock) {
+		t.Error("bare admission satisfies the run check, want no run without a turn")
+	}
+	if got := mock.SessionCreatesSnapshot(); got != 1 {
+		t.Errorf("SessionCreates = %d, want 1 (admitted, nothing more)", got)
+	}
+}
+
+// A touch whose release receipt reports a pending refund replays the DELETE
+// with the same instance until it settles, through the session manager's
+// real refund handler: two DELETEs, pending cleared, lastRefund recorded.
+func TestMaturityTouchReplaysPendingRefund(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	p := newMaturityPool(t, mock, false)
+	now := windowNow()
+	seedStreak(p, 0, 2, false, now)
+	if err := p.SetMaturity(0, true, 7, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	setMaturitySlot(p, 0, now.Add(-time.Hour), laDay(now))
+
+	deletes := 0
+	mock.SessionHandler = func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deletes++
+			w.Header().Set("Content-Type", "application/json")
+			if deletes == 1 {
+				_, _ = io.WriteString(w, `{"status":"ended","instanceId":"inst-abc-123","freebucksRefundPending":true}`)
+			} else {
+				_, _ = io.WriteString(w, `{"status":"ended","instanceId":"inst-abc-123","freebucksRefund":1.5}`)
+			}
+			return
+		}
+		// Minimal active-session shape (mirrors the mock's default create):
+		// the touch only needs an admitted instance to bind its turn to.
+		expiresAt := time.Now().Add(30 * time.Minute).UTC().Format("2006-01-02T15:04:05.000Z07:00")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":"active","instanceId":"inst-abc-123","expiresAt":"`+expiresAt+`"}`)
+	}
+
+	p.maturityTickAt(context.Background(), now)
+
+	if !touchRunSatisfied(mock) {
+		t.Fatal("run check unsatisfied on the refund-replay touch, want admit-turn-release first")
+	}
+	if deletes != 2 {
+		t.Errorf("deletes = %d, want 2 (release + one pending-refund replay)", deletes)
+	}
+	toks := p.roster.Load()
+	snap := (*toks)[0].sessionMgr().Snapshot()
+	if snap.PendingRefund != "" {
+		t.Errorf("PendingRefund = %q, want cleared after settle", snap.PendingRefund)
+	}
+	if snap.LastRefund == nil || *snap.LastRefund != 1.5 {
+		t.Errorf("LastRefund = %+v, want 1.5 (settled replay receipt)", snap.LastRefund)
+	}
+	action, result := maturityResult(p, 0)
+	if action != "admit" || result != "ok" {
+		t.Errorf("last touch = %q/%q, want admit/ok (replay is warn-only)", action, result)
+	}
+	if got := p.dayRequestCount(0); got != 0 {
+		t.Errorf("dayRequestCount = %d, want 0 (touch never feeds the activity ledger)", got)
+	}
+}

--- a/backend/internal/testutil/mockupstream.go
+++ b/backend/internal/testutil/mockupstream.go
@@ -748,6 +748,14 @@ func (m *MockUpstream) SessionProbesSnapshot() int {
 	return m.SessionProbes
 }
 
+// SessionEndsSnapshot returns a locked copy of the session-DELETE counter
+// (see StartedRunsSnapshot).
+func (m *MockUpstream) SessionEndsSnapshot() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.SessionEnds
+}
+
 // StreakHitsSnapshot returns a locked copy of the streak-GET counter.
 func (m *MockUpstream) StreakHitsSnapshot() int {
 	m.mu.Lock()


### PR DESCRIPTION
Real streak maintenance: the nightly touch becomes admit → one minimal turn → release, because upstream advances streaks on agent-run message rows, not bare admission.

**Touch triple** (`pool/maturity.go: maturityTouchRun`): admit via `EnsureSessionForModel` → `StartRun` (registry-resolved agent) → one trivial `ChatCompletions` turn bound to the instance + run with effort none (no `reasoning_effort` key, silent-turn contract) → `FinishRun(completed, 1 step)` → release through the session manager's real refund handler (`EndSession` + bounded `RefreshRefund` replay, port #488).

**Contracts preserved:**
- Turn rides `tok.client` directly, never `Pool.Chat` — `dayRequestCount` stays a pure client-traffic signal (only contact is the read-only `skip:client-active` gate).
- Health gates first, price-0 unmetered only, one touch per account per night (slot + touchDay + upstream TodayUsed), restart idempotency, dry-run stays slot-less probe, first-429 abort + 15m backoff, warn-only failures (failed turn keeps the session for reuse; release trouble after a landed turn stays warn-only).
- Failed turns still FINISH their run (`failed` status) so no run is stranded open.

**Tests** (`pool/maturity_touch_test.go` + `SessionEndsSnapshot` mock accessor): stub asserts admit-turn-release satisfies the run check (START + bound turn + FINISH + DELETE) while probe-only and bare-admit touches do not; touch never increments `dayRequestCount`; pending-refund receipt replays the DELETE to a settled `lastRefund`.

Backend affected-surface green (pool/session/upstream/runs/registry). Full hermetic suite: 30 packages ok; `store`/`cli` perm-bit and `archtest` binary-lock failures reproduce on pristine `ab4db8a` (Windows environmental, unrelated).