### PR TITLE
fix(upstream): wire hierarchy gate, peak_hours underscore, any-status turn breaker

### DIFF
--- a/backend/internal/server/error_taxonomy.go
+++ b/backend/internal/server/error_taxonomy.go
@@ -31,6 +31,8 @@ func defaultHintForCode(code, message string) string {
 	switch {
 	case code == "free_mode_cli_required" || strings.Contains(lowerMsg, "free_mode_cli_required"):
 		return "Upstream free tier gate requires official CLI traffic envelope. See FAQ: https://github.com/trefeon/freebuff-proxy#faq"
+	case code == "free_mode_invalid_agent_hierarchy" || strings.Contains(lowerMsg, "free_mode_invalid_agent_hierarchy"):
+		return "Upstream hierarchy gate rejected the subagent (not in its root's allowlist). Retry with a root agent id from the registry."
 	case code == "free_mode_legacy_luna_agent" || strings.Contains(lowerMsg, "free_mode_legacy_luna_agent"):
 		return "Retired Luna agent — new session required, retry immediately."
 	case code == "free_mode_rate_limited" || strings.Contains(lowerMsg, "free_mode_rate_limited"):

--- a/backend/internal/server/errors.go
+++ b/backend/internal/server/errors.go
@@ -354,6 +354,9 @@ func (s *Server) writeError(w http.ResponseWriter, r *http.Request, err error, m
 	case errors.Is(err, upstream.ErrFreeModeCLIRequired):
 		status, code = http.StatusForbidden, "free_mode_cli_required"
 		message = err.Error()
+	case errors.Is(err, upstream.ErrFreeModeInvalidAgentHierarchy):
+		status, code = http.StatusForbidden, "free_mode_invalid_agent_hierarchy"
+		message = err.Error()
 	case errors.As(err, &ce):
 		// 402 "Out of credits": surfacing the upstream body verbatim keeps
 		// the quota detail (limit/recent/reset) for the client.

--- a/backend/internal/server/replay_wiring_test.go
+++ b/backend/internal/server/replay_wiring_test.go
@@ -1,0 +1,269 @@
+package server_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"freebuff-proxy/backend/internal/testutil"
+)
+
+// Wiring replays: every new classify arm must surface the same client code on
+// both the OpenAI envelope (/v1/chat/completions) and the Anthropic envelope
+// (/v1/messages). Each test drives a real upstream refusal through the mock
+// into the client response.
+
+// TestChatHierarchyGateSurfaced403 replays the hierarchy-gate refusal: a 403
+// free_mode_invalid_agent_hierarchy body must reach the OpenAI client as 403
+// free_mode_invalid_agent_hierarchy with an actionable hint — never the dead
+// 502 the default branch used to write.
+func TestChatHierarchyGateSurfaced403(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"error":"free_mode_invalid_agent_hierarchy","message":"subagent inline not in root allowlist"}`)
+	}
+	ts, _ := newTestServerCfg(t, nil, nil, mock)
+
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", resp.StatusCode, data)
+	}
+	if got := errorCode(t, data); got != "free_mode_invalid_agent_hierarchy" {
+		t.Errorf("code = %q, want free_mode_invalid_agent_hierarchy: %s", got, data)
+	}
+	if !strings.Contains(string(data), "allowlist") {
+		t.Errorf("body missing the hierarchy hint: %s", data)
+	}
+	if !strings.Contains(string(data), "subagent inline not in root allowlist") {
+		t.Errorf("body missing the upstream message: %s", data)
+	}
+}
+
+// TestReplayMessagesHierarchyGate replays the same refusal on the Anthropic
+// surface: identical 403 + code, in the Anthropic envelope
+// (permission_error / free_mode_invalid_agent_hierarchy).
+func TestReplayMessagesHierarchyGate(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"error":"free_mode_invalid_agent_hierarchy","message":"subagent inline not in root allowlist"}`)
+	}
+	ts, _ := newTestServerCfg(t, []string{"replay-key"}, nil, mock)
+	headers := map[string]string{
+		"Content-Type":      "application/json",
+		"x-api-key":         "replay-key",
+		"anthropic-version": "2023-06-01",
+	}
+	body := `{"model":"deepseek/deepseek-v4-flash","max_tokens":64,"messages":[{"role":"user","content":"hi"}]}`
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/messages", []byte(body), headers)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", resp.StatusCode, truncate(string(data), 300))
+	}
+	var envelope struct {
+		Type  string `json:"type"`
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		t.Fatalf("403 response is not parseable: %v: %s", err, data)
+	}
+	if envelope.Type != "error" {
+		t.Errorf("top-level type = %q, want error (Anthropic envelope)", envelope.Type)
+	}
+	if envelope.Error.Type != "permission_error" {
+		t.Errorf("error.type = %q, want permission_error", envelope.Error.Type)
+	}
+	if envelope.Error.Code != "free_mode_invalid_agent_hierarchy" {
+		t.Errorf("error.code = %q, want free_mode_invalid_agent_hierarchy", envelope.Error.Code)
+	}
+}
+
+// TestChatPeakHoursUnderscoreSurfaced429 replays the underscore body form: a
+// 429 carrying peak_hours must surface exactly like the space form — 429
+// peak_hours with the bounded 30m Retry-After, never generic rate_limited.
+func TestChatPeakHoursUnderscoreSurfaced429(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"status":"rate_limited","message":"Usage is temporarily limited during peak_hours, prices double"}`)
+	}
+	ts, _ := newTestServerCfg(t, nil, nil, mock)
+
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429: %s", resp.StatusCode, data)
+	}
+	if got := errorCode(t, data); got != "peak_hours" {
+		t.Errorf("code = %q, want peak_hours: %s", got, data)
+	}
+	if ra := resp.Header.Get("Retry-After"); ra != "1800" {
+		t.Errorf("Retry-After = %q, want 1800 (bounded 30m, not midnight)", ra)
+	}
+}
+
+// TestReplayMessagesPeakHoursUnderscore replays the same body on the
+// Anthropic surface: 429 + rate_limit_error / peak_hours.
+func TestReplayMessagesPeakHoursUnderscore(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"status":"rate_limited","message":"Usage is temporarily limited during peak_hours, prices double"}`)
+	}
+	ts, _ := newTestServerCfg(t, []string{"replay-key"}, nil, mock)
+	headers := map[string]string{
+		"Content-Type":      "application/json",
+		"x-api-key":         "replay-key",
+		"anthropic-version": "2023-06-01",
+	}
+	body := `{"model":"deepseek/deepseek-v4-flash","max_tokens":64,"messages":[{"role":"user","content":"hi"}]}`
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/messages", []byte(body), headers)
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429: %s", resp.StatusCode, truncate(string(data), 300))
+	}
+	var envelope struct {
+		Type  string `json:"type"`
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		t.Fatalf("429 response is not parseable: %v: %s", err, data)
+	}
+	if envelope.Error.Type != "rate_limit_error" {
+		t.Errorf("error.type = %q, want rate_limit_error", envelope.Error.Type)
+	}
+	if envelope.Error.Code != "peak_hours" {
+		t.Errorf("error.code = %q, want peak_hours", envelope.Error.Code)
+	}
+}
+
+// TestChatTurnSpendOffStatusSurfaced429 replays the breaker on a non-429
+// status: the turn_spend_limit literal is terminal whatever carries it, so a
+// 403 carrying it must still surface as 429 turn_spend_limited with the loop
+// warning and NO Retry-After — never the 502 the default branch wrote.
+func TestChatTurnSpendOffStatusSurfaced429(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	var chatCalls atomic.Int32
+	mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
+		chatCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"error":"turn_spend_limit","message":"Something went wrong with this turn.","retryAfterMs":60000}`)
+	}
+	ts, _ := newTestServerCfg(t, nil, nil, mock)
+
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429: %s", resp.StatusCode, data)
+	}
+	if ra := resp.Header.Get("Retry-After"); ra != "" {
+		t.Errorf("Retry-After = %q, want none (no retry drumbeat for a killed turn)", ra)
+	}
+	if !strings.Contains(string(data), `"code":"turn_spend_limited"`) {
+		t.Errorf("body missing turn_spend_limited code: %s", data)
+	}
+	if !strings.Contains(string(data), "Something went wrong with this turn") {
+		t.Errorf("body missing the upstream loop warning: %s", data)
+	}
+	if got := chatCalls.Load(); got != 1 {
+		t.Errorf("upstream chat calls = %d, want 1 (never re-POST into a turn-spend refusal)", got)
+	}
+}
+
+// TestReplayMessagesTurnSpendOffStatus replays the same off-status breaker on
+// the Anthropic surface: identical terminal framing in the Anthropic
+// envelope, with NO Retry-After.
+func TestReplayMessagesTurnSpendOffStatus(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	var mu sync.Mutex
+	chatCalls := 0
+	mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		chatCalls++
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"error":"turn_spend_limit","message":"Something went wrong with this turn.","retryAfterMs":60000}`)
+	}
+	ts, _ := newTestServerCfg(t, []string{"replay-key"}, nil, mock)
+	headers := map[string]string{
+		"Content-Type":      "application/json",
+		"x-api-key":         "replay-key",
+		"anthropic-version": "2023-06-01",
+	}
+	body := `{"model":"deepseek/deepseek-v4-flash","max_tokens":64,"messages":[{"role":"user","content":"hi"}]}`
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/messages", []byte(body), headers)
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429: %s", resp.StatusCode, truncate(string(data), 300))
+	}
+	var envelope struct {
+		Type  string `json:"type"`
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		t.Fatalf("429 response is not parseable: %v: %s", err, data)
+	}
+	if envelope.Error.Type != "rate_limit_error" {
+		t.Errorf("error.type = %q, want rate_limit_error", envelope.Error.Type)
+	}
+	if envelope.Error.Code != "turn_spend_limited" {
+		t.Errorf("error.code = %q, want turn_spend_limited", envelope.Error.Code)
+	}
+	if !strings.Contains(envelope.Error.Message, "Something went wrong with this turn") {
+		t.Errorf("error.message missing the upstream loop warning: %q", envelope.Error.Message)
+	}
+	if ra := resp.Header.Get("Retry-After"); ra != "" {
+		t.Errorf("Retry-After = %q, want none (no retry drumbeat for a killed turn)", ra)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if chatCalls != 1 {
+		t.Errorf("upstream chat calls = %d, want 1 (never re-POST into a turn-spend refusal)", chatCalls)
+	}
+}
+
+// TestChatVendorUICopyStaysDefault502 pins the no-literal rule end to end: a
+// purchase-flavored refusal with no wire status literal must surface as the
+// default 502 upstream_unavailable — never a typed code.
+func TestChatVendorUICopyStaysDefault502(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mock.ChatHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		_, _ = io.WriteString(w, `{"error":"purchase_required","message":"No purchase was made"}`)
+	}
+	ts, _ := newTestServerCfg(t, nil, nil, mock)
+
+	resp, data := doJSON(t, http.MethodPost, ts.URL+"/v1/chat/completions", chatBody(modelA), nil)
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502: %s", resp.StatusCode, data)
+	}
+	if got := errorCode(t, data); got != "upstream_unavailable" {
+		t.Errorf("code = %q, want upstream_unavailable: %s", got, data)
+	}
+}

