### PR TITLE
feat(pool): persist smart-probe timer and quota cache, skip in-use tokens

### DIFF
--- a/backend/internal/cli/cli_serve.go
+++ b/backend/internal/cli/cli_serve.go
@@ -334,6 +334,16 @@ func Serve(configPath string, verbose bool, version string) int {
 	// Dashboard history (ADR-0016): pool maturity events persist through a
 	// nil-safe adapter; without a store the pool stays persistence-free.
 	p.SetHistorySink(&poolHistorySink{st: histStore})
+	// Pool runtime persist (pool_state): the smart-probe scheduler timer
+	// plus the live per-token quota cache survive restarts through the
+	// dashboard store (opaque blobs, SHA-256 keys — raw tokens never
+	// reach the DB). The flush rides the maintain tick + Shutdown and
+	// Start restores; a nil store stays live-only. The concrete nil
+	// guard stays here: a nil *Store would arrive as a non-nil
+	// interface.
+	if histStore != nil {
+		p.SetPoolPersist(histStore)
+	}
 	// Quota boot seed (ADR-0024): push the latest persisted quota row per
 	// (token, model) into the live view before Start, so a restart shows
 	// last-known quotas instantly and the scheduler learns reset_at from

--- a/backend/internal/pool/pool_lifecycle.go
+++ b/backend/internal/pool/pool_lifecycle.go
@@ -121,6 +121,13 @@ func pollSession(ctx context.Context, sess *session.Manager, cfg *config.Config,
 // nothing else.
 func (p *Pool) Start(ctx context.Context) {
 	p.once.Do(func() {
+		// Restore the persisted runtime state first (pool_state): the
+		// smart-probe timer plus the live per-token quota cache, so a
+		// restart resumes warm — the boot round below still fires as an
+		// event but probes nothing while the restored cache is fresh.
+		// Missing rows are a fresh boot (current behavior); a nil store
+		// is a no-op; restore never fails the boot (warn-only).
+		p.RestorePoolPersist()
 		// Anchor the smart-probe boot round before the maintain loop
 		// launches (spawn happens-before the first tick).
 		p.quotaBootAt = time.Now()

--- a/backend/internal/pool/pool_persist.go
+++ b/backend/internal/pool/pool_persist.go
@@ -5,6 +5,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"time"
+
+	"freebuff-proxy/backend/internal/upstream"
 )
 
 // pool_persist.go — pool runtime write-through cache (DB-unified-storage).
@@ -21,25 +23,36 @@ import (
 // live-only and never blocks the request hot path.
 //
 // Persist allowlist (parent-scoped): ledger counters, admissions counts,
-// bridge daily usage plus survivors, burst hits. Never persisted: live
-// handles (channels, sync.Once, WaitGroup, CancelFunc, atomic.Pointer,
-// Logger, Registry, tokenEntry pointers) and the unfit registry (pure
+// bridge daily usage plus survivors, burst hits, the smart-probe scheduler
+// timer (lastProbe, backoff, overloadedAt, idleSlept) and the live
+// per-token quota cache (QuotaByModel + QuotaSavedAt). Never persisted:
+// live handles (channels, sync.Once, WaitGroup, CancelFunc,
+// atomic.Pointer, Logger, Registry, tokenEntry pointers), the transient
+// scheduler dispatch flags (kick, inflight — a persisted inflight would
+// suppress ticks forever; restore hard-resets both), the boot flag
+// (a restart always re-arms the boot round event; with the quota cache
+// restored it probes nothing when warm), and the unfit registry (pure
 // 5-minute TTL episode state; a restart starts servable and re-marks on
 // the next upstream limited_ip refusal).
 //
 // Key namespace (stable strings; store never interprets values):
 //
-//	pool/ledger/<sha256hex(token)>  one AccountLedger blob per token
-//	pool/admissions                  in-flight session admissions by model
-//	pool/burst                       per-model sliding-window burst hits
-//	pool/bridge/usage                global bridge daily counter
-//	pool/bridge/survivors            evicted bridge usage survivors
+//	pool/ledger/<sha256hex(token)>       one AccountLedger blob per token
+//	pool/admissions                       in-flight session admissions by model
+//	pool/burst                            per-model sliding-window burst hits
+//	pool/bridge/usage                     global bridge daily counter
+//	pool/bridge/survivors                 evicted bridge usage survivors
+//	pool/probe/scheduler                  smart-probe scheduler timer (pool-scoped)
+//	pool/probe/quota/<sha256hex(token)>   live quota cache per token (SHA-keyed:
+//	                                      roster order is unstable across restarts)
 const (
 	poolStateAdmissions      = "pool/admissions"
 	poolStateBurst           = "pool/burst"
 	poolStateBridgeUsage     = "pool/bridge/usage"
 	poolStateBridgeSurvivors = "pool/bridge/survivors"
 	poolLedgerPrefix         = "pool/ledger/"
+	poolProbeScheduler       = "pool/probe/scheduler"
+	poolProbeQuotaPrefix     = "pool/probe/quota/"
 )
 
 // PoolPersist is the persistence backend for pool runtime state. Values
@@ -94,8 +107,42 @@ type poolSurvivorBlob struct {
 	Evicted int64 `json:"evicted"`
 }
 
-// poolTokenHash keys a token's ledger row by the SHA-256 hex of the token
-// value: raw tokens never cross the persistence boundary.
+// poolSmartProbeBlob is the JSON-stable mirror of the persisted scheduler
+// timer fields (Unix millis UTC, 0 = zero time). Only the timer crosses a
+// restart: bootDone is excluded (a restart re-arms the boot round event),
+// and kick/inflight are transient dispatch state (restore hard-resets
+// both — a persisted inflight would suppress ticks forever).
+type poolSmartProbeBlob struct {
+	LastProbe    int64 `json:"last_probe"`
+	Backoff      int   `json:"backoff"`
+	IdleSlept    bool  `json:"idle_slept"`
+	OverloadedAt int64 `json:"overloaded_at"`
+}
+
+// poolQuotaRow mirrors one live quota row. ResetAt is Unix millis UTC
+// (0 = absent, preserved as the zero time on restore).
+type poolQuotaRow struct {
+	Model       string             `json:"model"`
+	Limit       float64            `json:"limit"`
+	RecentCount float64            `json:"recent_count"`
+	ResetAt     int64              `json:"reset_at"`
+	Period      string             `json:"period,omitempty"`
+	Pool        string             `json:"pool,omitempty"`
+	PoolLabel   string             `json:"pool_label,omitempty"`
+	Entitlement map[string]float64 `json:"entitlement,omitempty"`
+}
+
+// poolQuotaBlob is one token's live quota cache: the QuotaByModel map plus
+// the QuotaSavedAt write time (Unix millis UTC). Field names stay
+// snake_case and additive — old rows must still unmarshal after new
+// counters land.
+type poolQuotaBlob struct {
+	SavedAt int64                   `json:"saved_at"`
+	Quota   map[string]poolQuotaRow `json:"quota_by_model"`
+}
+
+// poolTokenHash keys a token's per-token rows by the SHA-256 hex of the
+// token value: raw tokens never cross the persistence boundary.
 func poolTokenHash(raw string) string {
 	h := sha256.Sum256([]byte(raw))
 	return hex.EncodeToString(h[:])
@@ -104,9 +151,16 @@ func poolTokenHash(raw string) string {
 // poolLedgerKey returns the pool_state key for one token's ledger blob.
 func poolLedgerKey(tokenHash string) string { return poolLedgerPrefix + tokenHash }
 
-// SetPoolPersist wires the runtime persistence backend (nil disables). The
-// owner calls RestorePoolPersist once at boot after wiring so counters
-// survive restarts.
+// poolProbeQuotaKey returns the pool_state key for one token's live quota
+// cache blob. SHA-keyed like the ledger rows: roster order is unstable
+// across restarts (config reloads, removals), so a positional index key
+// would mis-target another account.
+func poolProbeQuotaKey(tokenHash string) string { return poolProbeQuotaPrefix + tokenHash }
+
+// SetPoolPersist wires the runtime persistence backend (nil disables).
+// Start restores the persisted state automatically after wiring, so
+// counters and the probe cache survive restarts; direct RestorePoolPersist
+// calls remain for tests and pre-Start restores.
 func (p *Pool) SetPoolPersist(s PoolPersist) {
 	p.persistMu.Lock()
 	defer p.persistMu.Unlock()
@@ -146,7 +200,7 @@ func (p *Pool) FlushPoolPersist() error {
 	if st == nil || !p.persistDirty.Swap(false) {
 		return nil
 	}
-	staged, liveLedgers := p.snapshotPoolState()
+	staged, liveLedgers, liveQuotas := p.snapshotPoolState()
 	for _, kv := range staged {
 		if err := st.SavePoolState(kv.key, kv.val); err != nil {
 			p.persistDirty.Store(true)
@@ -154,7 +208,7 @@ func (p *Pool) FlushPoolPersist() error {
 			return err
 		}
 	}
-	// Best-effort orphan prune: ledger rows whose token left the roster
+	// Best-effort orphan prune: per-token rows whose token left the roster
 	// (config reload, RemoveLastToken) must not accumulate across
 	// restarts. Failure is not fatal — the next pass retries.
 	if rows, err := st.ListPoolState(poolLedgerPrefix); err == nil {
@@ -164,21 +218,35 @@ func (p *Pool) FlushPoolPersist() error {
 			}
 		}
 	}
+	if rows, err := st.ListPoolState(poolProbeQuotaPrefix); err == nil {
+		for key := range rows {
+			if !liveQuotas[key] {
+				_ = st.DeletePoolState(key)
+			}
+		}
+	}
 	return nil
 }
 
 // snapshotPoolState copies the allowlisted state under each subsystem's
 // own lock and marshals it. No store I/O happens here. It also returns
-// the live ledger key set for orphan pruning.
-func (p *Pool) snapshotPoolState() (staged []poolKV, liveLedgers map[string]bool) {
+// the live per-token key sets for orphan pruning.
+func (p *Pool) snapshotPoolState() (staged []poolKV, liveLedgers, liveQuotas map[string]bool) {
 	liveLedgers = make(map[string]bool)
+	liveQuotas = make(map[string]bool)
 
 	// Per-token ledgers (roster lock; entry pointers stay in memory —
-	// only the counters cross into blobs).
+	// only the counters cross into blobs). The entry list is also copied
+	// for the quota snapshot below (sessions read outside this lock).
 	p.roster.mu.Lock()
 	ledgers := make([]poolKV, 0)
+	quotaEntries := make([]*tokenEntry, 0)
 	for _, entry := range *p.roster.toks.Load() {
-		if entry == nil || entry.ledger == nil {
+		if entry == nil {
+			continue
+		}
+		quotaEntries = append(quotaEntries, entry)
+		if entry.ledger == nil {
 			continue
 		}
 		key := poolLedgerKey(poolTokenHash(entry.token))
@@ -188,6 +256,64 @@ func (p *Pool) snapshotPoolState() (staged []poolKV, liveLedgers map[string]bool
 	}
 	p.roster.mu.Unlock()
 	staged = append(staged, ledgers...)
+
+	// Live per-token quota cache (session snapshots read outside the
+	// roster lock — the established Snapshot() order — so a slow session
+	// lock never wedges roster mutations). Tokens with neither quota rows
+	// nor a write time stage nothing: a missing row reads as a fresh boot.
+	for _, entry := range quotaEntries {
+		if entry.session == nil {
+			continue
+		}
+		snap := entry.session.Snapshot()
+		if len(snap.QuotaByModel) == 0 && snap.QuotaSavedAt.IsZero() {
+			continue
+		}
+		blob := poolQuotaBlob{Quota: make(map[string]poolQuotaRow, len(snap.QuotaByModel))}
+		if !snap.QuotaSavedAt.IsZero() {
+			blob.SavedAt = snap.QuotaSavedAt.UnixMilli()
+		}
+		for model, q := range snap.QuotaByModel {
+			if model == "" {
+				continue
+			}
+			row := poolQuotaRow{
+				Model:       q.Model,
+				Limit:       q.Limit,
+				RecentCount: q.RecentCount,
+				Period:      q.Period,
+				Pool:        q.Pool,
+				PoolLabel:   q.PoolLabel,
+				Entitlement: q.Entitlement,
+			}
+			if row.Model == "" {
+				row.Model = model
+			}
+			if !q.ResetAt.IsZero() {
+				row.ResetAt = q.ResetAt.UnixMilli()
+			}
+			blob.Quota[model] = row
+		}
+		key := poolProbeQuotaKey(poolTokenHash(entry.token))
+		staged = append(staged, poolKV{key: key, val: mustMarshalPool(blob)})
+		liveQuotas[key] = true
+	}
+
+	// Smart-probe scheduler timer (own mutex; bootDone/kick/inflight are
+	// transient and never staged — see poolSmartProbeBlob).
+	p.smartProbe.mu.Lock()
+	sched := poolSmartProbeBlob{
+		Backoff:   p.smartProbe.backoff,
+		IdleSlept: p.smartProbe.idleSlept,
+	}
+	if !p.smartProbe.lastProbe.IsZero() {
+		sched.LastProbe = p.smartProbe.lastProbe.UnixMilli()
+	}
+	if !p.smartProbe.overloadedAt.IsZero() {
+		sched.OverloadedAt = p.smartProbe.overloadedAt.UnixMilli()
+	}
+	p.smartProbe.mu.Unlock()
+	staged = append(staged, poolKV{key: poolProbeScheduler, val: mustMarshalPool(sched)})
 
 	// Admissions (transient in-flight counts; restored as-is, self-heals
 	// on the next admission cycle).
@@ -224,7 +350,7 @@ func (p *Pool) snapshotPoolState() (staged []poolKV, liveLedgers map[string]bool
 		poolKV{key: poolStateBridgeUsage, val: mustMarshalPool(usage)},
 		poolKV{key: poolStateBridgeSurvivors, val: mustMarshalPool(survivors)},
 	)
-	return staged, liveLedgers
+	return staged, liveLedgers, liveQuotas
 }
 
 // marshalLedger copies one ledger's counters into its blob form. Caller
@@ -258,12 +384,16 @@ func marshalLedger(l *AccountLedger) poolLedgerBlob {
 	return blob
 }
 
-// RestorePoolPersist loads persisted runtime state into the live maps
-// (boot path; the owner calls it once after SetPoolPersist). Missing rows
-// stay zero-valued; corrupt rows warn and are skipped — restore never
-// fails the boot. TTL/expiry is enforced on the way in: out-of-window
-// usage/request/burst/survivor timestamps are dropped and stale spend
-// buckets roll, so a restart never resurrects expired windows.
+// RestorePoolPersist loads persisted runtime state into the live maps.
+// Start calls it automatically after the owner wires the store with
+// SetPoolPersist; direct calls remain for tests and pre-Start restores.
+// Missing rows stay zero-valued (a fresh boot behaves exactly as before);
+// corrupt rows warn and are skipped — restore never fails the boot.
+// TTL/expiry is enforced on the way in: out-of-window usage/request/burst/
+// survivor timestamps are dropped and stale spend buckets roll, so a
+// restart never resurrects expired windows. Restored quota rows seed the
+// session cache as last-known (stale-marked, dashboard-visible at once);
+// the scheduler's freshness gate re-probes them only once aged out.
 func (p *Pool) RestorePoolPersist() {
 	p.persistMu.Lock()
 	st := p.persist
@@ -276,6 +406,114 @@ func (p *Pool) RestorePoolPersist() {
 	p.restoreAdmissions(st)
 	p.restoreBurst(st, now)
 	p.restoreBridge(st, now)
+	p.restoreSmartProbe(st)
+	p.restoreProbeQuota(st)
+}
+
+// restoreSmartProbe loads the scheduler timer persisted by the last flush.
+// A missing row is a fresh boot (zero state, current behavior); a corrupt
+// row warns and is skipped. The transient dispatch flags are hard-reset:
+// kick=false (no spurious forced round) and inflight=false (a persisted
+// inflight would suppress ticks forever). bootDone is never persisted —
+// a restart always re-arms the boot round event, and the restored quota
+// cache keeps that round a zero-probe no-op while warm.
+func (p *Pool) restoreSmartProbe(st PoolPersist) {
+	raw, ok, err := st.LoadPoolState(poolProbeScheduler)
+	if err != nil {
+		p.logger.Warn("pool: runtime persist restore failed (starting fresh)", "key", poolProbeScheduler, "error", err)
+		return
+	}
+	if !ok {
+		return
+	}
+	var blob poolSmartProbeBlob
+	if err := json.Unmarshal(raw, &blob); err != nil {
+		p.logger.Warn("pool: runtime persist row corrupt (starting fresh)", "key", poolProbeScheduler, "error", err)
+		return
+	}
+	p.smartProbe.mu.Lock()
+	defer p.smartProbe.mu.Unlock()
+	if blob.LastProbe > 0 {
+		p.smartProbe.lastProbe = time.UnixMilli(blob.LastProbe)
+	}
+	if blob.Backoff >= 0 {
+		if blob.Backoff > maxSmartProbeBackoff {
+			p.smartProbe.backoff = maxSmartProbeBackoff
+		} else {
+			p.smartProbe.backoff = blob.Backoff
+		}
+	}
+	if blob.OverloadedAt > 0 {
+		p.smartProbe.overloadedAt = time.UnixMilli(blob.OverloadedAt)
+	}
+	p.smartProbe.idleSlept = blob.IdleSlept
+	p.smartProbe.kick = false
+	p.smartProbe.inflight = false
+}
+
+// restoreProbeQuota seeds each live token's session quota cache from its
+// SHA-keyed pool_state row, so a restart shows warm data immediately and
+// the first tick probes nothing while the cache is fresh. Rows for tokens
+// no longer in the roster are ignored (the flush prunes them); quota
+// history stays append-only and untouched. Seeding rides the session
+// manager's SeedQuota ts-compare, so a newer live write always wins and
+// re-restores are no-ops.
+func (p *Pool) restoreProbeQuota(st PoolPersist) {
+	// Index the live roster by quota key first (no store I/O under the
+	// roster lock). SHA-keyed, so a roster reorder across restarts still
+	// seeds the right account.
+	p.roster.mu.Lock()
+	byKey := make(map[string]*tokenEntry)
+	for _, entry := range *p.roster.toks.Load() {
+		if entry == nil || entry.session == nil {
+			continue
+		}
+		byKey[poolProbeQuotaKey(poolTokenHash(entry.token))] = entry
+	}
+	p.roster.mu.Unlock()
+
+	for key, entry := range byKey {
+		raw, ok, err := st.LoadPoolState(key)
+		if err != nil {
+			p.logger.Warn("pool: runtime persist restore failed (starting fresh)", "key", key, "error", err)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		var blob poolQuotaBlob
+		if err := json.Unmarshal(raw, &blob); err != nil {
+			p.logger.Warn("pool: runtime persist row corrupt (starting fresh)", "key", key, "error", err)
+			continue
+		}
+		if len(blob.Quota) == 0 || blob.SavedAt <= 0 {
+			continue
+		}
+		savedAt := time.UnixMilli(blob.SavedAt)
+		for model, row := range blob.Quota {
+			if model == "" {
+				continue
+			}
+			q := upstream.ModelQuota{
+				Model:       model,
+				Limit:       row.Limit,
+				RecentCount: row.RecentCount,
+				Period:      row.Period,
+				Pool:        row.Pool,
+				PoolLabel:   row.PoolLabel,
+			}
+			if row.ResetAt > 0 {
+				q.ResetAt = time.UnixMilli(row.ResetAt)
+			}
+			if len(row.Entitlement) > 0 {
+				q.Entitlement = make(map[string]float64, len(row.Entitlement))
+				for k, v := range row.Entitlement {
+					q.Entitlement[k] = v
+				}
+			}
+			entry.session.SeedQuota(q, savedAt)
+		}
+	}
 }
 
 func (p *Pool) restoreLedgers(st PoolPersist, now time.Time) {

--- a/backend/internal/pool/quota_smartprobe.go
+++ b/backend/internal/pool/quota_smartprobe.go
@@ -36,8 +36,12 @@
 //
 // Probe traffic is internal: the session-less ProbeToken path never touches
 // the usage ledgers, lastActive, or requestsServed, so probes neither feed
-// the tier classifier nor count as client usage. All scheduler state is
-// in-memory only (a restart re-probes on the next due tick); the
+// the tier classifier nor count as client usage. The scheduler timer
+// (lastProbe, backoff, overloadedAt, idleSlept) and the live per-token
+// quota cache (QuotaByModel + QuotaSavedAt) persist in pool_state under
+// pool/probe/* keys (see pool_persist.go): a restart resumes warm — the
+// boot round still fires as an event but probes nothing while the cache
+// is fresh — and a missing row reads as a fresh boot. The
 // quota_snapshots wallet persistence path is untouched.
 package pool
 
@@ -186,10 +190,14 @@ func effectiveQuotaProbeInterval(base time.Duration, backoff int) time.Duration 
 	return eff
 }
 
-// smartProbeState is the scheduler's in-memory-only state. Guarded by mu;
-// AddToken/Remove/ProbeAll (request goroutines) mutate kick/lastProbe while
-// the maintain goroutine owns the tick, so every access takes mu and the
-// probes themselves always run outside it.
+// smartProbeState is the scheduler's state. Guarded by mu; AddToken/Remove/
+// ProbeAll (request goroutines) mutate kick/lastProbe while the maintain
+// goroutine owns the tick, so every access takes mu and the probes
+// themselves always run outside it. The timer fields (lastProbe, backoff,
+// idleSlept, overloadedAt) persist in pool_state and reload at Start;
+// kick, inflight and bootDone are transient per process (restore
+// hard-resets kick/inflight; bootDone always re-arms so the restart
+// replays the boot round event).
 type smartProbeState struct {
 	mu sync.Mutex
 	// lastProbe is when the last round ran (forced or due, any outcome).
@@ -239,6 +247,9 @@ func (p *Pool) smartProbeNoteManual(now time.Time) {
 	p.smartProbe.kick = false
 	p.smartProbe.idleSlept = true
 	p.smartProbe.mu.Unlock()
+	// The timer moved: arm the background flush so the restart resumes
+	// from this round instead of re-probing on the next tick.
+	p.markPersistDirty()
 }
 
 // smartProbeTick runs one scheduler pass on the maintain clock.
@@ -343,6 +354,10 @@ func (p *Pool) smartProbeTickAt(ctx context.Context, now time.Time) {
 		} else {
 			p.smartProbe.idleSlept = false
 		}
+		// The timer moved: arm the background flush (lock-free, safe
+		// under mu) so a restart resumes from this round. The canceled
+		// path above returns early with the timer untouched.
+		p.markPersistDirty()
 	}()
 }
 
@@ -476,6 +491,11 @@ func (p *Pool) smartProbeOne(ctx context.Context, i int, tok *tokenEntry) (*upst
 	st, err := tok.client.ProbeAccount(fire)
 	if err == nil && st != nil {
 		tok.session.UpdateQuotaFromProbe(st)
+		// The live quota cache moved: arm the background flush so the
+		// restart restores this write instead of re-probing the fleet.
+		// Still no ledger/lastActive/requestsServed touch — the cache
+		// write stays out of the usage accounts by construction.
+		p.markPersistDirty()
 	}
 	cancel()
 	if err != nil {
@@ -497,11 +517,22 @@ func (p *Pool) smartProbeOne(ctx context.Context, i int, tok *tokenEntry) (*upst
 	return st, nil
 }
 
-// smartProbeSkipToken reports whether the token sits out this round: the
-// administrative lock plus the same health gates as the maturity tick
-// (quarantined, banned, cooling, country-blocked accounts are never poked).
-// Health state is set by the request path; a probe never sets it (probe
-// failures stay warn-only so scheduler work cannot change serving).
+// smartProbeSkipToken reports whether the token sits out this round.
+// Decision order (cheap to costly):
+//
+//  1. Gates: the administrative lock plus the same health gates as the
+//     maturity tick (quarantined, banned, cooling, country-blocked
+//     accounts are never poked). Health state is set by the request
+//     path; a probe never sets it (probe failures stay warn-only so
+//     scheduler work cannot change serving).
+//  2. In-use: a token with in-flight runs is mid-chat — the upstream
+//     allows one client per account at a time, so a probe landing
+//     mid-chat can kick the active session (same
+//     runs.InflightCount()>0 rule as sessionPollTick/maintainTick; no
+//     new busy signal). Busy tokens stay fresh through the request
+//     path's own quota write, so skipping never starves them.
+//  3. Staleness (not here): the caller applies smartProbeQuotaStale, so
+//     a token whose cached quota is still fresh sits out the round.
 func smartProbeSkipToken(tok *tokenEntry, now time.Time) bool {
 	if tok == nil {
 		return true
@@ -520,6 +551,12 @@ func smartProbeSkipToken(tok *tokenEntry, now time.Time) bool {
 		return true
 	}
 	if tok.runs.CountryBlockedError() != nil {
+		return true
+	}
+	// In-use (decision step 2): a token with in-flight runs is mid-chat;
+	// probing now could kick the active session, so it sits out until
+	// the lease drains.
+	if tok.runs.InflightCount() > 0 {
 		return true
 	}
 	return false

--- a/backend/internal/pool/smartprobe_persist_test.go
+++ b/backend/internal/pool/smartprobe_persist_test.go
@@ -1,0 +1,272 @@
+// smartprobe_persist_test.go — smart-probe restart persistence: the
+// scheduler timer (lastProbe, backoff, overloadedAt, idleSlept) and the
+// live per-token quota cache (QuotaByModel + QuotaSavedAt) ride pool_state
+// under pool/probe/* keys (SHA-keyed, never positional), so a restart
+// resumes warm — the boot round still fires as an event but probes
+// nothing while the cache is fresh — and in-use tokens sit out rounds
+// until their lease drains.
+package pool
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"freebuff-proxy/backend/internal/testutil"
+)
+
+func (m *memPoolPersist) saveCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.saves
+}
+
+// TestSmartProbeSchedulerPersistRoundTrip pins the persisted timer shape:
+// lastProbe/backoff/overloadedAt/idleSlept survive a flush + fresh-pool
+// restore, while bootDone is never persisted (the restart re-arms the
+// boot round) and the transient kick/inflight flags hard-reset to false
+// (a persisted inflight would suppress ticks forever).
+func TestSmartProbeSchedulerPersistRoundTrip(t *testing.T) {
+	mock := testutil.NewMock()
+	defer mock.Close()
+	mem := newMemPoolPersist()
+
+	p1 := newTestPool(t, mock)
+	p1.SetPoolPersist(mem)
+	lastProbe := time.Now().Add(-time.Minute)
+	overloadedAt := time.Now().Add(-30 * time.Second)
+	p1.smartProbe.mu.Lock()
+	p1.smartProbe.lastProbe = lastProbe
+	p1.smartProbe.backoff = 4
+	p1.smartProbe.idleSlept = true
+	p1.smartProbe.overloadedAt = overloadedAt
+	p1.smartProbe.bootDone = true
+	p1.smartProbe.kick = true
+	p1.smartProbe.inflight = true
+	p1.smartProbe.mu.Unlock()
+	p1.markPersistDirty()
+	if err := p1.FlushPoolPersist(); err != nil {
+		t.Fatalf("FlushPoolPersist: %v", err)
+	}
+	found := false
+	for _, k := range mem.keys() {
+		if k == poolProbeScheduler {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("scheduler row %q missing after flush: %v", poolProbeScheduler, mem.keys())
+	}
+
+	p2 := newTestPool(t, mock)
+	p2.SetPoolPersist(mem)
+	p2.RestorePoolPersist()
+
+	p2.smartProbe.mu.Lock()
+	defer p2.smartProbe.mu.Unlock()
+	if got := p2.smartProbe.lastProbe.UnixMilli(); got != lastProbe.UnixMilli() {
+		t.Errorf("restored lastProbe = %v, want %v", got, lastProbe.UnixMilli())
+	}
+	if p2.smartProbe.backoff != 4 {
+		t.Errorf("restored backoff = %d, want 4", p2.smartProbe.backoff)
+	}
+	if !p2.smartProbe.idleSlept {
+		t.Error("restored idleSlept = false, want true")
+	}
+	if got := p2.smartProbe.overloadedAt.UnixMilli(); got != overloadedAt.UnixMilli() {
+		t.Errorf("restored overloadedAt = %v, want %v", got, overloadedAt.UnixMilli())
+	}
+	if p2.smartProbe.bootDone {
+		t.Error("restored bootDone = true, want false (restart re-arms the boot round)")
+	}
+	if p2.smartProbe.kick {
+		t.Error("restored kick = true, want false (transient)")
+	}
+	if p2.smartProbe.inflight {
+		t.Error("restored inflight = true, want false (would suppress ticks forever)")
+	}
+}
+
+// TestSmartProbeRestartSkipsFreshCache is the restart simulation:
+// populate the cache with a live round, flush, rebuild a fresh pool over
+// the same store, and prove the first tick sends zero probes while the
+// restored cache is fresh — with the dashboard view warm immediately.
+func TestSmartProbeRestartSkipsFreshCache(t *testing.T) {
+	mock1 := testutil.NewMock()
+	defer mock1.Close()
+	mem := newMemPoolPersist()
+
+	p1 := newTestPool(t, mock1)
+	p1.SetPoolPersist(mem)
+	setQuotaAutoProbe(p1, true)
+	probeTick(t, p1, context.Background(), time.Now())
+	if got := mock1.SessionProbesSnapshot(); got != 1 {
+		t.Fatalf("p1 probes = %d, want 1 (live round populates the cache)", got)
+	}
+	if err := p1.FlushPoolPersist(); err != nil {
+		t.Fatalf("FlushPoolPersist: %v", err)
+	}
+	// Raw tokens never reach the store (SHA-only rule).
+	for _, k := range mem.keys() {
+		raw, _, _ := mem.LoadPoolState(k)
+		if strings.Contains(k, "tok-0") || strings.Contains(string(raw), "tok-0") {
+			t.Fatalf("raw token leaked into pool_state row %q", k)
+		}
+	}
+
+	mock2 := testutil.NewMock()
+	defer mock2.Close()
+	p2 := newTestPool(t, mock2)
+	p2.SetPoolPersist(mem)
+	setQuotaAutoProbe(p2, true)
+	p2.RestorePoolPersist()
+
+	// Warm view before any new probe traffic.
+	snap := p2.Snapshot()[0]
+	if len(snap.QuotaByModel) == 0 {
+		t.Fatal("restored QuotaByModel empty, want the warm cache")
+	}
+	if snap.QuotaSavedAt.IsZero() {
+		t.Error("restored QuotaSavedAt zero, want the flush-time write")
+	}
+	if !snap.QuotaStale {
+		t.Error("restored QuotaStale = false, want true (last-known until live contact)")
+	}
+
+	// The boot round fires as an event but probes nothing: every token
+	// is fresh from the restore.
+	p2.quotaBootAt = time.Now()
+	probeTick(t, p2, context.Background(), time.Now())
+	if got := mock2.SessionProbesSnapshot(); got != 0 {
+		t.Errorf("p2 probes after restart = %d, want 0 (fresh cache skips the round)", got)
+	}
+	// Probe traffic stays out of the usage accounts on the new process too.
+	if got := p2.usageCount(0); got != 0 {
+		t.Errorf("p2 usageCount = %d, want 0 (probes never touch the ledgers)", got)
+	}
+	if got := p2.dayRequestCount(0); got != 0 {
+		t.Errorf("p2 dayRequestCount = %d, want 0 (probes never feed the activity ledger)", got)
+	}
+	if got := p2.requestsServed.Load(); got != 0 {
+		t.Errorf("p2 requestsServed = %d, want 0 (probes are not client traffic)", got)
+	}
+}
+
+// TestSmartProbeSkipsInUseToken pins the true-smart refresh: a token with
+// in-flight runs sits out the round (same InflightCount gate as
+// sessionPollTick/maintainTick — no new busy signal) while the idle token
+// is still covered, and rejoins once the lease drains.
+func TestSmartProbeSkipsInUseToken(t *testing.T) {
+	mock0 := testutil.NewMock()
+	defer mock0.Close()
+	mock1 := testutil.NewMock()
+	defer mock1.Close()
+	p := newTestPool(t, mock0, mock1)
+	setQuotaAutoProbe(p, true)
+	now := time.Now()
+	p.quotaBootAt = now.Add(-time.Hour)
+	markPoolActive(p, now)
+
+	ctx := context.Background()
+	lease, err := p.Acquire(ctx, modelA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	toks := p.roster.Load()
+	held := -1
+	for i, e := range *toks {
+		if e.runs.InflightCount() > 0 {
+			if held != -1 {
+				t.Fatal("multiple tokens in flight after one Acquire")
+			}
+			held = i
+		}
+	}
+	if held == -1 {
+		t.Fatal("no token in flight after Acquire")
+	}
+	if !smartProbeSkipToken((*toks)[held], now) {
+		t.Errorf("held token skipped = false, want true (in-use)")
+	}
+
+	// The round covers only the idle token.
+	probeTick(t, p, ctx, now)
+	heldMock, otherMock := mock0, mock1
+	if held == 1 {
+		heldMock, otherMock = mock1, mock0
+	}
+	if got := heldMock.SessionProbesSnapshot(); got != 0 {
+		t.Errorf("held token probes = %d, want 0 (in-use skip)", got)
+	}
+	if got := otherMock.SessionProbesSnapshot(); got != 1 {
+		t.Errorf("idle token probes = %d, want 1 (round still covers it)", got)
+	}
+
+	// Released, the token rejoins: no longer skipped, and probed on the
+	// next due tick (its quota is still empty — the default mock
+	// admission carries none — so staleness, not freshness, decides).
+	p.LeaseRelease(lease)
+	if smartProbeSkipToken((*toks)[held], now) {
+		t.Error("released token skipped = true, want false")
+	}
+	probeTick(t, p, ctx, now.Add(61*time.Second))
+	if got := heldMock.SessionProbesSnapshot(); got != 1 {
+		t.Errorf("released token probes = %d, want 1 (probed once the lease drains)", got)
+	}
+}
+
+// TestSmartProbeStartRestoresAndTickFlushes is the boot-level proof: Start
+// restores the timer + quota cache synchronously (warm view before any
+// tick), the maintain tick then runs the boot round with zero probes on
+// the warm cache, and the following tick flushes the re-stamped timer.
+func TestSmartProbeStartRestoresAndTickFlushes(t *testing.T) {
+	mock1 := testutil.NewMock()
+	defer mock1.Close()
+	mem := newMemPoolPersist()
+
+	p1 := newTestPool(t, mock1)
+	p1.SetPoolPersist(mem)
+	setQuotaAutoProbe(p1, true)
+	probeTick(t, p1, context.Background(), time.Now())
+	if got := mock1.SessionProbesSnapshot(); got != 1 {
+		t.Fatalf("p1 probes = %d, want 1", got)
+	}
+	if err := p1.FlushPoolPersist(); err != nil {
+		t.Fatalf("FlushPoolPersist: %v", err)
+	}
+
+	mock2 := testutil.NewMock()
+	defer mock2.Close()
+	p2 := newTestPool(t, mock2)
+	p2.SetPoolPersist(mem)
+	setQuotaAutoProbe(p2, true)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p2.Start(ctx)
+
+	// Start restored synchronously: warm view + timer before any tick.
+	if got := len(p2.Snapshot()[0].QuotaByModel); got == 0 {
+		t.Fatal("post-Start QuotaByModel empty, want the restored cache")
+	}
+	p2.smartProbe.mu.Lock()
+	restoredLastProbe := p2.smartProbe.lastProbe
+	p2.smartProbe.mu.Unlock()
+	if restoredLastProbe.IsZero() {
+		t.Fatal("post-Start lastProbe zero, want the restored timer")
+	}
+
+	// The maintain tick runs the boot round (zero probes on the warm
+	// cache); the round completion re-arms the dirty flag, so the next
+	// tick flushes the timer back to the store.
+	savesBefore := mem.saveCount()
+	p2.maintainTick(ctx)
+	waitSmartProbeIdle(t, p2)
+	if got := mock2.SessionProbesSnapshot(); got != 0 {
+		t.Errorf("post-restart probes = %d, want 0 (warm cache)", got)
+	}
+	p2.maintainTick(ctx)
+	if got := mem.saveCount(); got <= savesBefore {
+		t.Errorf("store saves = %d, want > %d (tick flushes the timer)", got, savesBefore)
+	}
+}


### PR DESCRIPTION
Probe state survives restarts: scheduler timer (lastProbe/backoff/overloadedAt/idleSlept) and per-token quota cache (QuotaByModel/QuotaSavedAt, SHA-keyed) persist through pool_state blobs, saved on the FlushPoolPersist path and restored at Start (missing row = fresh boot). Restart replays the boot round as a zero-probe no-op while warm; dashboard shows warm data immediately. Includes the 4-line serve-boot wiring hunk (SetPoolPersist) so persist is live in prod, and in-use skip (InflightCount>0, same gate as the poll/maintain ticks) in the refresh decision order. Probes still never touch usage ledgers. Tests: scheduler round-trip, restart simulation with zero probes and zero ledger movement, in-use skip, boot-level restore+flush. Hermetic pool/session green, gofmt/vet clean.