--- a/backend/internal/upstream/classify.go
+++ b/backend/internal/upstream/classify.go
@@ -80,6 +80,15 @@ func classifyError(status int, body string, hdr http.Header) error {
 		// lease/session — never a token cooldown, never a session
 		// invalidation (reference/freebuff-proxy-hengxin proxy.js:652-668).
 		return &CapacityDeferredError{Status: status, Body: truncate(body, 500), RetryAfter: retryAfter}
+	case containsAny(lower, string(WireCodeTurnSpendLimit)):
+		// turn_spend_limit is a distinctive loop-protection literal and it is
+		// terminal on WHATEVER status carries it: upstream attaches it to
+		// 429 canonically, but retrying the same turn re-trips the breaker
+		// instantly (live 20+ minutes of 60s re-trips), so it must never
+		// become a RateLimitError cooldown drumbeat and never the generic
+		// 502. The incoming status is preserved for telemetry; the server
+		// still surfaces 429 turn_spend_limited with no Retry-After.
+		return &TurnSpendLimitError{Status: status, Body: truncate(body, 200)}
 	case status == http.StatusUnauthorized:
 		return fmt.Errorf("%w: %d %s", ErrAuthRejected, status, truncate(body, 200))
 	case status == http.StatusServiceUnavailable:
@@ -95,6 +104,13 @@ func classifyError(status int, body string, hdr http.Header) error {
 		return &SessionLimitError{Status: status, Body: truncate(body, 200)}
 	case status == http.StatusForbidden && strings.Contains(lower, string(WireCodeFreeModeCLIRequired)):
 		return fmt.Errorf("%w: %d %s", ErrFreeModeCLIRequired, status, truncate(body, 200))
+	case status == http.StatusForbidden && strings.Contains(lower, string(WireCodeFreeModeInvalidAgentHierarchy)):
+		// free_mode_invalid_agent_hierarchy: the subagent id is not in its
+		// root's allowlist (vendor free-agents.ts hierarchy gate). Dedicated
+		// 403 sentinel mirroring free_mode_cli_required: a config refusal,
+		// never a cooldown, never the generic 502. The 403 gate stays
+		// tight — the same marker on any other status falls to default.
+		return fmt.Errorf("%w: %d %s", ErrFreeModeInvalidAgentHierarchy, status, truncate(body, 200))
 	case status == http.StatusForbidden && strings.Contains(lower, string(WireCodeCountryBlocked)):
 		return parseCountryBlock(body)
 	case containsAny(lower, string(WireCodeIpCapped)):
@@ -177,11 +193,14 @@ func classifyError(status int, body string, hdr http.Header) error {
 			RetryAfter: LoadShedCooldown,
 			Body:       truncate(body, 200),
 		}
-	case status == http.StatusTooManyRequests && containsAny(lower, string(WireCodePeakHours)):
+	case status == http.StatusTooManyRequests && containsAny(lower, string(WireCodePeakHours), string(WireCodePeakHoursStatus)):
 		// #133: "Usage is temporarily limited during peak hours, when
-		// upstream model prices double…". The peak end is unknowable from
-		// the body: bounded conservative cooldown instead of locking the
-		// token until Pacific midnight (the peak is hours, not a day).
+		// upstream model prices double…". Both the space body form ("peak
+		// hours") and the underscore form ("peak_hours") share this arm;
+		// the RateLimitError.Status stays the underscore constant. The peak
+		// end is unknowable from the body: bounded conservative cooldown
+		// instead of locking the token until Pacific midnight (the peak is
+		// hours, not a day).
 		return &RateLimitError{
 			Status:     string(WireCodePeakHoursStatus),
 			RetryAfter: PeakHoursCooldown,
@@ -190,6 +209,14 @@ func classifyError(status int, body string, hdr http.Header) error {
 	case status == http.StatusTooManyRequests || containsAny(lower, string(WireCodeRateLimited), string(WireCodeSpendLimited)):
 		return parseRateLimit(body, parseRetryAfter(hdr))
 	default:
+		// Vendor-UI copy only, never a classify marker: purchase / consent /
+		// terms / purchasesPaused strings (availability labels, Desktop
+		// updateRequired/purchasesPaused session flags, wallet-consent prose)
+		// ride UI copy or session-parse flags, never a chat/body status
+		// literal — and the wiregen guard fails loud on any new snapshot
+		// literal. Until vendor ships one, bodies carrying only those
+		// strings stay this default 502 upstream_unavailable. Do NOT invent
+		// arms for them here.
 		return &UpstreamError{Status: status, Body: truncate(body, 500), RetryAfter: retryAfter}
 	}
 }

--- a/backend/internal/upstream/classify_wiring_test.go
+++ b/backend/internal/upstream/classify_wiring_test.go
@@ -1,0 +1,146 @@
+package upstream
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestClassifyFreeModeInvalidAgentHierarchy pins the hierarchy gate: a 403
+// carrying free_mode_invalid_agent_hierarchy is a dedicated config refusal
+// (mirroring free_mode_cli_required), never a generic 502 and never a
+// cooldown-bearing RateLimitError. The 403 gate stays tight: the same marker
+// on any other status must not match the arm.
+func TestClassifyFreeModeInvalidAgentHierarchy(t *testing.T) {
+	body := `{"error":"free_mode_invalid_agent_hierarchy","message":"subagent not in root allowlist"}`
+	err := classifyError(http.StatusForbidden, body, http.Header{})
+	if !errors.Is(err, ErrFreeModeInvalidAgentHierarchy) {
+		t.Fatalf("errors.Is(ErrFreeModeInvalidAgentHierarchy) = false, got %T %v", err, err)
+	}
+	if errors.Is(err, ErrFreeModeCLIRequired) {
+		t.Errorf("hierarchy refusal unwraps to ErrFreeModeCLIRequired, want the dedicated sentinel")
+	}
+	var rle *RateLimitError
+	if errors.As(err, &rle) {
+		t.Errorf("hierarchy refusal = RateLimitError (%v), want the cooldown-free 403 sentinel", rle)
+	}
+
+	// Off-status bodies must not match: the gate is 403-only, so a 429 with
+	// the marker stays on the rate-limit path and a 400 stays generic.
+	if err := classifyError(http.StatusTooManyRequests, body, http.Header{}); errors.Is(err, ErrFreeModeInvalidAgentHierarchy) {
+		t.Errorf("429 hierarchy body matched the 403 arm: %v", err)
+	}
+	if err := classifyError(http.StatusBadRequest, body, http.Header{}); errors.Is(err, ErrFreeModeInvalidAgentHierarchy) {
+		t.Errorf("400 hierarchy body matched the 403 arm: %v", err)
+	}
+
+	// A bare 403 without the marker stays generic.
+	if err := classifyError(http.StatusForbidden, `{"error":"forbidden"}`, http.Header{}); errors.Is(err, ErrFreeModeInvalidAgentHierarchy) {
+		t.Errorf("marker-less 403 matched the hierarchy arm: %v", err)
+	}
+}
+
+// TestClassifyPeakHoursUnderscore pins the underscore body form: a 429
+// carrying peak_hours classifies exactly like the space form ("peak hours") —
+// bounded PeakHoursCooldown, distinct peak_hours status, no midnight lock.
+func TestClassifyPeakHoursUnderscore(t *testing.T) {
+	for _, body := range []string{
+		`{"status":"rate_limited","message":"Usage is temporarily limited during peak_hours, prices double"}`,
+		`{"error":"peak_hours","message":"peak_hours cap"}`,
+	} {
+		err := classifyError(http.StatusTooManyRequests, body, http.Header{})
+		var rle *RateLimitError
+		if !errors.As(err, &rle) {
+			t.Fatalf("classifyError(%q) = %T %v, want *RateLimitError", body, err, err)
+		}
+		if rle.Status != string(WireCodePeakHoursStatus) {
+			t.Errorf("Status = %q, want %q", rle.Status, string(WireCodePeakHoursStatus))
+		}
+		if rle.RetryAfter != PeakHoursCooldown {
+			t.Errorf("RetryAfter = %v, want %v (bounded, not midnight)", rle.RetryAfter, PeakHoursCooldown)
+		}
+		if !rle.ResetAt.IsZero() {
+			t.Errorf("ResetAt = %v, want zero (no Pacific-midnight lock)", rle.ResetAt)
+		}
+	}
+}
+
+// TestClassifyTurnSpendLimitAnyStatus pins the loop-protection breaker as
+// status-agnostic: the turn_spend_limit literal is terminal (a retry re-trips
+// instantly) on whatever status carries it, so it must surface as
+// *TurnSpendLimitError — never a RateLimitError cooldown, never the generic
+// 502 — with the incoming status preserved for telemetry.
+func TestClassifyTurnSpendLimitAnyStatus(t *testing.T) {
+	for _, status := range []int{http.StatusBadRequest, http.StatusForbidden, http.StatusTooManyRequests, http.StatusInternalServerError} {
+		body := `{"error":"turn_spend_limit","message":"Something went wrong with this turn.","retryAfterMs":60000}`
+		err := classifyError(status, body, http.Header{})
+		var tsle *TurnSpendLimitError
+		if !errors.As(err, &tsle) {
+			t.Fatalf("status %d: classifyError = %T %v, want *TurnSpendLimitError", status, err, err)
+		}
+		if !errors.Is(err, ErrTurnSpendLimited) {
+			t.Errorf("status %d: does not unwrap to ErrTurnSpendLimited", status)
+		}
+		if tsle.Status != status {
+			t.Errorf("status %d: TurnSpendLimitError.Status = %d, want the incoming status preserved", status, tsle.Status)
+		}
+		if !strings.Contains(tsle.Body, "Something went wrong with this turn") {
+			t.Errorf("status %d: Body = %q, want the upstream loop warning intact", status, tsle.Body)
+		}
+		var rle *RateLimitError
+		if errors.As(err, &rle) {
+			t.Errorf("status %d: = RateLimitError (%v), want the terminal type (no cooldown/backoff)", status, rle)
+		}
+	}
+}
+
+// TestClassifyVendorUICopyStaysDefault pins the no-literal rule: purchase /
+// consent / terms / purchasesPaused strings are vendor-UI copy (availability
+// labels, Desktop updateRequired/purchasesPaused flags, wallet-consent prose)
+// with no wire status literal — the wiregen guard fails loud on any new
+// snapshot literal — so bodies carrying only those strings must stay the
+// default *UpstreamError (502 upstream_unavailable), never a typed refusal.
+func TestClassifyVendorUICopyStaysDefault(t *testing.T) {
+	bodies := []struct {
+		status int
+		body   string
+	}{
+		{405, `{"error":"purchase_required","message":"No purchase was made"}`},
+		{http.StatusBadRequest, `{"error":"consent_required","message":"re-confirm 2 wallet Freebucks to admit"}`},
+		{http.StatusForbidden, `{"error":"terms_not_accepted","message":"accept the terms first"}`},
+		{http.StatusConflict, `{"status":"model_unavailable","availableHours":"Purchased sessions are paused.","purchasesPaused":true}`},
+	}
+	for _, tc := range bodies {
+		err := classifyError(tc.status, tc.body, http.Header{})
+		var ue *UpstreamError
+		if !errors.As(err, &ue) {
+			t.Fatalf("status %d body %q: classifyError = %T %v, want default *UpstreamError", tc.status, tc.body, err, err)
+		}
+		if ue.Retryable {
+			t.Errorf("status %d body %q: Retryable = true, want the non-retryable default", tc.status, tc.body)
+		}
+		for _, typed := range []error{ErrBanned, ErrCountryBlocked, ErrRateLimited, ErrSessionInvalid, ErrRunInvalid, ErrTurnSpendLimited, ErrFreeModeCLIRequired, ErrFreeModeInvalidAgentHierarchy} {
+			if errors.Is(err, typed) {
+				t.Errorf("status %d body %q: unwraps to %v, want no typed refusal", tc.status, tc.body, typed)
+			}
+		}
+	}
+}
+
+// TestClassifyRunIDGateStays400 pins the existing contract: the run-id
+// markers only match on 400. Any other status carrying them stays off the
+// run-invalid path.
+func TestClassifyRunIDGateStays400(t *testing.T) {
+	err := classifyError(http.StatusBadRequest, `{"error":"runid not found"}`, http.Header{})
+	if !errors.Is(err, ErrRunInvalid) {
+		t.Fatalf("400 runid body = %T %v, want ErrRunInvalid", err, err)
+	}
+	for _, status := range []int{http.StatusConflict, http.StatusNotFound, http.StatusInternalServerError} {
+		for _, body := range []string{`{"error":"runid not found"}`, `{"error":"runid not running"}`} {
+			if err := classifyError(status, body, http.Header{}); errors.Is(err, ErrRunInvalid) {
+				t.Errorf("status %d body %q matched the 400-gated run arm: %v", status, body, err)
+			}
+		}
+	}
+}

--- a/backend/internal/upstream/errors.go
+++ b/backend/internal/upstream/errors.go
@@ -34,6 +34,11 @@ var (
 	// ErrFreeModeCLIRequired: the free tier refused the request because it
 	// did not carry the CLI request envelope (403 free_mode_cli_required).
 	ErrFreeModeCLIRequired = errors.New("upstream free mode requires CLI request envelope")
+	// ErrFreeModeInvalidAgentHierarchy: the free tier refused the request
+	// because the subagent id is not in its root's allowlist (403
+	// free_mode_invalid_agent_hierarchy; vendor free-agents.ts hierarchy
+	// gate, mirrored in backend/internal/registry/testdata/upstream).
+	ErrFreeModeInvalidAgentHierarchy = errors.New("upstream free mode subagent hierarchy rejected")
 	// ErrCredits: 402 payment required — the account has no credits / free
 	// quota left to spend.
 	ErrCredits = errors.New("upstream payment required")

--- a/backend/internal/upstream/tokenhealth.go
+++ b/backend/internal/upstream/tokenhealth.go
@@ -343,6 +343,8 @@ func (c *Client) probeSession(ctx context.Context) (TokenHealthState, string) {
 		return TokenUnknown, "upstream waiting room (transient; retry later)"
 	case errors.Is(err, ErrFreeModeCLIRequired):
 		return TokenUnknown, "free-mode CLI envelope rejected (403 free_mode_cli_required)"
+	case errors.Is(err, ErrFreeModeInvalidAgentHierarchy):
+		return TokenUnknown, "free-mode subagent hierarchy rejected (403 free_mode_invalid_agent_hierarchy)"
 	case errors.Is(err, ErrSessionInvalid):
 		return TokenUnknown, "session invalid upstream (stale row; refresh on demand)"
 	default:

--- a/backend/internal/upstream/wirecodes_gen.go
+++ b/backend/internal/upstream/wirecodes_gen.go
@@ -40,6 +40,9 @@ const (
 	// WireCodeFreeModeInvalidAgentModel: the (agent, model) pair is not in the allowlist. Also the RateLimitError.Status for the refusal.
 	// pinned server-observed body marker (absent from the snapshots).
 	WireCodeFreeModeInvalidAgentModel WireCode = "free_mode_invalid_agent_model"
+	// WireCodeFreeModeInvalidAgentHierarchy: the subagent id is not in its root's allowlist (hierarchy gate).
+	// pinned server-observed body marker (absent from the snapshots).
+	WireCodeFreeModeInvalidAgentHierarchy WireCode = "free_mode_invalid_agent_hierarchy"
 	// WireCodeSessionSuperseded: another instance took over the account (409).
 	// snapshot: common/src/types/freebuff-session.ts.
 	WireCodeSessionSuperseded WireCode = "session_superseded"

--- a/backend/internal/wirefacts/emit_wire.go
+++ b/backend/internal/wirefacts/emit_wire.go
@@ -52,6 +52,7 @@ var wireCodes = []wireCode{
 	{"WireCodeWaitingRoomRequired", "waiting_room_required", "WireCodeWaitingRoomRequired: the account must walk the pre-session ad-chain + streak flow (428).", wireSessionFile},
 	{"WireCodeSessionModelMismatch", "session_model_mismatch", "WireCodeSessionModelMismatch: the session row is bound to a different model (with a \"limited\" marker for the egress-IP case).", wireSessionFile},
 	{"WireCodeFreeModeInvalidAgentModel", "free_mode_invalid_agent_model", "WireCodeFreeModeInvalidAgentModel: the (agent, model) pair is not in the allowlist. Also the RateLimitError.Status for the refusal.", ""},
+	{"WireCodeFreeModeInvalidAgentHierarchy", "free_mode_invalid_agent_hierarchy", "WireCodeFreeModeInvalidAgentHierarchy: the subagent id is not in its root's allowlist (hierarchy gate).", ""},
 	{"WireCodeSessionSuperseded", "session_superseded", "WireCodeSessionSuperseded: another instance took over the account (409).", wireSessionFile},
 	{"WireCodeTurnSpendLimit", "turn_spend_limit", "WireCodeTurnSpendLimit: upstream killed a runaway turn (429 per-turn spend ceiling, usually a stuck agent loop).", ""},
 	{"WireCodeFreebuffUpdateRequired", "freebuff_update_required", "WireCodeFreebuffUpdateRequired: the CLI app version is out of date.", ""},


### PR DESCRIPTION
Wires the mappable gaps from the vendor-code audit. New arms: 403 free_mode_invalid_agent_hierarchy as a dedicated 403 (both surfaces, Anthropic via status-derived permission_error); peak_hours underscore body on 429 matching the space form; turn_spend_limit terminal framing on any status with status preserved. Purchase/consent/terms have no wire literal: pinned to default 502 with a do-not-invent comment until the vendor ships a status (wiregen fails loud). Includes the wiregen table row + regen (byte-identical elsewhere) and TokenUnknown tokenhealth mirror. Tests: 5 upstream classify funcs + 7 server envelope replays, proven red pre-arm and green post-arm. Hermetic upstream/session/server/wirefacts suites green, gofmt/vet clean.